### PR TITLE
Windows Install Script and Buildshell improvements

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,1 @@
+@cmd.exe /K "%~dp0\gcc-arm-none-eabi\bin\buildenv.cmd && make all AXIS=5 PAXIS=3 CNC=1 && copy /Y LPC1768\main.bin %USERPROFILE%\Desktop\firmware.bin"

--- a/win_install.cmd
+++ b/win_install.cmd
@@ -41,10 +41,10 @@ rem Initialize install log files.
 echo Logging install results to %LOGFILE%
 echo %DATE% %TIME%  Starting %0 %*>%LOGFILE%
 
-echo Downloading GNU Tools for ARM Embedded Processors...
-echo %DATE% %TIME%  Executing build\win32\curl -kL0 %GCC4ARM_URL%>>%LOGFILE%
-build\win32\curl -kL0 %GCC4ARM_URL% >%GCC4ARM_TAR%
-if errorlevel 1 goto ExitOnError
+
+
+
+
 
 echo Validating md5 signature of GNU Tools for ARM Embedded Processors...
 echo %GCC4ARM_MD5% *%GCC4ARM_FILENAME%>%GCC4ARM_MD5_FILENAME%


### PR DESCRIPTION
The Windows install script was failing to download the prerequisites. This change has the user manually download the prerequisites to the same folder as their install script instead as a .zip.

Build.cmd uses the buildshell.cmd file created by the windows installer, fills out the parameters specific to the Carvera build, and then copies the resulting file to the desktop of the user as firmware.bin, ready to test upload to the machine