### PR TITLE
[robot] inverse-time mode support

### DIFF
--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1690,7 +1690,7 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
     } else if (what == "state") {
         // also $G and $I
         // [G0 G54 G17 G21 G90 G94 M0 M5 M9 T0 F0.]
-        stream->printf("[G%d %s G%d G%d G%d G94 M0 M%c M%c T%d F%1.4f S%1.4f]\n",
+        stream->printf("[G%d %s G%d G%d G%d G%d M0 M%c M%c T%d F%1.4f S%1.4f]\n",
             THEKERNEL->gcode_dispatch->get_modal_command(),
             wcs2gcode(THEROBOT->get_current_wcs()).c_str(),
             THEROBOT->plane_axis_0 == X_AXIS && THEROBOT->plane_axis_1 == Y_AXIS && THEROBOT->plane_axis_2 == Z_AXIS ? 17 :
@@ -1698,6 +1698,7 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
               THEROBOT->plane_axis_0 == Y_AXIS && THEROBOT->plane_axis_1 == Z_AXIS && THEROBOT->plane_axis_2 == X_AXIS ? 19 : 17,
             THEROBOT->inch_mode ? 20 : 21,
             THEROBOT->absolute_mode ? 90 : 91,
+            THEROBOT->inverse_time_mode ? 93 : 94,
             get_switch_state("spindle") ? '3' : '5',
             get_switch_state("mist") ? '7' : get_switch_state("flood") ? '8' : '9',
             get_active_tool(),

--- a/version.txt
+++ b/version.txt
@@ -9,6 +9,8 @@
 - Enhancement: Added M891 to remove a tool slot defintion. Parameter is T for the tool slot to remove. This immediately removes the config from memory and file. If /sd/custom_tool_slots.txt doesn't exist it will be created and populated.
 - Enhancement: Added the current spindle PWM value to the status response (? command)
 - Enhancement: If flex compensation file is missing and autoload is active, new error informs user
+- Enhancement: Added G93 (Inverse Time Feed Mode) - Sets feed rate mode where F parameter specifies 1/min (inverse time). The feed rate is multiplied by move distance to calculate mm/min. Useful for maintaining consistent time per move regardless of distance.
+- Enhancement: Added G94 (Feed Rate Per Minute Mode) - Sets feed rate mode to mm/min (default mode). The F parameter directly specifies feed rate in millimeters per minute.
 - Fix: Active measurement of flex compensation will be aborted if the machine goes to a halt
 - Fix: Restored the stock Makera probing laser behaviour if tool 0 is NOT the 3d probe
 


### PR DESCRIPTION
This adds two new codes:

* G93 - enables the inverse-time mode and causes the feed (F) parameter to be interpreted as minutes^-1 instead of mm/minute, meaning all commanded axes move towards the target at their constant speeds and reach it at the same time after 1/F minutes. It disables the A axis radius compensation, but the max axis speed clamping is still in place.

* G94 - enables the classic mm/minute feed mode. It is the default. The behavior should be identical to that before the changes, except that A axis movement is now also synchronized to G02/G03 arc movements (previously the linear axes moved first, and only then A moved).
