### PR TITLE
M491.1 H{tolerance} tool break test

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -827,13 +827,88 @@ void ATCHandler::on_gcode_received(void *argument)
 				loose_tool();
 			}
 		} else if (gcode->m == 491) {
-			// do calibrate
-            THEROBOT->push_state();
-            THEROBOT->get_axis_position(last_pos, 3);
-            set_inner_playing(true);
-            this->clear_script_queue();
-            atc_status = CALI;
-    	    this->fill_cali_scripts(active_tool == 0, true);
+			if (gcode->subcode == 1) {
+				char buff[100];
+				float tolerance = 0.1;
+				if (gcode->has_letter('H')) {
+		    		tolerance = gcode->get_value('H');
+					if (tolerance < 0.02) {
+						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
+        				THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
+						return;
+					}
+
+				}
+				//store current TLO
+				float tlo = THEKERNEL->eeprom_data->TLO;
+
+				// do calibrate to find new TLO
+				THEROBOT->push_state();
+				THEROBOT->get_axis_position(last_pos, 3);
+				set_inner_playing(true);
+				this->clear_script_queue();
+				
+				//make sure spindle is off
+				snprintf(buff, sizeof(buff), "M5");
+				this->script_queue.push(buff);
+
+				atc_status = CALI;
+				this->fill_cali_scripts(active_tool == 0, true);
+
+				THECONVEYOR->wait_for_idle();
+				// lift z to safe position with fast speed
+				
+				snprintf(buff, sizeof(buff), "G53 G0 Z%.3f", THEROBOT->from_millimeters(this->safe_z_mm));
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "M491.2 H%.3f , P%.3f", tolerance, tlo);
+				this->script_queue.push(buff);
+				
+				
+
+
+			}else if (gcode->subcode == 2){
+				float tlo = 0;
+				float tolerance = 0.1;
+				THECONVEYOR->wait_for_idle();
+				if (gcode->has_letter('H')) {
+		    		tolerance = gcode->get_value('H');
+					if (tolerance < 0.02) {
+						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
+        				THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
+						return;
+					}
+
+				}
+				if (gcode->has_letter('P')) {
+		    		tlo = gcode->get_value('P');
+					if (tlo == 0) {
+						THEKERNEL->streams->printf("No previous TLO included, aborting\n");
+						return;
+					}
+
+				}
+				float new_tlo = THEKERNEL->eeprom_data->TLO;
+				THEKERNEL->streams->printf("Old: %.3f , new: %.3f\n",tlo,new_tlo);
+				//test for breakage
+				if (fabs(tlo - new_tlo) > tolerance) {
+					THEKERNEL->streams->printf("ERROR: Tool Break Check - check tool for breakage\n");
+					THEKERNEL->call_event(ON_HALT, nullptr);
+					THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
+					return;
+				}
+
+			} else {
+				// do calibrate
+				THEROBOT->push_state();
+				THEROBOT->get_axis_position(last_pos, 3);
+				set_inner_playing(true);
+				this->clear_script_queue();
+				atc_status = CALI;
+				this->fill_cali_scripts(active_tool == 0, true);
+
+			}
 		} else if (gcode->m == 492) {
 			if (gcode->subcode == 0 || gcode->subcode == 1) {
 				// check true

--- a/tests/TEST_M491.1ToolBreak/TEST_M491.1ToolBreak.cnc
+++ b/tests/TEST_M491.1ToolBreak/TEST_M491.1ToolBreak.cnc
@@ -1,0 +1,22 @@
+G90 G94
+G17
+G21
+
+T1 M6
+S1000 M3
+G54
+
+G0 X100
+
+(testing if the tool break test handles a situation that should never happen.)
+(The post processor should have added a M5 before this point)
+(the machine should not throw an error on this command unless the tool broke)
+M491.1 H0.1
+
+
+(paused to allow the user to remove replace the tool in the spindle with a broken one)
+(using M490.2, M490.1. without changing tool number or recalibtating)
+(to simulate a broken tool)
+(after this point the machine should throw an error)
+M600
+M491.1

--- a/tests/TEST_M491.1ToolBreak/TEST_M491.1ToolBreak_readme.txt
+++ b/tests/TEST_M491.1ToolBreak/TEST_M491.1ToolBreak_readme.txt
@@ -1,0 +1,7 @@
+M491.1 tests the current stored TLO against a new TLO measurement and halts the machine if the values are more that a tolerance value H off. H defaults to 0.1mm
+
+This function will not test if a tool is broken in the ATC, only if it has broken after the initial calibration that happens when you switch to the tool. 
+
+The TEST_M491.1ToolBreak.cnc file shows minimal usage and tests for a potential error where the user did not supply an M5 before running M491.1.
+
+After the pause the user should manually simulate a broken tool by running M490.1 to loosen the collet, replacing the tool with a shorter one, and running M490.2 to tighten the collet. After that point, hit continue and the machine will test TLO and halt due to a mismatch.


### PR DESCRIPTION
M491.1 tests the current stored TLO against a new TLO measurement and halts the machine if the values are more that a tolerance value H off. H defaults to 0.1mm

This function will not test if a tool is broken in the ATC, only if it has broken after the initial calibration that happens when you switch to the tool since TLO are not stored for each tool individually, only the current tool.

The TEST_M491.1ToolBreak.cnc file shows minimal usage and tests for a potential error where the user did not supply an M5 before running M491.1.

After the pause the user should manually simulate a broken tool by running M490.1 to loosen the collet, replacing the tool with a shorter one, and running M490.2 to tighten the collet. After that point, hit continue and the machine will test TLO and halt due to a mismatch.

