### PR TITLE
Fixed arcs for the rotated wcs

### DIFF
--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -65,6 +65,10 @@ class Robot : public Module {
         std::tuple<float, float, float, uint8_t> get_last_probe_position() const { return last_probe_position; }
         void set_last_probe_position(std::tuple<float, float, float, uint8_t> p) { last_probe_position = p; }
         bool delta_move(const float delta[], float rate_mm_s, uint8_t naxis);
+        void rotate(float pos[]){return rotate(&pos[0], &pos[1], &pos[2]);}
+        void rotate(float *x, float *y, float *z);
+        void unrotate(float *x, float *y, float *z);
+        void unrotate(float pos[]){return unrotate(&pos[0], &pos[1], &pos[2]);}
         uint8_t register_motor(StepperMotor*);
         uint8_t get_number_registered_motors() const {return n_motors; }
         uint8_t get_current_motion_mode() const {return current_motion_mode; }
@@ -126,8 +130,8 @@ class Robot : public Module {
         void load_config();
         bool append_milestone(const float target[], float rate_mm_s, unsigned int line);
         bool append_line( Gcode* gcode, const float target[], float rate_mm_s, float delta_e);
-        bool append_arc( Gcode* gcode, const float target[], const float offset[], float radius, bool is_clockwise );
-        bool compute_arc(Gcode* gcode, const float offset[], const float target[], enum MOTION_MODE_T motion_mode);
+        bool append_arc( Gcode* gcode, const float target[], const float rotated_target[], const float offset[], float radius, bool is_clockwise );
+        bool compute_arc(Gcode* gcode, const float offset[], const float target[], const float rotated_target[], enum MOTION_MODE_T motion_mode);
         void process_move(Gcode *gcode, enum MOTION_MODE_T);
         bool is_homed(uint8_t i) const;
 


### PR DESCRIPTION
Arcs now fully support every rotation angle in absolute or relative coordinates. Works for G17 G18 and G19