### PR TITLE
bugfix: clarify ATC tool detection failure messages

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -922,14 +922,14 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (!laser_detect()) {
 			        THEKERNEL->call_event(ON_HALT, nullptr);
 			        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
-			        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+			        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
 				}
 			} else if (gcode->subcode == 2) {
 				// check false
 				if (laser_detect()) {
 			        THEKERNEL->call_event(ON_HALT, nullptr);
 			        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);
-			        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+			        THEKERNEL->streams->printf("ERROR: Unexpected tool presence detected, please check tool rack!\n");
 				}
 			} else if (gcode->subcode == 3) {
 				// check if the probe was triggered


### PR DESCRIPTION
The ATC error messages use "ERROR: Tool confliction occured, please check tool rack!" as the error message for when the tool sensor detects a tool already in the rack and when there is not a tool in the rack to pick up. This is a simple clarification of that information

based on this request from the brooklikeme repo:

https://github.com/brooklikeme/Smoothieware/commit/695a2499217f8f42ce5436beea415b5857d0f7a8#diff-cffcd3ae63a965f7278f81fe46497b8a30bf5d0518f9f38b9c31156af14d0222L843
