### PR TITLE
New MCode: M600.5 pause when not playing file

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -260,7 +260,7 @@ void Player::on_gcode_received(void *argument)
             this->goto_line = 0;
 
         } else if (gcode->m == 600) { // suspend print, Not entirely Marlin compliant, M600.1 will leave the heaters on
-            this->suspend_command((gcode->subcode == 1)?"h":"", gcode->stream);
+            this->suspend_command((gcode->subcode == 1)?"h":"", gcode->stream, (gcode->subcode == 5)?true:false);
 
         } else if (gcode->m == 601) { // resume print
             this->resume_command("", gcode->stream);
@@ -848,14 +848,14 @@ Suspend a print in progress
 User may jog or remove and insert filament at this point, extruding or retracting as needed
 
 */
-void Player::suspend_command(string parameters, StreamOutput *stream )
+void Player::suspend_command(string parameters, StreamOutput *stream, bool pause_outside_play_mode )
 {
     if (THEKERNEL->is_suspending() || THEKERNEL->is_waiting()) {
         stream->printf("Already suspended!\n");
         return;
     }
 
-    if(!this->playing_file) {
+    if(!this->playing_file && !pause_outside_play_mode) {
         stream->printf("Can not suspend when not playing file!\n");
         return;
     }

--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -36,7 +36,7 @@ class Player : public Module {
         void play_command( string parameters, StreamOutput* stream );
         void progress_command( string parameters, StreamOutput* stream );
         void abort_command( string parameters, StreamOutput* stream );
-        void suspend_command( string parameters, StreamOutput* stream );
+        void suspend_command( string parameters, StreamOutput* stream , bool pause_outside_play_mode = false);
         void resume_command( string parameters, StreamOutput* stream );
         void goto_command( string parameters, StreamOutput* stream );
         void buffer_command( string parameters, StreamOutput* stream );


### PR DESCRIPTION
This is a prerequisite for the manual tool change functionality being added to the firmware.

Generally M600.5 allows the software to queue up several functions in a row that require user input to continue to the next step.

Used by the manual tool change feature that will be added. 