### PR TITLE
New Feature: Line by Line Execution Mode

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -75,6 +75,7 @@ Kernel::Kernel()
     laser_mode = false;
     vacuum_mode = false;
     optional_stop_mode = false;
+    line_by_line_exec_mode = false;
     sleeping = false;
     waiting = false;
     suspending = false;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -136,6 +136,8 @@ class Kernel {
 
         void set_optional_stop_mode(bool f) { optional_stop_mode = f; }
         bool get_optional_stop_mode() const { return optional_stop_mode; }
+        void set_line_by_line_exec_mode(bool f) { line_by_line_exec_mode = f; }
+        bool get_line_by_line_exec_mode() const { return line_by_line_exec_mode; }
 
         void set_sleeping(bool f) { sleeping = f; }
         bool is_sleeping() const { return sleeping; }
@@ -204,6 +206,7 @@ class Kernel {
             bool laser_mode:1;
             bool vacuum_mode:1;
             bool optional_stop_mode:1;
+            bool line_by_line_exec_mode:1;
             bool sleeping:1;
             bool suspending: 1;
             bool waiting: 1;

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -708,6 +708,11 @@ void Player::on_main_loop(void *argument)
                 // THEKERNEL->streams->printf("0-[Line: %d] %s\n", message.line, buf);
                 played_lines += 1;
                 played_cnt += len;
+                //M335 disables line by line, M336 Enables. Pauses after every valid gcode line
+                if (THEKERNEL->get_line_by_line_exec_mode() && len > 2 && buf[0] != ';' && buf[0] != '('){
+                    this->suspend_command("", THEKERNEL->streams);
+                }
+
                 return; // we feed one line per main loop
 
             } else {

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -248,6 +248,12 @@ void SimpleShell::on_gcode_received(void *argument)
 			THEKERNEL->set_optional_stop_mode(true);
 			// turn on optional stop mode
 			gcode->stream->printf("turning optional stop mode on\r\n");
+		} else if (gcode->m == 335) { // turn off optional stop mode
+			THEKERNEL->set_line_by_line_exec_mode(false);
+			gcode->stream->printf("turning line by line execute mode off\r\n");
+		} else if (gcode->m == 336) { // turn off optional stop mode
+			THEKERNEL->set_line_by_line_exec_mode(true);
+			gcode->stream->printf("turning line by line execute mode on.\r\nPlaying file will pause after every valid gcode line, skipping empty and commented lines\r\n");
 		}
     }
 }


### PR DESCRIPTION
When testing out programs for the first time, it is common in industry to put the machine into "step" or "line by line execution" mode

This will pause after ach line of the playing gcode, skipping empty/only commented lines

M335 to turn on
M336 to turn off

value does not persist on machine reset and returns to off