### PR TITLE
Port of the continuous jog feature from upstream smoothieware and extending it for a keep alive packet and working with software endstops

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -72,6 +72,7 @@ Kernel::Kernel()
     feed_hold = false;
     enable_feed_hold = false;
     bad_mcu= true;
+    stop_request = false;
     uploading = false;
     laser_mode = false;
     vacuum_mode = false;

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -90,6 +90,7 @@ Kernel::Kernel()
     checkled = false;
     spindleon = false;
     cachewait = false;
+    keep_alive_request = false;
 
     instance = this; // setup the Singleton instance of the kernel    
     

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -147,6 +147,12 @@ class Kernel {
         bool get_stop_request() const { return stop_request; }
         void set_stop_request(bool f) { stop_request= f; }
 
+        uint32_t get_stop_request_time() const { return stop_request_time; }
+        void set_stop_request_time(uint32_t t) { stop_request_time = t; }
+
+        bool get_internal_stop_request() const { return internal_stop_request; }
+        void set_internal_stop_request(bool f) { internal_stop_request = f; }
+
         void set_uploading(bool f) { uploading = f; }
         bool is_uploading() const { return uploading; }
 
@@ -255,6 +261,8 @@ class Kernel {
             volatile bool enable_feed_hold:1;
             bool bad_mcu:1;
             bool stop_request:1;
+            uint32_t stop_request_time;
+            bool internal_stop_request:1;
             volatile bool uploading:1;
             bool laser_mode:1;
             bool vacuum_mode:1;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -150,6 +150,9 @@ class Kernel {
         uint32_t get_stop_request_time() const { return stop_request_time; }
         void set_stop_request_time(uint32_t t) { stop_request_time = t; }
 
+        void set_keep_alive_request(bool f) { keep_alive_request = f; }
+        bool get_keep_alive_request() const { return keep_alive_request; }
+
         bool get_internal_stop_request() const { return internal_stop_request; }
         void set_internal_stop_request(bool f) { internal_stop_request = f; }
 
@@ -252,6 +255,7 @@ class Kernel {
         // When a module asks to be called for a specific event ( a hook ), this is where that request is remembered
         mbed::I2C* i2c;
         std::array<std::vector<Module*>, NUMBER_OF_DEFINED_EVENTS> hooks;
+        uint32_t stop_request_time;
         struct {
             bool use_leds:1;
             bool halted:1;
@@ -261,8 +265,8 @@ class Kernel {
             volatile bool enable_feed_hold:1;
             bool bad_mcu:1;
             bool stop_request:1;
-            uint32_t stop_request_time;
             bool internal_stop_request:1;
+            bool keep_alive_request:1;
             volatile bool uploading:1;
             bool laser_mode:1;
             bool vacuum_mode:1;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -144,6 +144,9 @@ class Kernel {
         void set_bad_mcu(bool b) { bad_mcu= b; }
         bool is_bad_mcu() const { return bad_mcu; }
 
+        bool get_stop_request() const { return stop_request; }
+        void set_stop_request(bool f) { stop_request= f; }
+
         void set_uploading(bool f) { uploading = f; }
         bool is_uploading() const { return uploading; }
 
@@ -251,6 +254,7 @@ class Kernel {
             bool ok_per_line:1;
             volatile bool enable_feed_hold:1;
             bool bad_mcu:1;
+            bool stop_request:1;
             volatile bool uploading:1;
             bool laser_mode:1;
             bool vacuum_mode:1;

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <stdarg.h>
 using std::string;
+#include "mbed.h" // for us_ticker_read()
 #include "libs/Module.h"
 #include "libs/Kernel.h"
 #include "libs/nuts_bolts.h"
@@ -89,7 +90,12 @@ void SerialConsole::on_serial_char_received() {
 			continue;
 		}
         if(received == 'Y' - 'A' + 1) { // ^Y
-            THEKERNEL->set_stop_request(true); // generic stop what you are doing request
+            if(THEKERNEL->get_internal_stop_request()) {
+                THEKERNEL->set_internal_stop_request(false);
+            } else {
+                THEKERNEL->set_stop_request(true); // generic stop what you are doing request
+                THEKERNEL->set_stop_request_time(us_ticker_read() / 1000);
+            }
             continue;
         }
         if(THEKERNEL->is_feed_hold_enabled()) {

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -98,6 +98,10 @@ void SerialConsole::on_serial_char_received() {
             }
             continue;
         }
+        if(received == 'Z' - 'A' + 1) { // ^Z
+            THEKERNEL->set_keep_alive_request(true);
+            continue;
+        }
         if(THEKERNEL->is_feed_hold_enabled()) {
             if(received == '!') { // safe pause
                 THEKERNEL->set_feed_hold(true);

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -88,6 +88,10 @@ void SerialConsole::on_serial_char_received() {
 			halt_flag = true;
 			continue;
 		}
+        if(received == 'Y' - 'A' + 1) { // ^Y
+            THEKERNEL->set_stop_request(true); // generic stop what you are doing request
+            continue;
+        }
         if(THEKERNEL->is_feed_hold_enabled()) {
             if(received == '!') { // safe pause
                 THEKERNEL->set_feed_hold(true);

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -28,6 +28,7 @@ using std::string;
 SerialConsole::SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate ){
     this->serial = new mbed::Serial( rx_pin, tx_pin );
     this->serial->baud(baud_rate);
+    this->previous_char = 0;
 }
 
 // Called when the module has just been loaded
@@ -79,8 +80,19 @@ void SerialConsole::on_serial_char_received() {
 		
 		if (received == '?') {
 			query_flag = true;
+            this->previous_char = received;
+			continue;
+		} else if (this->previous_char == '?' && received == '1') {
+			// Found ?1 pattern
+			query_flag = true;
+			THEKERNEL->set_keep_alive_request(true);
+			this->previous_char = 0; // Reset
 			continue;
 		}
+		
+		// Reset previous_char for any other character
+		this->previous_char = received;
+		
 		//if (received == '*') {
 		//	diagnose_flag = true;
 		//	continue;

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -43,6 +43,7 @@ class SerialConsole : public Module, public StreamOutput {
         //vector<std::string> received_lines;    // Received lines are stored here until they are requested
         RingBuffer<char,256> buffer;             // Receive buffer
         mbed::Serial* serial;
+        char previous_char;                       // Track previous character for ?1 detection
         struct {
           bool query_flag:1;
           bool halt_flag:1;

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -107,6 +107,15 @@ void Block::clear()
     }
 }
 
+// Only used for continuous mode to reuse the same block over and over
+void Block::reset(tickinfo_t *saved)
+{
+    for(int i = 0; i < n_actuators; ++i) {
+        if(saved[i].steps_to_move == 0) continue;
+        tick_info[i]= saved[i];
+    }
+}
+
 void Block::debug() const
 {
     THEKERNEL->streams->printf("%p: steps-X:%lu Y:%lu Z:%lu ", this, this->steps[0], this->steps[1], this->steps[2]);

--- a/src/modules/robot/Block.h
+++ b/src/modules/robot/Block.h
@@ -64,6 +64,7 @@ class Block {
             uint32_t step_count;
             uint32_t next_accel_event;
         };
+        void reset(tickinfo_t *saved);
 
         // need info for each active motor
         tickinfo_t *tick_info;

--- a/src/modules/robot/Conveyor.h
+++ b/src/modules/robot/Conveyor.h
@@ -35,6 +35,8 @@ public:
     void flush_queue(void);
     float get_current_feedrate() const { return current_feedrate; }
     void force_queue() { check_queue(true); }
+    bool set_continuous_mode(bool f);
+    void set_hold(bool f) { hold_queue= f; }
 
     friend class Planner; // for queue
 
@@ -44,7 +46,8 @@ private:
 
     using  Queue_t= BlockQueue;
     Queue_t queue;  // Queue of Blocks
-
+    void *saved_block;
+    
     uint32_t queue_delay_time_ms;
     size_t queue_size;
     float current_feedrate{0}; // actual nominal feedrate that current block is running at in mm/sec
@@ -53,6 +56,8 @@ private:
         volatile bool running:1;
         volatile bool allow_fetch:1;
         bool flush:1;
+        volatile bool hold_queue:1;
+        volatile uint8_t continuous_mode:2;
     };
 
 };

--- a/src/modules/robot/Conveyor.h
+++ b/src/modules/robot/Conveyor.h
@@ -36,6 +36,7 @@ public:
     float get_current_feedrate() const { return current_feedrate; }
     void force_queue() { check_queue(true); }
     bool set_continuous_mode(bool f);
+    bool is_continuous_mode() const { return continuous_mode == 2; }
     void set_hold(bool f) { hold_queue= f; }
 
     friend class Planner; // for queue

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1617,6 +1617,20 @@ void Robot::reset_position_from_current_actuator_position()
     #endif
 }
 
+// this needs to be done if compensation is turned off for continuous jog
+void Robot::reset_compensated_machine_position()
+{
+    if(compensationTransform) {
+        compensationTransform = nullptr;
+        // we want to leave it where we have set Z, not where it ended up AFTER compensation so
+        // this should correct the Z position to the machine_position
+        is_g123 = false; // we don't want the laser to fire
+        if(!append_milestone(machine_position, this->seek_rate / 60.0F, 0)) {
+            reset_axis_position(machine_position[X_AXIS], machine_position[Y_AXIS], machine_position[Z_AXIS]);
+        }
+    }
+}
+
 // Convert target (in machine coordinates) to machine_position, then convert to actuator position and append this to the planner
 // target is in machine coordinates without the compensation transform, however we save a compensated_machine_position that includes
 // all transforms and is what we actually convert to actuator positions

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -38,6 +38,7 @@ class Robot : public Module {
         void reset_axis_position(float x, float y, float z);
         void reset_actuator_position(const ActuatorCoordinates &ac);
         void reset_position_from_current_actuator_position();
+        void reset_compensated_machine_position();
         float get_seconds_per_minute() const { return seconds_per_minute; }
         float get_z_maxfeedrate() const { return this->max_speeds[Z_AXIS]; }
         float get_default_acceleration() const { return default_acceleration; }

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -114,6 +114,15 @@ class Robot : public Module {
             uint8_t plane_axis_2:2;
         };
 
+        // Soft endstop accessors
+        float get_soft_endstop_min(int axis) const { return soft_endstop_min[axis]; }
+        float get_soft_endstop_max(int axis) const { return soft_endstop_max[axis]; }
+        bool is_soft_endstop_enabled() const { return soft_endstop_enabled; }
+        bool is_soft_endstop_halt() const { return soft_endstop_halt; }
+
+        // Homing status accessors
+        bool is_homed(uint8_t i) const;
+
     private:
         bool home_override = false;
         enum MOTION_MODE_T {
@@ -130,7 +139,6 @@ class Robot : public Module {
         bool append_arc( Gcode* gcode, const float target[], const float offset[], float radius, bool is_clockwise );
         bool compute_arc(Gcode* gcode, const float offset[], const float target[], enum MOTION_MODE_T motion_mode);
         void process_move(Gcode *gcode, enum MOTION_MODE_T);
-        bool is_homed(uint8_t i) const;
 
         float theta(float x, float y);
         void select_plane(uint8_t axis_0, uint8_t axis_1, uint8_t axis_2);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -2121,7 +2121,6 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
     if(THEKERNEL->get_internal_stop_request()) {
         THEKERNEL->set_internal_stop_request(false);
         stream->printf("Internal stop request reset\n");
-        return;
     }
 
     // set feedrate, either scale of max or actual feedrate

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -2016,7 +2016,7 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
 
 void SimpleShell::jog(string parameters, StreamOutput *stream)
 {
-    // $J X0.1 [Y0.2] [F0.5]
+    // $J X0.1 [Y0.2] [S0.5]
     int n_motors= THEROBOT->get_number_registered_motors();
 
     // get axis to move and amount (X0.1)
@@ -2024,6 +2024,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
 
     float rate_mm_s= NAN;
     float scale= 1.0F;
+    float fr= NAN;
     float delta[n_motors];
     for (int i = 0; i < n_motors; ++i) {
         delta[i]= 0;
@@ -2032,17 +2033,42 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
     // $J is first parameter
     shift_parameter(parameters);
     if(parameters.empty()) {
-        stream->printf("usage: $J X0.01 [F0.5] - axis can be XYZABC, optional speed is scale of max_rate\n");
+        stream->printf("usage: $J [-c] X0.01 [S0.5|Fnnn] - axis can be XYZABC, optional speed is scale of max_rate or feedrate. -c turns on continuous jog mode\n");
         return;
     }
 
+    bool cont_mode= false;
+    bool send_ok= false;
     while(!parameters.empty()) {
         string p= shift_parameter(parameters);
 
+        if(p.size() == 2 && p[0] == '-') {
+            // process option
+            switch(toupper(p[1])) {
+                case 'C':
+                    cont_mode= true;
+                    break;
+                case 'R': // send ok when done use this when sending $J in a gcode file
+                    send_ok= true;
+                    break;
+                default:
+                    stream->printf("error:illegal option %c\n", p[1]);
+                    return;
+            }
+            continue;
+        }
+
+
         char ax= toupper(p[0]);
-        if(ax == 'F') {
+        if(ax == 'S') {
             // get speed scale
             scale= strtof(p.substr(1).c_str(), NULL);
+            fr= NAN;
+            continue;
+        }else if(ax == 'F') {
+            // OR specify feedrate (last one wins)
+            scale= 1.0F;
+            fr= strtof(p.substr(1).c_str(), NULL) / 60.0F; // we want mm/sec but F is specified in mm/min
             continue;
         }
 
@@ -2078,11 +2104,89 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
         return;
     }
 
-    //stream->printf("F%f\n", rate_mm_s*scale);
+    // There is a race condition where a quick press/release could send the ^Y before the $J -c is executed
+    // this would result in continuous movement, not a good thing.
+    // so check if stop request is true and abort if it is, this means we must leave stop request false after this
+    if(THEKERNEL->get_stop_request()) {
+        THEKERNEL->set_stop_request(false);
+        stream->printf("ok\n");
+        return;
+    }
 
-    THEROBOT->delta_move(delta, rate_mm_s*scale, n_motors);
-    // turn off queue delay and run it now
-    THECONVEYOR->force_queue();
+    // set feedrate, either scale of max or actual feedrate
+    if(isnan(fr)) {
+        fr = rate_mm_s * scale;
+    }else{
+        // make sure we do not exceed maximum
+        if(fr > rate_mm_s) fr= rate_mm_s;
+    }
+
+    if(cont_mode) {
+        // continuous jog mode
+        // calculate minimum distance to travel to accomodate acceleration and feedrate
+        float acc= THEROBOT->get_default_acceleration();
+        float t= fr/acc; // time to reach feed rate
+        float d= 0.5F * acc * powf(t, 2); // distance required to accelerate (or decelerate)
+        d = std::max(d, 0.3333F); // take minimum being 1mm overall so 0.3333mm
+        // we need to check if the feedrate is too slow, for continuous jog if it takes over 5 seconds it is too slow
+        t= d*3 / fr; // time it will take to do all three blocks
+        if(t > 5) {
+            // increase feedrate so it will not take more than 5 seconds
+            fr= (d*3)/5;
+        }
+
+        // we need to move at least this distance to reach full speed
+        for (int i = 0; i < n_motors; ++i) {
+            if(delta[i] != 0) {
+                delta[i]= d * (delta[i]<0?-1:1);
+            }
+        }
+        // stream->printf("distance: %f, time:%f, X%f Y%f Z%f, speed:%f\n", d, t, delta[0], delta[1], delta[2], fr);
+
+        THECONVEYOR->wait_for_idle();
+        // turn off any compensation transform so Z does not move as we jog
+        auto savect= THEROBOT->compensationTransform;
+        THEROBOT->reset_compensated_machine_position();
+
+        // feed three blocks that allow full acceleration, full speed and full deceleration
+        THECONVEYOR->set_hold(true);
+        THEROBOT->delta_move(delta, fr, n_motors); // accelerates upto speed
+        THEROBOT->delta_move(delta, fr, n_motors); // continues at full speed
+        THEROBOT->delta_move(delta, fr, n_motors); // decelerates to zero
+
+        // DEBUG
+        // THECONVEYOR->dump_queue();
+
+        // tell it to run the second block until told to stop
+        if(!THECONVEYOR->set_continuous_mode(true)) {
+            stream->printf("error:Not enough memory to run continuous mode\n");
+            THECONVEYOR->set_hold(false);
+            THECONVEYOR->flush_queue();
+            return;
+        }
+
+        THECONVEYOR->set_hold(false);
+        THECONVEYOR->force_queue();
+
+        while(!THEKERNEL->get_stop_request()) {
+            THEKERNEL->call_event(ON_IDLE);
+            if(THEKERNEL->is_halted()) break;
+        }
+        THECONVEYOR->set_continuous_mode(false);
+        THEKERNEL->set_stop_request(false);
+        THECONVEYOR->wait_for_idle();
+
+        // reset the position based on current actuator position
+        THEROBOT->reset_position_from_current_actuator_position();
+        // restore compensationTransform
+        THEROBOT->compensationTransform= savect;
+        stream->printf("ok\n");
+
+    }else{
+        THEROBOT->delta_move(delta, fr, n_motors);
+        // turn off queue delay and run it now
+        THECONVEYOR->force_queue();
+    }
 }
 
 void SimpleShell::help_command( string parameters, StreamOutput *stream )

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -2187,7 +2187,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
             if(THEKERNEL->get_keep_alive_request()) {
                 THEKERNEL->set_keep_alive_request(false);
                 keep_alive_time = us_ticker_read() / 1000;
-            }else if (us_ticker_read() / 1000 - keep_alive_time > 500) {
+            }else if (us_ticker_read() / 1000 - keep_alive_time > 400) {
                 THEKERNEL->set_internal_stop_request(true);
             }
 

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -99,5 +99,5 @@ private:
 
     static const ptentry_t commands_table[];
     static int reset_delay_secs;
-
+    uint32_t keep_alive_time;
 };

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -128,10 +128,19 @@ void WifiProvider::receive_wifi_data() {
 			if(THEKERNEL->is_cachewait()) {
 				continue;
 			}
-	        if(WifiData[i] == '?') {
-	            query_flag = true;
-	            continue;
-	        }
+	        // Check for "?1" pattern
+			if (i < received - 1 && WifiData[i] == '?' && WifiData[i + 1] == '1') {
+				query_flag = true;
+				THEKERNEL->set_keep_alive_request(true);
+				i++; // Skip both characters
+				continue;
+			}
+
+			// Check for single "?" pattern
+			if(WifiData[i] == '?') {
+				query_flag = true;
+				continue;
+			}
 			//if (WifiData[i] == '*') {
 			//	diagnose_flag = true;
 			//	continue;

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -140,6 +140,11 @@ void WifiProvider::receive_wifi_data() {
 	            halt_flag = true;
 	            continue;
 	        }
+			if(WifiData[i] == 'Y' - 'A' + 1) { // ^Y
+	            THEKERNEL->set_stop_request(true); // generic stop what you are doing request
+				THEKERNEL->streams->printf("^Y\n");
+	            continue;
+	        }
 	        if(THEKERNEL->is_feed_hold_enabled()) {
 	            if(WifiData[i] == '!') { // safe pause
 	                THEKERNEL->set_feed_hold(true);

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -145,6 +145,10 @@ void WifiProvider::receive_wifi_data() {
 				THEKERNEL->streams->printf("^Y\n");
 	            continue;
 	        }
+			if(WifiData[i] == 'Z' - 'A' + 1) { // ^Z
+				THEKERNEL->set_keep_alive_request(true);
+				continue;
+			}
 	        if(THEKERNEL->is_feed_hold_enabled()) {
 	            if(WifiData[i] == '!') { // safe pause
 	                THEKERNEL->set_feed_hold(true);


### PR DESCRIPTION
I ported the continuous jog mode of smoothieware to the carvera.

For safety reasons I reused the getquery flag "?". If the continuous jog is active, the controller sends "?1" instead every 200ms. If the connection is lost. The machine stops every movement.

The jog movement doesn't stop precisely at the endstop when coming from a great distance, but it stops with a safety distance. If another jog command torwards the endstop is issued, it just delta moves to the endstop instead of going into the continuous jog mode.

Community Controller with continuous jog functionality is needed (in development right now)