### PR TITLE
New Feature: Manual Tool Changes for tools 7-99

### DIFF
--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -78,6 +78,10 @@ private:
     void fill_cali_scripts(bool is_probe, bool clear_z);
 
     //
+    void fill_manual_drop_scripts(int old_tool);
+    void fill_manual_pickup_scripts(int new_tool, bool clear_z, bool auto_calibrate, float custom_TLO);
+
+    //
     void fill_margin_scripts(float x_pos, float y_pos, float x_pos_max, float y_pos_max);
     void fill_zprobe_scripts(float x_pos, float y_pos, float x_offset, float y_offset);
     void fill_zprobe_abs_scripts();
@@ -172,6 +176,7 @@ private:
 
     int active_tool;
     int tool_number;
+    int max_manual_tool_number;
     int goto_position;
     float position_x;
     float position_y;

--- a/tests/TEST_ManualToolChanges/TEST_ManualToolChanges.cnc
+++ b/tests/TEST_ManualToolChanges/TEST_ManualToolChanges.cnc
@@ -1,0 +1,16 @@
+M118 Running through some standard atc commands
+M6T0
+M118 Picked up Probe. Ready to move on
+M6T1
+M118 Picked up Tool 1. Ready to move on
+M6T-1
+M118 Dropped Tool 1 Ready to move on
+M6T1
+M118 Start of manual tool Change Commands
+M6T7
+M6T1
+M118 Start of a manual tool change with a predefined TLO
+M6T7 H-100
+M118 Start of a manual tool change with manual calibration
+M6T8 C0
+M6T-1


### PR DESCRIPTION
When a tool number > than the max tool_number and less than max_manual_tool_number is provided to an M6 Tool change, the machine will:

-Drop the current tool. If it is an ATC tool it will drop it in the slot. If it is not in the atc it will move to clearance, pause for use input, then release the collet. -pickup the new tool if it is in the atc, or wait for user input and then close the collet for a manual tool. -If the parameter C is not given, or set to 1, the machine will use the ATC toolsetter to set the TLO for the tool -If the parameter H is provided, it will set the TLO to this value. -If the parameter C is set to 0 the machine will remain paused and you are able to set the TLO manually via an endmill/paper method -The tool number is updated to match the given tool and shows up correctly in the stock controller -The program will continue

during tool changes, instructions are provided to the controller console and pauses are included so the machine does not move unexpectedly.

This commit requires the M600.5 and M493.3 Z and H to work

examples:

M6T5 - normal

M6T8 - manual tool change, preforms automatic TLO

M6T99 H-15 - manual tool change, sets TLO to -15 directly

M6T28 C0 - manual tool change, does not perform automatic TLO. Leaves machine paused and ready to set TLO manually