### PR TITLE
bugfix: adding error correction to ref_tool_mz checks

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -730,7 +730,14 @@ void ATCHandler::set_tool_offset()
         	tool_offset = cur_tool_mz - ref_tool_mz;
         	const float offset[3] = {0.0, 0.0, tool_offset};
         	THEROBOT->saveToolOffset(offset, cur_tool_mz);
-        }
+		} else{
+			THEKERNEL->eeprom_data->REFMZ = -10;
+		    THEKERNEL->write_eeprom_data();
+			THEKERNEL->call_event(ON_HALT, nullptr);
+			THEKERNEL->set_halt_reason(MANUAL);
+			THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+			return;
+		}
     }
 
 }


### PR DESCRIPTION
before if REFMZ in the eeprom ever got set to > 0, the machine would silently fail these tests leading to a constant TLO of 0. This could lead to major physical crashes

The change: cause a halt on TLO<0, reset refMZ to -10, and warn the user to recalibrate.