### PR TITLE
New Mcode: M493.3 Set Tool Length Offset M493.4 report tool length offset

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -742,6 +742,31 @@ void ATCHandler::set_tool_offset()
 
 }
 
+void ATCHandler::set_tlo_by_offset(float z_axis_offset){
+	// new TLO = Current TLO - (current WCS - z_axis_offset)
+	float mpos[3];
+	Robot::wcs_t pos;
+	THEROBOT->get_current_machine_position(mpos);
+	// current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+	if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
+	pos = THEROBOT->mcs2wcs(mpos);
+	cur_tool_mz = cur_tool_mz + THEROBOT->from_millimeters(std::get<Z_AXIS>(pos)) - z_axis_offset;
+
+	if (ref_tool_mz < 0) {
+		tool_offset = cur_tool_mz - ref_tool_mz;
+		const float offset[3] = {0.0, 0.0, tool_offset};
+		THEROBOT->saveToolOffset(offset, cur_tool_mz);
+	}else{
+		THEKERNEL->eeprom_data->REFMZ = -10;
+		THEKERNEL->write_eeprom_data();
+		THEKERNEL->call_event(ON_HALT, nullptr);
+		THEKERNEL->set_halt_reason(MANUAL);
+		THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+		return;
+	}
+
+}
+
 void ATCHandler::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode*>(argument);
@@ -959,6 +984,33 @@ void ATCHandler::on_gcode_received(void *argument)
 					THEKERNEL->streams->printf("ERROR: No tool was set!\n");
 
 				}
+			} else if (gcode->subcode == 3) { //set current tool offset
+				
+				
+				if (gcode->has_letter('Z')) {
+					cur_tool_mz = gcode->get_value('Z');
+					if (ref_tool_mz < 0) {
+						tool_offset = cur_tool_mz;// + ref_tool_mz;
+						const float offset[3] = {0.0, 0.0, tool_offset};
+						THEROBOT->saveToolOffset(offset, cur_tool_mz);
+					}else{
+						THEKERNEL->eeprom_data->REFMZ = -10;
+						THEKERNEL->write_eeprom_data();
+						THEKERNEL->call_event(ON_HALT, nullptr);
+						THEKERNEL->set_halt_reason(MANUAL);
+						THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+						return;
+					}
+				}
+				if (gcode->has_letter('H')) { //set tlo from current position. H is offset above Z0
+					this->set_tlo_by_offset(gcode->get_value('H'));
+					
+				}
+
+
+				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
+			} else if (gcode->subcode == 4) { //report current TLO
+				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
 			}
 		} else if (gcode->m == 494) {
 			// control probe laser

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -82,6 +82,10 @@ private:
     void fill_zprobe_scripts(float x_pos, float y_pos, float x_offset, float y_offset);
     void fill_zprobe_abs_scripts();
     void fill_xyzprobe_scripts(float tool_dia, float probe_height);
+
+    //
+    void set_tlo_by_offset(float z_axis_offset);
+
     void fill_autolevel_scripts(float x_pos, float y_pos, float x_size, float y_size, int x_grids, int y_grids, float height);
     void fill_goto_origin_scripts(float x_pos, float y_pos);
 


### PR DESCRIPTION
M493.3 has two parameters, H{offset} and Z{new value}

If the z parameter is provided, the firmware will directly set the TLO value to the new number.
M493.3 Z-15 would set the current TLO to -15

If the H parameter is set, the TLO will be set as a function of an {offset} above the current Z0 for the WCS.
M493.3 H5 - set the tlo manually using an endmill or gauge pin of a known diameter, in this case 5mm, that rests on the Z0 surface.
I accomplish this by lowering the bit until a 5mm endmill on the Z0 surface cannot roll underneath the bit. Then I raise the z axis by small increments until the endmill can just pass underneath the bit with a tiny amount of resistance.

This command will then autocalculate the TLO for current tool. When complete the tool will be located at 5mm in Z.


M494 reports current TLO to console for debugging



