### PR TITLE
Implementing LinuxCNC/Fanuic Style Math and Variables

### DIFF
--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -93,6 +93,7 @@ typedef struct {
 	float TOOLMZ;
 	float reserve;
 	int TOOL;
+    float perm_vars[20];
 } EEPROM_data;
 
 class Kernel {
@@ -113,6 +114,8 @@ class Kernel {
 
         bool kernel_has_event(_EVENT_ENUM id_event, Module *module);
         void unregister_for_event(_EVENT_ENUM id_event, Module *module);
+
+        float get_user_var(int var_num);
 
         bool is_using_leds() const { return use_leds; }
         bool is_halted() const { return halted; }
@@ -189,6 +192,7 @@ class Kernel {
         uint8_t halt_reason;
         uint8_t atc_state;
         EEPROM_data *eeprom_data;
+        float local_vars[20];
 
     private:
         // When a module asks to be called for a specific event ( a hook ), this is where that request is remembered

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -80,7 +80,7 @@ try_again:
         return;
     }
 
-    if ( first_char == 'G' || first_char == 'M' || first_char == 'T' || first_char == 'S' || first_char == 'N' ) {
+    if ( first_char == 'G' || first_char == 'M' || first_char == 'T' || first_char == 'S' || first_char == 'N' || first_char == '#') {
 
         //Get linenumber
         if ( first_char == 'N' ) {
@@ -161,6 +161,10 @@ try_again:
 				// Prepare gcode for dispatch
 				// new_message.stream->printf("GCode1: %s!\n", single_command.c_str());
 				Gcode *gcode = new Gcode(single_command, new_message.stream, false, new_message.line);
+
+				if ( first_char == '#'){
+					gcode->set_variable_value();
+				}
 
 				if(THEKERNEL->is_halted()) {
 					// we ignore all commands until M999, unless it is in the exceptions list (like M105 get temp)

--- a/src/modules/communication/utils/Gcode.h
+++ b/src/modules/communication/utils/Gcode.h
@@ -18,6 +18,8 @@ class StreamOutput;
 // Object to represent a Gcode command
 class Gcode {
     public:
+        using wcs_t= std::tuple<float, float, float>;
+
         Gcode(const string&, StreamOutput*, bool strip = true, unsigned int line = 0);
         Gcode(const Gcode& to_copy);
         Gcode& operator= (const Gcode& to_copy);
@@ -26,6 +28,12 @@ class Gcode {
         const char* get_command() const { return command; }
         bool has_letter ( char letter ) const;
         // 2024
+
+// 2024
+        float get_variable_value(const char * expr, char ** endptr) const;
+        float set_variable_value() const;
+
+        float evaluate_expression(const char * expr, char ** endptr) const;
         // int  index_of_letter( char letter, int start = 0) const;
         float get_value ( char letter, char **ptr= nullptr ) const;
         // 2024
@@ -58,5 +66,8 @@ class Gcode {
     private:
         void prepare_cached_values(bool strip=true);
         char *command;
+        float parse_expression(const char*& expr) const;
+        float parse_term(const char*& expr) const;
+        float parse_factor(const char*& expr) const;
 };
 #endif

--- a/tests/TEST_basicMathFunctions/TEST_basicMathFunctions.cnc
+++ b/tests/TEST_basicMathFunctions/TEST_basicMathFunctions.cnc
@@ -1,0 +1,158 @@
+G90 G94
+G17
+G21
+
+M118 testing 1+1. Should return 2
+M118.1 P1+1
+M118 testing 2-1. Should return 1
+M118.1 P2-1
+M118 testing 2*3 Should return 6
+M118.1 P2*3
+M118 testing 5/4 Should return 1.25
+M118.1 P5/4
+M118 testing 2^3 Should return 8
+M118.1 P2^3
+M118 testing Pemdas [1+2*[5-2*2]+2^2+SIN[0.5]]
+M118 Should return 7.009
+M118.1 P[1+2*[5-2*2]+2^2+SIN[0.5]]
+M118 testing SIN[45] should return 0.707
+M118.1 P SIN[45] 
+M118 testing SIN[0] should return 0
+M118.1 P SIN[0]
+M118 testing SIN[90] should return 1
+M118.1 P SIN[90]
+M118 testing COS[0] should return 1
+M118.1 P COS[0]
+M118 testing COS[45] should return 0.707
+M118.1 P COS[45]
+M118 testing COS[90] should return 0
+M118.1 P COS[90]
+M118 testing TAN[0] should return 0
+M118.1 P TAN[0]
+M118 testing TAN[90] should return undefined
+M118.1 P TAN[90]
+M118 testing ASIN[0] should return 0 degrees
+M118.1 P ASIN[0]
+M118 testing ASIN[0.5] should return 30 degrees
+M118.1 P ASIN[0.5]
+M118 testing ACOS[0] should return 90
+M118.1 P ACOS[0]
+M118 testing ACOS[0.5] should return 60 degrees
+M118.1 P ACOS[0.5]
+M118 testing ATAN[0] should return 0 degrees
+M118.1 P ATAN[0]
+M118 testing ATAN[0.5] should return 26.565
+M118.1 P ATAN[0.5]
+
+M118 testing ROUND[3.2] should return 3
+M118.1 P ROUND[3.2]
+M118 testing ROUND[3.5] should return 4
+M118.1 P ROUND[3.5]
+
+M118 testing FIX[3.2] should return 3
+M118.1 P FIX[3.2]
+M118 testing FIX[3.5] should return 3
+M118.1 P FIX[3.5]
+
+M118 testing FUP[3.2] should return 4
+M118.1 P FUP[3.2]
+M118 testing FUP[3.5] should return 4
+M118.1 P FUP[3.5]
+
+M118 testing SQRT[4] should return 2
+M118.1 P SQRT[4]
+M118 testing SQRT[15] should return 3.873
+M118.1 P SQRT[15]
+
+M118 testing LN[1.2] should return 0.182
+M118.1 P LN[1.2]
+
+M118 testing ABS[-2] should return 2
+M118.1 P ABS[-2]
+M118 testing ABS[2] should return 2
+M118.1 P ABS[2]
+
+M118 testing EXP[2] should return 7.389
+M118.1 P EXP[2]
+M118 testing 3MOD[2] should return 1
+M118.1 P 3MOD[2] 
+
+M118 testing 1AND[2] should return 1
+M118.1 P 1AND[2]
+M118 testing 0OR[0] should return 0
+M118.1 P 0OR[0]
+M118 testing 0XOR[1] should return 1
+M118.1 P 0XOR[1]
+M118 testing 0NOR[1] should return 0
+M118.1 P 0NOR[1]
+
+M118 testing 1EQ[1] should return 1
+M118.1 P 1EQ[1]
+M118 testing 1NE[1] should return 0
+M118.1 P 1NE[1]
+M118 testing 1LT[1] should return 0
+M118.1 P 1LT[1]
+M118 testing 1LE[1] should return 1
+M118.1 P 1LE[1]
+M118 testing 1GT[1] should return 0
+M118.1 P 1GT[1]
+M118 testing 1GE[1] should return 1
+M118.1 P 1GE[1]
+
+M118 testing 1EQ[2] should return 0
+M118.1 P 1EQ[2]
+M118 testing 1NE[2] should return 1
+M118.1 P 1NE[2]
+M118 testing 1LT[2] should return 1
+M118.1 P 1LT[2]
+M118 testing 1LE[2] should return 1
+M118.1 P 1LE[2]
+M118 testing 1GT[2] should return 0
+M118.1 P 1GT[2]
+M118 testing 1GE[2] should return 0
+M118.1 P 1GE[2]
+
+M118 testing 1EQ[0] should return 0
+M118.1 P 1EQ[0]
+M118 testing 1NE[0] should return 1
+M118.1 P 1NE[0]
+M118 testing 1LT[0] should return 0
+M118.1 P 1LT[0]
+M118 testing 1LE[0] should return 0
+M118.1 P 1LE[0]
+M118 testing 1GT[0] should return 1
+M118.1 P 1GT[0]
+M118 testing 1GE[0] should return 1
+M118.1 P 1GE[0]
+
+M118 testing set variable 101
+#101 = 1.5
+M118.1 P #101
+M118 testing set variable 501
+#501 = 1.5
+M118.1 P#501
+M118 testing get variable current tool number
+M118.1 P#3026
+
+M118 test pemdas with variable
+M118 Should return 4.5
+M118.1 P[1+2*[5-2*2]+#101]
+
+
+M118 moving on to break tests. Use goto line# to test each one. 
+M600
+M118 testing mismatched brackets v2
+M118.1 P 1+2]+1
+M600
+M118 testing divide by zero error
+M118.1 P 1/0
+M600
+M118 testing mismatched brackets
+M118.1 P [1+2
+M600
+M118 testing floating expression
+M118.1 P1+
+M600
+M118 testing get variable that doesnt exist
+M118.1 P#300
+ 


### PR DESCRIPTION
Variables are a very useful feature to be able to access on a cnc machine. Per linux cnc/faunic formatting, variables are denoted with a preceding # character. They come in three major variations:

#101-#120 user variables that are not stored on machine reset #501-#520 - user variables that persist on machine reset system variables- access information about the machine's current status like current TLO, WCS offset, etc inside gcode directly.

There are currently 20 local variables that are transient (are lost when the machine turns off), they are useful for any variables needed inside a gcode file

there are 20 variables that persist through reset. They should be used for long term values that you want to store

there are currently 12 system variables implemented such as being able to load the current x position into a gcode file. As a result you can write a probe program that probes in the positive x direction, zeros at the new position, probes in the negative X direction, on contact grab the current x position and divide by 2. There are a more variables to implement eventually.

Which system variables are implemented I have a spreadsheet here:https://docs.google.com/spreadsheets/d/1QXAimN-S1dCBaja-8on7d3joM2v30wR_76DH1bB0lyI/edit?usp=sharing

Implement math in the LinuxCNC/faunic style

whitespace is ignored, pemdas is folowed

+ additon
- subtraction
* multiplication : note that that the controller uses * to get diagnostic information from the machine through the MDI console. This consumes the * input and leads to unexpected results such as 2*3 reporting 6 when run in gcode, but 23 when run through the MDI. This will be fixed before the feature is released / division

Brackets: #100=#1*[#2-3] - note that the standard uses [] instead of () as () denote comments.

SIN[#] , COS[#], TAN[#], ASIN, ACOS, ATAN - trig functions

ROUND[#] - round to nearest whole value

FUP[#] - round up
FIX[#} - round down
ROUND[#] - round up if decimal >= 0.5, round down if not

ABS[#] - absolute value

SQRT[#] - square root

#^# - power function

EXP[#] - e to the power of #

#MOD[#] - modulo

#EQ[#] and the variants NE GT GE LT LE - binary comparisons

AND,OR,XOR,NOR binary operators

LN[X] - natural log