### PR TITLE
Pr save all wcs

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -812,132 +812,13 @@ void Kernel::check_eeprom_data()
 		needrewtite = true;
 	}
 	
-	if(isnan(this->eeprom_data->G54[0]))
-	{
-		this->eeprom_data->G54[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G54[1]))
-	{
-		this->eeprom_data->G54[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G54[2]))
-	{
-		this->eeprom_data->G54[2] = 0;
-		needrewtite = true;
-	}
-    
-    if(isnan(this->eeprom_data->G55[0]))
-	{
-		this->eeprom_data->G55[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G55[1]))
-	{
-		this->eeprom_data->G55[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G55[2]))
-	{
-		this->eeprom_data->G55[2] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G55[3]))
-	{
-		this->eeprom_data->G55[3] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G56[0]))
-	{
-		this->eeprom_data->G56[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G56[1]))
-	{
-		this->eeprom_data->G56[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G56[2]))
-	{
-		this->eeprom_data->G56[2] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G56[3]))
-	{
-		this->eeprom_data->G56[3] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G57[0]))
-	{
-		this->eeprom_data->G57[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G57[1]))
-	{
-		this->eeprom_data->G57[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G57[2]))
-	{
-		this->eeprom_data->G57[2] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G57[3]))
-	{
-		this->eeprom_data->G57[3] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G58[0]))
-	{
-		this->eeprom_data->G58[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G58[1]))
-	{
-		this->eeprom_data->G58[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G58[2]))
-	{
-		this->eeprom_data->G58[2] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G58[3]))
-	{
-		this->eeprom_data->G58[3] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G59[0]))
-	{
-		this->eeprom_data->G59[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G59[1]))
-	{
-		this->eeprom_data->G59[1] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G59[2]))
-	{
-		this->eeprom_data->G59[2] = 0;
-		needrewtite = true;
-	}
-    if(isnan(this->eeprom_data->G59[3]))
-	{
-		this->eeprom_data->G59[3] = 0;
-		needrewtite = true;
-	}
-
-	if(isnan(this->eeprom_data->G54AB[0]))
-	{
-		this->eeprom_data->G54AB[0] = 0;
-		needrewtite = true;
-	}
-	if(isnan(this->eeprom_data->G54AB[1]))
-	{
-		this->eeprom_data->G54AB[1] = 0;
-		needrewtite = true;
+	for (int row = 0; row < 2; row ++){
+		for (int col=0;col<6;col++) {
+			if (isnan(this->eeprom_data->WCScoord[row][col])){
+				this->eeprom_data->WCScoord[row][col] = 0;
+				needrewtite = true;
+			}
+		}
 	}
     if(!((this->eeprom_data->probe_tool_not_calibrated & ~1) == 0))
 	{

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -812,10 +812,10 @@ void Kernel::check_eeprom_data()
 		needrewtite = true;
 	}
 	
-	for (int row = 0; row < 2; row ++){
-		for (int col=0;col<6;col++) {
-			if (isnan(this->eeprom_data->WCScoord[row][col])){
-				this->eeprom_data->WCScoord[row][col] = 0;
+	for (int wcs_index = 0; wcs_index < 6; wcs_index++){
+		for (int axis = 0; axis < 2; axis++) {
+			if (isnan(this->eeprom_data->WCScoord[wcs_index][axis])){
+				this->eeprom_data->WCScoord[wcs_index][axis] = 0;
 				needrewtite = true;
 			}
 		}

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -827,6 +827,108 @@ void Kernel::check_eeprom_data()
 		this->eeprom_data->G54[2] = 0;
 		needrewtite = true;
 	}
+    
+    if(isnan(this->eeprom_data->G55[0]))
+	{
+		this->eeprom_data->G55[0] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G55[1]))
+	{
+		this->eeprom_data->G55[1] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G55[2]))
+	{
+		this->eeprom_data->G55[2] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G55[3]))
+	{
+		this->eeprom_data->G55[3] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G56[0]))
+	{
+		this->eeprom_data->G56[0] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G56[1]))
+	{
+		this->eeprom_data->G56[1] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G56[2]))
+	{
+		this->eeprom_data->G56[2] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G56[3]))
+	{
+		this->eeprom_data->G56[3] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G57[0]))
+	{
+		this->eeprom_data->G57[0] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G57[1]))
+	{
+		this->eeprom_data->G57[1] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G57[2]))
+	{
+		this->eeprom_data->G57[2] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G57[3]))
+	{
+		this->eeprom_data->G57[3] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G58[0]))
+	{
+		this->eeprom_data->G58[0] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G58[1]))
+	{
+		this->eeprom_data->G58[1] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G58[2]))
+	{
+		this->eeprom_data->G58[2] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G58[3]))
+	{
+		this->eeprom_data->G58[3] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G59[0]))
+	{
+		this->eeprom_data->G59[0] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G59[1]))
+	{
+		this->eeprom_data->G59[1] = 0;
+		needrewtite = true;
+	}
+	if(isnan(this->eeprom_data->G59[2]))
+	{
+		this->eeprom_data->G59[2] = 0;
+		needrewtite = true;
+	}
+    if(isnan(this->eeprom_data->G59[3]))
+	{
+		this->eeprom_data->G59[3] = 0;
+		needrewtite = true;
+	}
+
 	if(isnan(this->eeprom_data->G54AB[0]))
 	{
 		this->eeprom_data->G54AB[0] = 0;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -92,20 +92,14 @@ enum ATC_STATE {
 typedef struct {
 	float TLO;
 	// int TOOL;
-	float G54[3];
 //	float G54[5*MAX_WCS];
 	float REFMZ;
 	float TOOLMZ;
 	float reserve;
 	int TOOL;
-	float G54AB[2];
     float perm_vars[20];
     bool probe_tool_not_calibrated;
-    float G55[4];
-    float G56[4];
-    float G57[4];
-    float G58[4];
-    float G59[4];
+    float WCScoord[6][4];
 } EEPROM_data;
 
 typedef struct {

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -101,6 +101,11 @@ typedef struct {
 	float G54AB[2];
     float perm_vars[20];
     bool probe_tool_not_calibrated;
+    float G55[4];
+    float G56[4];
+    float G57[4];
+    float G58[4];
+    float G59[4];
 } EEPROM_data;
 
 typedef struct {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -158,6 +158,11 @@ void Robot::on_module_loaded()
 	float a = THEKERNEL->eeprom_data->G54AB[0];
 	float b = THEKERNEL->eeprom_data->G54AB[1];
     wcs_offsets[0] = wcs_t(x, y, z, a, b);
+    wcs_offsets[1] = wcs_t(THEKERNEL->eeprom_data->G55[0] , THEKERNEL->eeprom_data->G55[1] , THEKERNEL->eeprom_data->G55[2] , THEKERNEL->eeprom_data->G55[3]);
+    wcs_offsets[2] = wcs_t(THEKERNEL->eeprom_data->G56[0] , THEKERNEL->eeprom_data->G56[1] , THEKERNEL->eeprom_data->G56[2] , THEKERNEL->eeprom_data->G56[3]);
+    wcs_offsets[3] = wcs_t(THEKERNEL->eeprom_data->G57[0] , THEKERNEL->eeprom_data->G57[1] , THEKERNEL->eeprom_data->G57[2] , THEKERNEL->eeprom_data->G57[3]);
+    wcs_offsets[4] = wcs_t(THEKERNEL->eeprom_data->G58[0] , THEKERNEL->eeprom_data->G58[1] , THEKERNEL->eeprom_data->G58[2] , THEKERNEL->eeprom_data->G58[3]);
+    wcs_offsets[5] = wcs_t(THEKERNEL->eeprom_data->G59[0] , THEKERNEL->eeprom_data->G59[1] , THEKERNEL->eeprom_data->G59[2] , THEKERNEL->eeprom_data->G59[3]);
 }
 
 #define ACTUATOR_CHECKSUMS(X) {     \
@@ -553,7 +558,38 @@ void Robot::set_current_wcs_by_mpos(float x, float y, float z, float a, float b)
         THEKERNEL->eeprom_data->G54AB[0] = a;
         THEKERNEL->eeprom_data->G54AB[1] = b;
         THEKERNEL->write_eeprom_data();
+    } else if (current_wcs == 1) {
+        THEKERNEL->eeprom_data->G55[0] = x;
+        THEKERNEL->eeprom_data->G55[1] = y;
+        THEKERNEL->eeprom_data->G55[2] = z;
+        THEKERNEL->eeprom_data->G55[3] = a;
+        THEKERNEL->write_eeprom_data();
+    } else if (current_wcs == 2) {
+        THEKERNEL->eeprom_data->G56[0] = x;
+        THEKERNEL->eeprom_data->G56[1] = y;
+        THEKERNEL->eeprom_data->G56[2] = z;
+        THEKERNEL->eeprom_data->G56[3] = a;
+        THEKERNEL->write_eeprom_data();
+    } else if (current_wcs == 3) {
+        THEKERNEL->eeprom_data->G57[0] = x;
+        THEKERNEL->eeprom_data->G57[1] = y;
+        THEKERNEL->eeprom_data->G57[2] = z;
+        THEKERNEL->eeprom_data->G57[3] = a;
+        THEKERNEL->write_eeprom_data();
+    } else if (current_wcs == 4) {
+        THEKERNEL->eeprom_data->G58[0] = x;
+        THEKERNEL->eeprom_data->G58[1] = y;
+        THEKERNEL->eeprom_data->G58[2] = z;
+        THEKERNEL->eeprom_data->G58[3] = a;
+        THEKERNEL->write_eeprom_data();
+    } else if (current_wcs == 5) {
+        THEKERNEL->eeprom_data->G59[0] = x;
+        THEKERNEL->eeprom_data->G59[1] = y;
+        THEKERNEL->eeprom_data->G59[2] = z;
+        THEKERNEL->eeprom_data->G59[3] = a;
+        THEKERNEL->write_eeprom_data();
     }
+
 }
 
 //A GCode has been received
@@ -675,6 +711,36 @@ void Robot::on_gcode_received(void *argument)
                     	    THEKERNEL->eeprom_data->G54AB[0] = a;
                     	    THEKERNEL->eeprom_data->G54AB[1] = b;
                     	    THEKERNEL->write_eeprom_data();
+                        }  else if (n == 1) {
+                            THEKERNEL->eeprom_data->G55[0] = x;
+                            THEKERNEL->eeprom_data->G55[1] = y;
+                            THEKERNEL->eeprom_data->G55[2] = z;
+                            THEKERNEL->eeprom_data->G55[3] = a;
+                            THEKERNEL->write_eeprom_data();
+                        } else if (n == 2) {
+                            THEKERNEL->eeprom_data->G56[0] = x;
+                            THEKERNEL->eeprom_data->G56[1] = y;
+                            THEKERNEL->eeprom_data->G56[2] = z;
+                            THEKERNEL->eeprom_data->G56[3] = a;
+                            THEKERNEL->write_eeprom_data();
+                        } else if (n == 3) {
+                            THEKERNEL->eeprom_data->G57[0] = x;
+                            THEKERNEL->eeprom_data->G57[1] = y;
+                            THEKERNEL->eeprom_data->G57[2] = z;
+                            THEKERNEL->eeprom_data->G57[3] = a;
+                            THEKERNEL->write_eeprom_data();
+                        } else if (n == 4) {
+                            THEKERNEL->eeprom_data->G58[0] = x;
+                            THEKERNEL->eeprom_data->G58[1] = y;
+                            THEKERNEL->eeprom_data->G58[2] = z;
+                            THEKERNEL->eeprom_data->G58[3] = a;
+                            THEKERNEL->write_eeprom_data();
+                        } else if (n == 5) {
+                            THEKERNEL->eeprom_data->G59[0] = x;
+                            THEKERNEL->eeprom_data->G59[1] = y;
+                            THEKERNEL->eeprom_data->G59[2] = z;
+                            THEKERNEL->eeprom_data->G59[3] = a;
+                            THEKERNEL->write_eeprom_data();
                         }
                     }
                 }
@@ -739,13 +805,43 @@ void Robot::on_gcode_received(void *argument)
                     		// third
                     		THEROBOT->reset_axis_position(gcode->get_value('A')+a, A_AXIS);  
                     		if (current_wcs == 0) {
-                    	    THEKERNEL->eeprom_data->G54[0] = x;
-                    	    THEKERNEL->eeprom_data->G54[1] = y;
-                    	    THEKERNEL->eeprom_data->G54[2] = z;
-                    	    THEKERNEL->eeprom_data->G54AB[0] = a;
-                    	    THEKERNEL->eeprom_data->G54AB[1] = b;
-                    	    THEKERNEL->write_eeprom_data();
-                        }
+                                THEKERNEL->eeprom_data->G54[0] = x;
+                                THEKERNEL->eeprom_data->G54[1] = y;
+                                THEKERNEL->eeprom_data->G54[2] = z;
+                                THEKERNEL->eeprom_data->G54AB[0] = a;
+                                THEKERNEL->eeprom_data->G54AB[1] = b;
+                                THEKERNEL->write_eeprom_data();
+                            }  else if (current_wcs == 1) {
+                                THEKERNEL->eeprom_data->G55[0] = x;
+                                THEKERNEL->eeprom_data->G55[1] = y;
+                                THEKERNEL->eeprom_data->G55[2] = z;
+                                THEKERNEL->eeprom_data->G55[3] = a;
+                                THEKERNEL->write_eeprom_data();
+                            } else if (current_wcs == 2) {
+                                THEKERNEL->eeprom_data->G56[0] = x;
+                                THEKERNEL->eeprom_data->G56[1] = y;
+                                THEKERNEL->eeprom_data->G56[2] = z;
+                                THEKERNEL->eeprom_data->G56[3] = a;
+                                THEKERNEL->write_eeprom_data();
+                            } else if (current_wcs == 3) {
+                                THEKERNEL->eeprom_data->G57[0] = x;
+                                THEKERNEL->eeprom_data->G57[1] = y;
+                                THEKERNEL->eeprom_data->G57[2] = z;
+                                THEKERNEL->eeprom_data->G57[3] = a;
+                                THEKERNEL->write_eeprom_data();
+                            } else if (current_wcs == 4) {
+                                THEKERNEL->eeprom_data->G58[0] = x;
+                                THEKERNEL->eeprom_data->G58[1] = y;
+                                THEKERNEL->eeprom_data->G58[2] = z;
+                                THEKERNEL->eeprom_data->G58[3] = a;
+                                THEKERNEL->write_eeprom_data();
+                            } else if (current_wcs == 5) {
+                                THEKERNEL->eeprom_data->G59[0] = x;
+                                THEKERNEL->eeprom_data->G59[1] = y;
+                                THEKERNEL->eeprom_data->G59[2] = z;
+                                THEKERNEL->eeprom_data->G59[3] = a;
+                                THEKERNEL->write_eeprom_data();
+                            }
                     		
                     	} else {
                         	THEROBOT->reset_axis_position(gcode->get_value('A'), A_AXIS);

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -152,8 +152,8 @@ void Robot::on_module_loaded()
     this->probe_tool_not_calibrated = THEKERNEL->eeprom_data->probe_tool_not_calibrated;
 
     // load wcs data from eeprom
-    for (int row = 0; row <2;row++){
-        wcs_offsets[row] = wcs_t(THEKERNEL->eeprom_data->WCScoord[row][0] , THEKERNEL->eeprom_data->WCScoord[row][1] , THEKERNEL->eeprom_data->WCScoord[row][2] , THEKERNEL->eeprom_data->WCScoord[row][3],0);
+    for (int wcs_index = 0; wcs_index < 6; wcs_index++){
+        wcs_offsets[wcs_index] = wcs_t(THEKERNEL->eeprom_data->WCScoord[wcs_index][0] , THEKERNEL->eeprom_data->WCScoord[wcs_index][1] , THEKERNEL->eeprom_data->WCScoord[wcs_index][2] , THEKERNEL->eeprom_data->WCScoord[wcs_index][3],0);
     }
 }
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -152,21 +152,9 @@ void Robot::on_module_loaded()
     this->probe_tool_not_calibrated = THEKERNEL->eeprom_data->probe_tool_not_calibrated;
 
     // load wcs data from eeprom
-	float x = THEKERNEL->eeprom_data->G54[0];
-	float y = THEKERNEL->eeprom_data->G54[1];
-	float z = THEKERNEL->eeprom_data->G54[2];
-	float a = THEKERNEL->eeprom_data->G54AB[0];
-	float b = THEKERNEL->eeprom_data->G54AB[1];
-    wcs_offsets[0] = wcs_t(x, y, z, a, b);
-    x = THEKERNEL->eeprom_data->G55[0];
-    y = THEKERNEL->eeprom_data->G55[1];
-    z = THEKERNEL->eeprom_data->G55[2];
-    a = THEKERNEL->eeprom_data->G55[3];
-    wcs_offsets[1] = wcs_t(x , y , z , a , b);
-    wcs_offsets[2] = wcs_t(THEKERNEL->eeprom_data->G56[0] , THEKERNEL->eeprom_data->G56[1] , THEKERNEL->eeprom_data->G56[2] , THEKERNEL->eeprom_data->G56[3],b);
-    wcs_offsets[3] = wcs_t(THEKERNEL->eeprom_data->G57[0] , THEKERNEL->eeprom_data->G57[1] , THEKERNEL->eeprom_data->G57[2] , THEKERNEL->eeprom_data->G57[3],b);
-    wcs_offsets[4] = wcs_t(THEKERNEL->eeprom_data->G58[0] , THEKERNEL->eeprom_data->G58[1] , THEKERNEL->eeprom_data->G58[2] , THEKERNEL->eeprom_data->G58[3],b);
-    wcs_offsets[5] = wcs_t(THEKERNEL->eeprom_data->G59[0] , THEKERNEL->eeprom_data->G59[1] , THEKERNEL->eeprom_data->G59[2] , THEKERNEL->eeprom_data->G59[3],b);
+    for (int row = 0; row <2;row++){
+        wcs_offsets[row] = wcs_t(THEKERNEL->eeprom_data->WCScoord[row][0] , THEKERNEL->eeprom_data->WCScoord[row][1] , THEKERNEL->eeprom_data->WCScoord[row][2] , THEKERNEL->eeprom_data->WCScoord[row][3],0);
+    }
 }
 
 #define ACTUATOR_CHECKSUMS(X) {     \
@@ -555,42 +543,11 @@ void Robot::set_current_wcs_by_mpos(float x, float y, float z, float a, float b)
     }
     THEROBOT->wcs_offsets[current_wcs] = Robot::wcs_t(x, y, z , a , b);
     // save wcs data to eeprom if current wcs = G54
-    if (current_wcs == 0) {
-        THEKERNEL->eeprom_data->G54[0] = x;
-        THEKERNEL->eeprom_data->G54[1] = y;
-        THEKERNEL->eeprom_data->G54[2] = z;
-        THEKERNEL->eeprom_data->G54AB[0] = a;
-        THEKERNEL->eeprom_data->G54AB[1] = b;
-        THEKERNEL->write_eeprom_data();
-    } else if (current_wcs == 1) {
-        THEKERNEL->eeprom_data->G55[0] = x;
-        THEKERNEL->eeprom_data->G55[1] = y;
-        THEKERNEL->eeprom_data->G55[2] = z;
-        THEKERNEL->eeprom_data->G55[3] = a;
-        THEKERNEL->write_eeprom_data();
-    } else if (current_wcs == 2) {
-        THEKERNEL->eeprom_data->G56[0] = x;
-        THEKERNEL->eeprom_data->G56[1] = y;
-        THEKERNEL->eeprom_data->G56[2] = z;
-        THEKERNEL->eeprom_data->G56[3] = a;
-        THEKERNEL->write_eeprom_data();
-    } else if (current_wcs == 3) {
-        THEKERNEL->eeprom_data->G57[0] = x;
-        THEKERNEL->eeprom_data->G57[1] = y;
-        THEKERNEL->eeprom_data->G57[2] = z;
-        THEKERNEL->eeprom_data->G57[3] = a;
-        THEKERNEL->write_eeprom_data();
-    } else if (current_wcs == 4) {
-        THEKERNEL->eeprom_data->G58[0] = x;
-        THEKERNEL->eeprom_data->G58[1] = y;
-        THEKERNEL->eeprom_data->G58[2] = z;
-        THEKERNEL->eeprom_data->G58[3] = a;
-        THEKERNEL->write_eeprom_data();
-    } else if (current_wcs == 5) {
-        THEKERNEL->eeprom_data->G59[0] = x;
-        THEKERNEL->eeprom_data->G59[1] = y;
-        THEKERNEL->eeprom_data->G59[2] = z;
-        THEKERNEL->eeprom_data->G59[3] = a;
+    if (current_wcs <= 5) {
+        THEKERNEL->eeprom_data->WCScoord[current_wcs][0] = x;
+        THEKERNEL->eeprom_data->WCScoord[current_wcs][1] = y;
+        THEKERNEL->eeprom_data->WCScoord[current_wcs][2] = z;
+        THEKERNEL->eeprom_data->WCScoord[current_wcs][3] = a;
         THEKERNEL->write_eeprom_data();
     }
 
@@ -708,42 +665,11 @@ void Robot::on_gcode_received(void *argument)
                         wcs_offsets[n] = wcs_t(x, y, z, a, b);
                         
                 		// save wcs data to eeprom
-                        if (n == 0) {
-                    	    THEKERNEL->eeprom_data->G54[0] = x;
-                    	    THEKERNEL->eeprom_data->G54[1] = y;
-                    	    THEKERNEL->eeprom_data->G54[2] = z;
-                    	    THEKERNEL->eeprom_data->G54AB[0] = a;
-                    	    THEKERNEL->eeprom_data->G54AB[1] = b;
-                    	    THEKERNEL->write_eeprom_data();
-                        }  else if (n == 1) {
-                            THEKERNEL->eeprom_data->G55[0] = x;
-                            THEKERNEL->eeprom_data->G55[1] = y;
-                            THEKERNEL->eeprom_data->G55[2] = z;
-                            THEKERNEL->eeprom_data->G55[3] = a;
-                            THEKERNEL->write_eeprom_data();
-                        } else if (n == 2) {
-                            THEKERNEL->eeprom_data->G56[0] = x;
-                            THEKERNEL->eeprom_data->G56[1] = y;
-                            THEKERNEL->eeprom_data->G56[2] = z;
-                            THEKERNEL->eeprom_data->G56[3] = a;
-                            THEKERNEL->write_eeprom_data();
-                        } else if (n == 3) {
-                            THEKERNEL->eeprom_data->G57[0] = x;
-                            THEKERNEL->eeprom_data->G57[1] = y;
-                            THEKERNEL->eeprom_data->G57[2] = z;
-                            THEKERNEL->eeprom_data->G57[3] = a;
-                            THEKERNEL->write_eeprom_data();
-                        } else if (n == 4) {
-                            THEKERNEL->eeprom_data->G58[0] = x;
-                            THEKERNEL->eeprom_data->G58[1] = y;
-                            THEKERNEL->eeprom_data->G58[2] = z;
-                            THEKERNEL->eeprom_data->G58[3] = a;
-                            THEKERNEL->write_eeprom_data();
-                        } else if (n == 5) {
-                            THEKERNEL->eeprom_data->G59[0] = x;
-                            THEKERNEL->eeprom_data->G59[1] = y;
-                            THEKERNEL->eeprom_data->G59[2] = z;
-                            THEKERNEL->eeprom_data->G59[3] = a;
+                        if (n <= 5) {
+                            THEKERNEL->eeprom_data->WCScoord[n][0] = x;
+                            THEKERNEL->eeprom_data->WCScoord[n][1] = y;
+                            THEKERNEL->eeprom_data->WCScoord[n][2] = z;
+                            THEKERNEL->eeprom_data->WCScoord[n][3] = a;
                             THEKERNEL->write_eeprom_data();
                         }
                     }
@@ -808,42 +734,11 @@ void Robot::on_gcode_received(void *argument)
         					THECONVEYOR->wait_for_idle();
                     		// third
                     		THEROBOT->reset_axis_position(gcode->get_value('A')+a, A_AXIS);  
-                    		if (current_wcs == 0) {
-                                THEKERNEL->eeprom_data->G54[0] = x;
-                                THEKERNEL->eeprom_data->G54[1] = y;
-                                THEKERNEL->eeprom_data->G54[2] = z;
-                                THEKERNEL->eeprom_data->G54AB[0] = a;
-                                THEKERNEL->eeprom_data->G54AB[1] = b;
-                                THEKERNEL->write_eeprom_data();
-                            }  else if (current_wcs == 1) {
-                                THEKERNEL->eeprom_data->G55[0] = x;
-                                THEKERNEL->eeprom_data->G55[1] = y;
-                                THEKERNEL->eeprom_data->G55[2] = z;
-                                THEKERNEL->eeprom_data->G55[3] = a;
-                                THEKERNEL->write_eeprom_data();
-                            } else if (current_wcs == 2) {
-                                THEKERNEL->eeprom_data->G56[0] = x;
-                                THEKERNEL->eeprom_data->G56[1] = y;
-                                THEKERNEL->eeprom_data->G56[2] = z;
-                                THEKERNEL->eeprom_data->G56[3] = a;
-                                THEKERNEL->write_eeprom_data();
-                            } else if (current_wcs == 3) {
-                                THEKERNEL->eeprom_data->G57[0] = x;
-                                THEKERNEL->eeprom_data->G57[1] = y;
-                                THEKERNEL->eeprom_data->G57[2] = z;
-                                THEKERNEL->eeprom_data->G57[3] = a;
-                                THEKERNEL->write_eeprom_data();
-                            } else if (current_wcs == 4) {
-                                THEKERNEL->eeprom_data->G58[0] = x;
-                                THEKERNEL->eeprom_data->G58[1] = y;
-                                THEKERNEL->eeprom_data->G58[2] = z;
-                                THEKERNEL->eeprom_data->G58[3] = a;
-                                THEKERNEL->write_eeprom_data();
-                            } else if (current_wcs == 5) {
-                                THEKERNEL->eeprom_data->G59[0] = x;
-                                THEKERNEL->eeprom_data->G59[1] = y;
-                                THEKERNEL->eeprom_data->G59[2] = z;
-                                THEKERNEL->eeprom_data->G59[3] = a;
+                            if (current_wcs <= 5) {
+                                THEKERNEL->eeprom_data->WCScoord[current_wcs][0] = x;
+                                THEKERNEL->eeprom_data->WCScoord[current_wcs][1] = y;
+                                THEKERNEL->eeprom_data->WCScoord[current_wcs][2] = z;
+                                THEKERNEL->eeprom_data->WCScoord[current_wcs][3] = a;
                                 THEKERNEL->write_eeprom_data();
                             }
                     		

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -158,11 +158,15 @@ void Robot::on_module_loaded()
 	float a = THEKERNEL->eeprom_data->G54AB[0];
 	float b = THEKERNEL->eeprom_data->G54AB[1];
     wcs_offsets[0] = wcs_t(x, y, z, a, b);
-    wcs_offsets[1] = wcs_t(THEKERNEL->eeprom_data->G55[0] , THEKERNEL->eeprom_data->G55[1] , THEKERNEL->eeprom_data->G55[2] , THEKERNEL->eeprom_data->G55[3]);
-    wcs_offsets[2] = wcs_t(THEKERNEL->eeprom_data->G56[0] , THEKERNEL->eeprom_data->G56[1] , THEKERNEL->eeprom_data->G56[2] , THEKERNEL->eeprom_data->G56[3]);
-    wcs_offsets[3] = wcs_t(THEKERNEL->eeprom_data->G57[0] , THEKERNEL->eeprom_data->G57[1] , THEKERNEL->eeprom_data->G57[2] , THEKERNEL->eeprom_data->G57[3]);
-    wcs_offsets[4] = wcs_t(THEKERNEL->eeprom_data->G58[0] , THEKERNEL->eeprom_data->G58[1] , THEKERNEL->eeprom_data->G58[2] , THEKERNEL->eeprom_data->G58[3]);
-    wcs_offsets[5] = wcs_t(THEKERNEL->eeprom_data->G59[0] , THEKERNEL->eeprom_data->G59[1] , THEKERNEL->eeprom_data->G59[2] , THEKERNEL->eeprom_data->G59[3]);
+    x = THEKERNEL->eeprom_data->G55[0];
+    y = THEKERNEL->eeprom_data->G55[1];
+    z = THEKERNEL->eeprom_data->G55[2];
+    a = THEKERNEL->eeprom_data->G55[3];
+    wcs_offsets[1] = wcs_t(x , y , z , a , b);
+    wcs_offsets[2] = wcs_t(THEKERNEL->eeprom_data->G56[0] , THEKERNEL->eeprom_data->G56[1] , THEKERNEL->eeprom_data->G56[2] , THEKERNEL->eeprom_data->G56[3],b);
+    wcs_offsets[3] = wcs_t(THEKERNEL->eeprom_data->G57[0] , THEKERNEL->eeprom_data->G57[1] , THEKERNEL->eeprom_data->G57[2] , THEKERNEL->eeprom_data->G57[3],b);
+    wcs_offsets[4] = wcs_t(THEKERNEL->eeprom_data->G58[0] , THEKERNEL->eeprom_data->G58[1] , THEKERNEL->eeprom_data->G58[2] , THEKERNEL->eeprom_data->G58[3],b);
+    wcs_offsets[5] = wcs_t(THEKERNEL->eeprom_data->G59[0] , THEKERNEL->eeprom_data->G59[1] , THEKERNEL->eeprom_data->G59[2] , THEKERNEL->eeprom_data->G59[3],b);
 }
 
 #define ACTUATOR_CHECKSUMS(X) {     \

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -2227,7 +2227,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				THEKERNEL->streams->printf("EEPRROM Data: TLO:%1.3f\n", THEKERNEL->eeprom_data->TLO);
 				THEKERNEL->streams->printf("EEPRROM Data: TOOLMZ:%1.3f\n", THEKERNEL->eeprom_data->TOOLMZ);
 				THEKERNEL->streams->printf("EEPRROM Data: REFMZ:%1.3f\n", THEKERNEL->eeprom_data->REFMZ);
-				THEKERNEL->streams->printf("EEPRROM Data: G54: %1.3f, %1.3f, %1.3f\n", THEKERNEL->eeprom_data->G54[0], THEKERNEL->eeprom_data->G54[1], THEKERNEL->eeprom_data->G54[2]);
+				for (int row = 0; row <2;row++){
+					THEKERNEL->streams->printf("EEPRROM Data: G5%d: %1.3f, %1.3f, %1.3f, %1.3f\n", row , THEKERNEL->eeprom_data->WCScoord[row][0] , THEKERNEL->eeprom_data->WCScoord[row][1] , THEKERNEL->eeprom_data->WCScoord[row][2] , THEKERNEL->eeprom_data->WCScoord[row][3]);
+				}
 			} else if (gcode->subcode == 2) {
 				// Show EEPROM DATA
 				THEKERNEL->erase_eeprom_data();

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -2227,8 +2227,8 @@ void ATCHandler::on_gcode_received(void *argument)
 				THEKERNEL->streams->printf("EEPRROM Data: TLO:%1.3f\n", THEKERNEL->eeprom_data->TLO);
 				THEKERNEL->streams->printf("EEPRROM Data: TOOLMZ:%1.3f\n", THEKERNEL->eeprom_data->TOOLMZ);
 				THEKERNEL->streams->printf("EEPRROM Data: REFMZ:%1.3f\n", THEKERNEL->eeprom_data->REFMZ);
-				for (int row = 0; row <2;row++){
-					THEKERNEL->streams->printf("EEPRROM Data: G5%d: %1.3f, %1.3f, %1.3f, %1.3f\n", row , THEKERNEL->eeprom_data->WCScoord[row][0] , THEKERNEL->eeprom_data->WCScoord[row][1] , THEKERNEL->eeprom_data->WCScoord[row][2] , THEKERNEL->eeprom_data->WCScoord[row][3]);
+				for (int wcs_index = 0; wcs_index < 6; wcs_index++){
+					THEKERNEL->streams->printf("EEPRROM Data: G5%d: %1.3f, %1.3f, %1.3f, %1.3f\n", wcs_index + 4, THEKERNEL->eeprom_data->WCScoord[wcs_index][0] , THEKERNEL->eeprom_data->WCScoord[wcs_index][1] , THEKERNEL->eeprom_data->WCScoord[wcs_index][2] , THEKERNEL->eeprom_data->WCScoord[wcs_index][3]);
 				}
 			} else if (gcode->subcode == 2) {
 				// Show EEPROM DATA

--- a/version.txt
+++ b/version.txt
@@ -2,6 +2,7 @@ Notice:
 To let the Carvera work perfectly, please make sure both your controller software and firmware are up to date. For firmware, download the new firmware first, then use the 'update' function to upgrade the firmware, and reset the machine after the update is complete.
 [1.0.3c1.0.6]
 - properly update to makera 1.0.3, something went wrong in 1.0.5 where not all the code came over
+- update to save G55-59 to EEPROM so they save when the machine is powered off
 [1.0.3c1.0.5]
 - added support for touch probe on carvera air
 - refactor of probing sequences code to combine repeated code


### PR DESCRIPTION
Adding the ability to save WCS 55-59 to eeprom so they are saved on reset

Should be relatively straightforward: go to any WCS, save a position using G10L20, reset, and the change should still be there