### PR TITLE
Adding Optional Stop Functionality M01. M333 turns off, M334 turns on

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -74,6 +74,7 @@ Kernel::Kernel()
     uploading = false;
     laser_mode = false;
     vacuum_mode = false;
+    optional_stop_mode = false;
     sleeping = false;
     waiting = false;
     suspending = false;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -134,6 +134,9 @@ class Kernel {
         void set_vacuum_mode(bool f) { vacuum_mode = f; }
         bool get_vacuum_mode() const { return vacuum_mode; }
 
+        void set_optional_stop_mode(bool f) { optional_stop_mode = f; }
+        bool get_optional_stop_mode() const { return optional_stop_mode; }
+
         void set_sleeping(bool f) { sleeping = f; }
         bool is_sleeping() const { return sleeping; }
 
@@ -200,6 +203,7 @@ class Kernel {
             volatile bool uploading:1;
             bool laser_mode:1;
             bool vacuum_mode:1;
+            bool optional_stop_mode:1;
             bool sleeping:1;
             bool suspending: 1;
             bool waiting: 1;

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -144,7 +144,13 @@ void Player::on_gcode_received(void *argument)
     Gcode *gcode = static_cast<Gcode *>(argument);
     string args = get_arguments(gcode->get_command());
     if (gcode->has_m) {
-        if (gcode->m == 21) { // Dummy code; makes Octoprint happy -- supposed to initialize SD card
+        if (gcode->m == 1) { //optiional stop
+            if (THEKERNEL->get_optional_stop_mode()){
+            this->suspend_command((gcode->subcode == 1)?"h":"", gcode->stream);
+            }
+
+        }      
+        else if (gcode->m == 21) { // Dummy code; makes Octoprint happy -- supposed to initialize SD card
             mounter.remount();
             gcode->stream->printf("SD card ok\r\n");
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -239,6 +239,15 @@ void SimpleShell::on_gcode_received(void *argument)
         	}
 			// turn off vacuum mode
 			gcode->stream->printf("turning vacuum mode off\r\n");
+
+		} else if (gcode->m == 333) { // turn off optional stop mode
+			THEKERNEL->set_optional_stop_mode(false);
+			// turn off optional stop mode
+			gcode->stream->printf("turning optional stop mode off\r\n");
+		} else if (gcode->m == 334) { // turn off optional stop mode
+			THEKERNEL->set_optional_stop_mode(true);
+			// turn on optional stop mode
+			gcode->stream->printf("turning optional stop mode on\r\n");
 		}
     }
 }

--- a/tests/TEST_M01_M333_M334_OptionalStop/TEST_M01_M333_M334_OptionalStop.cnc
+++ b/tests/TEST_M01_M333_M334_OptionalStop/TEST_M01_M333_M334_OptionalStop.cnc
@@ -1,0 +1,18 @@
+G90 G94
+G17
+G21
+
+(To run this test, run M334 from the console and play this file)
+(The program should pause between each move)
+(Then run M333 from the console and play the file again)
+(It should run from start to end without any pauses)
+(Optional stop mode will not persist on machine reset)
+
+G01 X350
+M01 (Optional Stop)
+G01 X300
+M01
+G01 X350
+M01
+G01 X300
+M01


### PR DESCRIPTION
Optional stop defaults to off on machine reset
M334 turns on optional stop mode
M333 turns off optional stop mode

when optional stop mode is enabled, M01 will pause the program and wait for the user to resume when optional stop mode is disabled, M01 will be ignored