### PR TITLE
M118 Print to Console M118.1

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -307,6 +307,22 @@ try_again:
 							return;
 						}
 
+						case 118: // M118 is a special non compliant Gcode as it allows arbitrary text on the line following the command
+						{    // concatenate the command again and send to the MDI
+							if (gcode->subcode == 1){
+								if (gcode->has_letter('P')) {
+									THEKERNEL->streams->printf("result = %.3f \n", gcode->get_value('P'));
+									delete gcode;
+									return;
+								}
+							}
+							
+							string str= single_command.substr(4) + possible_command;
+							delete gcode;
+							THEKERNEL->streams->printf("%s \r\n", str.c_str());
+							return;
+						}
+
 						case 1000: // M1000 is a special command that will pass thru the raw lowercased command to the simpleshell (for hosts that do not allow such things)
 						{
 							// reconstruct entire command line again

--- a/tests/TEST_M118_PrintToConsole/TEST_M118_PrintToConsole.cnc
+++ b/tests/TEST_M118_PrintToConsole/TEST_M118_PrintToConsole.cnc
@@ -1,0 +1,9 @@
+G90 G94
+G17
+G21
+
+M118 this is just a test
+M118 ABCDEFGHIJKLMNOPQRSTUVWXYZ*/?! (testing uppercase and special characters)
+M118 test comment 1(comments shouldn't print)
+M118 test comment 2;text beyond semicolons shouldn't print
+M118.1 P12


### PR DESCRIPTION
M118 prints the remainder of the line to the console, skipping comments () ;. Useful for debugging/giving the end user instructions. 
Will be used by the manual tool change process to give the end user directions

M118.1 P{value} prints the resulting value of the P parameter to the console. Useful for printing variables/testing math functions

In the tests folder, TEST_M118_PrintToConsole was added to demonstrate functionality/prove function. Expected behavior is detailed inside the file