### PR TITLE
Refactoring of the way the probing cycles are started in the ZProbe, added 4th axis probing and 3D Probe is always active on the AIR

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -2642,6 +2642,19 @@ void ATCHandler::on_get_public_data(void* argument)
     } else if (pdr->second_element_is(get_atc_clamped_status_checksum)) {
 		uint8_t* data = static_cast<uint8_t*>(pdr->get_data_ptr());
 		*data = static_cast<uint8_t>(this->atc_home_info.clamp_status); //0 unhomed, 1 clamped, 2 unclamped
+	} else if (pdr->second_element_is(get_machine_offsets_checksum)) {
+		struct machine_offsets *m = static_cast<machine_offsets*>(pdr->get_data_ptr());
+		m->anchor1_x = this->anchor1_x;
+		m->anchor1_y = this->anchor1_y;
+		m->anchor2_offset_x = this->anchor2_offset_x;
+		m->anchor2_offset_y = this->anchor2_offset_y;
+		m->anchor_width = this->anchor_width;
+		m->rotation_offset_x = this->rotation_offset_x;
+		m->rotation_offset_y = this->rotation_offset_y;
+		m->rotation_offset_z = this->rotation_offset_z;
+		m->rotation_width = this->rotation_width;
+		m->clearance_z = this->clearance_z;
+		pdr->set_taken();
 	}
 }
 

--- a/src/modules/tools/atc/ATCHandlerPublicAccess.h
+++ b/src/modules/tools/atc/ATCHandlerPublicAccess.h
@@ -6,6 +6,7 @@
 
 #define atc_handler_checksum   		CHECKSUM("atc_handler")
 #define get_tool_status_checksum    CHECKSUM("get_tool_status")
+#define get_machine_offsets_checksum CHECKSUM("get_machine_offsets")
 #define set_ref_tool_mz_checksum	CHECKSUM("set_ref_tool_mz")
 #define get_atc_pin_status_checksum	CHECKSUM("get_atc_pin_status")
 #define set_job_complete_checksum	CHECKSUM("set_job_complete")
@@ -23,6 +24,21 @@ struct tool_status {
 	float cur_tool_mz;
 	float ref_tool_mz;
 	float tool_offset;
+};
+
+struct machine_offsets {
+	float anchor1_x;
+    float anchor1_y;
+    float anchor2_offset_x;
+    float anchor2_offset_y;
+    float anchor_width;
+
+    float rotation_offset_x;
+    float rotation_offset_y;
+    float rotation_offset_z;
+    float rotation_width;
+
+	float clearance_z;
 };
 
 #endif

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -89,6 +89,9 @@ void ZProbe::on_module_loaded()
     // register event-handlers
     register_for_event(ON_GCODE_RECEIVED);
     register_for_event(ON_GET_PUBLIC_DATA);
+    register_for_event(ON_MAIN_LOOP);
+
+    this->probing_cycle = NONE;
 
     // we read the probe in this timer
     probing = false;
@@ -176,6 +179,55 @@ void ZProbe::config_load()
     }
     this->dwell_before_probing = THEKERNEL->config->value(zprobe_checksum, dwell_before_probing_checksum)->by_default(0)->as_number(); // dwell time in seconds before probing
 
+}
+
+void ZProbe::on_main_loop(void *argument)
+{
+    switch(probing_cycle)
+    {
+        case CALIBRATE_PROBE_BORE:
+            calibrate_probe_bore();
+            probing_cycle = NONE;
+            break;
+        case CALIBRATE_PROBE_BOSS:
+            calibrate_probe_boss();
+            probing_cycle = NONE;
+            break;
+        case PROBE_BORE:
+            probe_bore();
+            probing_cycle = NONE;
+            break;
+        case PROBE_BOSS:
+            probe_boss();
+            probing_cycle = NONE;
+            break;
+        case PROBE_INSIDE_CORNER:
+            probe_insideCorner();
+            probing_cycle = NONE;
+            break;
+        case PROBE_OUTSIDE_CORNER:
+            probe_outsideCorner();
+            probing_cycle = NONE;
+            break;
+        case PROBE_AXIS_ANGLE:
+            probe_axisangle();
+            probing_cycle = NONE;
+            break;
+        case PROBE_A_AXIS:
+            probe_axisangle(true, false);
+            probing_cycle = NONE;
+            break;
+        case PROBE_A_AXIS_WITH_OFFSET:
+            probe_axisangle(true, true);
+            probing_cycle = NONE;
+            break;
+        case PROBE_SINGLE_AXIS_DOUBLE_TAP:
+            single_axis_probe_double_tap();
+            probing_cycle = NONE;
+            break;
+        default:
+            break;
+    }
 }
 
 uint32_t ZProbe::read_probe(uint32_t dummy)
@@ -528,7 +580,7 @@ void ZProbe::on_gcode_received(void *argument)
                         return;
                     }
                     if (parse_parameters(gcode)){
-                        calibrate_probe_boss();
+                        probing_cycle = CALIBRATE_PROBE_BOSS;
                     }
                 }else {
                     if (!gcode->has_letter('X') && !gcode->has_letter('Y') ) { //error if there is a problem
@@ -538,7 +590,7 @@ void ZProbe::on_gcode_received(void *argument)
                         return;
                     }
                     if (parse_parameters(gcode)){
-                        calibrate_probe_bore();
+                        probing_cycle = CALIBRATE_PROBE_BORE;
                     }
                 }
                 
@@ -551,7 +603,7 @@ void ZProbe::on_gcode_received(void *argument)
                     return;
                 }
                 if (parse_parameters(gcode)){
-                    probe_bore();
+                    probing_cycle = PROBE_BORE;
                 }
                 break;
             case 462:
@@ -562,7 +614,7 @@ void ZProbe::on_gcode_received(void *argument)
                     return;
                 }
                 if (parse_parameters(gcode)){
-                    probe_boss();
+                    probing_cycle = PROBE_BOSS;
                 }
                 break;
             case 463:
@@ -573,7 +625,7 @@ void ZProbe::on_gcode_received(void *argument)
                     return;
                 }
                 if (parse_parameters(gcode)){
-                    probe_insideCorner();
+                    probing_cycle = PROBE_INSIDE_CORNER;
                 }
                 break;
             case 464:
@@ -584,24 +636,41 @@ void ZProbe::on_gcode_received(void *argument)
                     return;
                 }
                 if (parse_parameters(gcode)){
-                    probe_outsideCorner();
+                    probing_cycle = PROBE_OUTSIDE_CORNER;
                 }
                 break;
             case 465:
-                if (!gcode->has_letter('X') && !gcode->has_letter('Y')){
-                    gcode->stream->printf("ALARM: Probe fail: No Axis Set\n");
-                    THEKERNEL->call_event(ON_HALT, nullptr);
-                    THEKERNEL->set_halt_reason(PROBE_FAIL);
-                    return;
-                }
-                if (gcode->has_letter('X') && gcode->has_letter('Y')){
-                    gcode->stream->printf("ALARM: Probe fail: Axis Probing Only Supports 1 Axis Input\n");
-                    THEKERNEL->call_event(ON_HALT, nullptr);
-                    THEKERNEL->set_halt_reason(PROBE_FAIL);
-                    return;
-                }
-                if (parse_parameters(gcode)){
-                    probe_axisangle();
+                parse_parameters(gcode, true);
+                if (gcode->subcode == 1){
+                    if (!gcode->has_letter('Y') || !gcode->has_letter('H')){
+                        gcode->stream->printf("ALARM: Probe fail: No distance or height set\n");
+                        THEKERNEL->call_event(ON_HALT, nullptr);
+                        THEKERNEL->set_halt_reason(PROBE_FAIL);
+                        return;
+                    }
+                    probing_cycle = PROBE_A_AXIS;
+                }else if (gcode->subcode == 2){
+                    if (!gcode->has_letter('X') || !gcode->has_letter('Y') || !gcode->has_letter('R')){
+                        gcode->stream->printf("ALARM: Probe fail: No offset, distance or height set\n");
+                        THEKERNEL->call_event(ON_HALT, nullptr);
+                        THEKERNEL->set_halt_reason(PROBE_FAIL);
+                        return;
+                    }
+                    probing_cycle = PROBE_A_AXIS_WITH_OFFSET;
+                }else{
+                    if (!gcode->has_letter('X') && !gcode->has_letter('Y')){
+                            gcode->stream->printf("ALARM: Probe fail: No axis set\n");
+                        THEKERNEL->call_event(ON_HALT, nullptr);
+                        THEKERNEL->set_halt_reason(PROBE_FAIL);
+                        return;
+                    }
+                    if (gcode->has_letter('X') && gcode->has_letter('Y')){
+                        gcode->stream->printf("ALARM: Probe fail: Axis probing only supports 1 axis input\n");
+                        THEKERNEL->call_event(ON_HALT, nullptr);
+                        THEKERNEL->set_halt_reason(PROBE_FAIL);
+                        return;
+                    }
+                    probing_cycle = PROBE_AXIS_ANGLE;
                 }
                 break;
             case 466:
@@ -612,7 +681,7 @@ void ZProbe::on_gcode_received(void *argument)
                     return;
                 }
                 if (parse_parameters(gcode, (gcode->has_letter('Z') && !gcode->has_letter('X') && !gcode->has_letter('Y')))){
-                    single_axis_probe_double_tap();
+                    probing_cycle = PROBE_SINGLE_AXIS_DOUBLE_TAP;
                 }
                 break;
             case 670:
@@ -901,6 +970,7 @@ void ZProbe::coordinated_move(float x, float y, float z, float feedrate, bool re
     delete [] cmd;
 
     message.stream = &(StreamOutput::NullStream);
+    message.line = 0;
     THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
     THEKERNEL->conveyor->wait_for_idle();
     THEROBOT->pop_state();
@@ -1697,37 +1767,70 @@ void ZProbe::probe_outsideCorner() //M464
     }
 }
 
-void ZProbe::probe_axisangle() //M465
+void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
 {
     THECONVEYOR->wait_for_idle();
     THEKERNEL->streams->printf("Probing 2 points to find an angle\n");
 
     float mpos[3];
-    float old_mpos[3];
+    float a_axis_pos;
     bool probe_x = false;
 
-    if (param.x_axis_distance != 0) {
-        probe_x = true;
-        if (param.visualize_path_distance != 0){
-            param.visualize_path_distance = fabs(param.visualize_path_distance) * (param.x_axis_distance / fabs(param.x_axis_distance));
+    if (probe_with_offset){
+        probe_x = PublicData::get_value(atc_handler_checksum, get_machine_offsets_checksum, &machine_offset );
+        // Validate the values before using them
+        if (isnan(machine_offset.anchor1_x) || isnan(machine_offset.anchor1_y) || 
+            isnan(machine_offset.rotation_offset_x) || isnan(machine_offset.rotation_offset_y)) {
+            THEKERNEL->streams->printf("ALARM: Invalid machine offset values\n");
+            THEKERNEL->call_event(ON_HALT, nullptr);
+            THEKERNEL->set_halt_reason(PROBE_FAIL);
+            return;
         }
-        param.y_axis_distance = param.side_depth;
-    }else{
-        if (param.visualize_path_distance != 0){
-                param.visualize_path_distance = fabs(param.visualize_path_distance) * (param.y_axis_distance / fabs(param.y_axis_distance));
+        coordinated_move(NAN, NAN, machine_offset.clearance_z, param.rapid_rate / 60, false);
+        THECONVEYOR->wait_for_idle();
+
+        // Calculate target coordinates with validation
+        float target_x = machine_offset.anchor1_x + machine_offset.rotation_offset_x + param.x_axis_distance;
+        float target_y = machine_offset.anchor1_y + machine_offset.rotation_offset_y;
+
+        if (isnan(target_x) || isnan(target_y)) {
+            THEKERNEL->streams->printf("ALARM: Invalid target coordinates\n");
+            THEKERNEL->call_event(ON_HALT, nullptr);
+            THEKERNEL->set_halt_reason(PROBE_FAIL);
+            return;
         }
-        param.x_axis_distance = param.side_depth;
+        coordinated_move(target_x, target_y, NAN, param.rapid_rate / 60, false);
+        THECONVEYOR->wait_for_idle();
+        param.probe_height = 300;
     }
 
-    if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
-        THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->set_halt_reason(PROBE_FAIL);
-        return;
+    if (!probe_a_axis){
+        if (param.x_axis_distance != 0) {
+            probe_x = true;
+            if (param.visualize_path_distance != 0){
+                param.visualize_path_distance = fabs(param.visualize_path_distance) * (param.x_axis_distance / fabs(param.x_axis_distance));
+            }
+            param.y_axis_distance = param.side_depth;
+        }else{
+            if (param.visualize_path_distance != 0){
+                    param.visualize_path_distance = fabs(param.visualize_path_distance) * (param.y_axis_distance / fabs(param.y_axis_distance));
+            }
+            param.x_axis_distance = param.side_depth;
+        }
+
+        if (param.repeat < 1){
+            THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+            THEKERNEL->call_event(ON_HALT, nullptr);
+            THEKERNEL->set_halt_reason(PROBE_FAIL);
+            return;
+        }
+    }else{
+        param.rotation_angle = 0;
+        param.y_axis_distance = param.y_axis_distance / 2.0;
+        param.z_axis_distance = param.probe_height;
     }
-    
 	//slow zprobe without alarm to probe_height. Skip if probe height is 0
-	if (param.probe_height != 0){
+	if (param.probe_height != 0 && !probe_a_axis){
 		// do z probe with slow speed
         z_probe_move_with_retract(param.probe_g38_subcode, -param.probe_height, param.clearance_height, param.feed_rate);
     }
@@ -1737,12 +1840,12 @@ void ZProbe::probe_axisangle() //M465
     // always wait for idle before getting the machine pos
     THECONVEYOR->wait_for_idle();
     //save center position to use later
-    THEROBOT->get_current_machine_position(mpos);
-    memcpy(old_mpos, mpos, sizeof(mpos));
-    // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    THEROBOT->get_current_machine_position(mpos);    // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    a_axis_pos = THEROBOT->actuators[3]->get_current_position();
     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, true); // get inverse compensation transform
-    out_coords.origin_x = old_mpos[0];
-    out_coords.origin_y = old_mpos[1];
+    out_coords.origin_x = mpos[0];
+    out_coords.origin_y = mpos[1];
+    param.clearance_world_pos = mpos[2];
 
 
 	//setup repeat
@@ -1751,7 +1854,41 @@ void ZProbe::probe_axisangle() //M465
         //goto clearance height
         //coordinated_move(NAN, NAN, clearance_world_pos, rapid_rate);
 
-        if (probe_x) {
+        if (probe_a_axis){
+            // goto start point for repeated probing
+            coordinated_move(NAN, NAN, param.clearance_world_pos, param.rapid_rate );
+            coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
+
+            // probe along x axis to second position, alarm if hit
+            xy_probe_move_alarm_when_hit(POS, param.probe_g38_subcode, 0.0, param.y_rotated_y, param.feed_rate);
+            
+            fast_slow_probe_sequence(Z_AXIS, NEG);
+            if (check_last_probe_ok()){
+                out_coords.y_positive_y_out = out_coords.z_negative_z_out;
+            }else{
+                THEKERNEL->streams->printf("ALARM: Probe fail: first point not found\n");
+                THEKERNEL->call_event(ON_HALT, nullptr);
+                THEKERNEL->set_halt_reason(PROBE_FAIL);
+                return;
+            }
+            
+            xy_probe_move_alarm_when_hit(NEG, param.probe_g38_subcode, 0.0, 2 * param.y_rotated_y, param.feed_rate);
+            fast_slow_probe_sequence(Z_AXIS, NEG);
+            if (check_last_probe_ok()){
+                out_coords.y_negative_y_out = out_coords.z_negative_z_out;
+            }
+            else{
+                THEKERNEL->streams->printf("ALARM: Probe fail: second point not found\n");
+                THEKERNEL->call_event(ON_HALT, nullptr);
+                THEKERNEL->set_halt_reason(PROBE_FAIL);
+                return;
+            }
+
+            THEKERNEL->probe_outputs[2] = atan (  (out_coords.y_positive_y_out - out_coords.y_negative_y_out) 
+                                                / (2 * param.y_axis_distance)) * 180 /pi;
+            THEKERNEL->streams->printf("Angle from A Axis is: %.3f degrees or %.3f radians and is stored in radians at variable #153\n" , THEKERNEL->probe_outputs[2] , THEKERNEL->probe_outputs[2] * pi / 180 );
+
+        }else if (probe_x) {
             
             fast_slow_probe_sequence(Y_AXIS, POS);
             THECONVEYOR->wait_for_idle();
@@ -1816,6 +1953,16 @@ void ZProbe::probe_axisangle() //M465
 	}
 
     if (param.visualize_path_distance != 0) {
+        if (probe_a_axis){
+            THECONVEYOR->wait_for_idle();
+            coordinated_move(NAN, NAN, param.clearance_world_pos, param.rapid_rate );
+            coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
+            float delta[5];
+            memset(delta, 0, sizeof(delta));
+            delta[A_AXIS] = - THEKERNEL->probe_outputs[2];
+            THEROBOT->delta_move(delta, param.rapid_rate, A_AXIS + 1);
+            THECONVEYOR->wait_for_idle();
+        }else{
         //probe to second position
         if (probe_x){
             xy_probe_move_alarm_when_hit(POS, 
@@ -1833,9 +1980,14 @@ void ZProbe::probe_axisangle() //M465
         //return to center position
         THECONVEYOR->wait_for_idle();
         coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
+        }   
     }
     if (param.save_position == 1){
+        if (probe_a_axis){
+            THEROBOT->set_current_wcs_by_mpos(NAN,NAN,NAN,a_axis_pos - THEKERNEL->probe_outputs[2],NAN,NAN);
+        }else{
         THEROBOT->set_current_wcs_by_mpos(NAN,NAN,NAN,NAN,NAN,THEKERNEL->probe_outputs[2]);
+        }
     }
 }
 

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -11,6 +11,7 @@
 #include "Module.h"
 #include "Pin.h"
 #include <fastmath.h>
+#include "atchandlerpublicaccess.h"
 
 #include <vector>
 
@@ -22,6 +23,21 @@ class StepperMotor;
 class Gcode;
 class StreamOutput;
 class LevelingStrategy;
+
+// Homing States
+enum PROBING_CYCLES {
+    CALIBRATE_PROBE_BORE = 0, // M460
+    CALIBRATE_PROBE_BOSS = 1, // M460.3
+    PROBE_BORE = 10, // M461
+    PROBE_BOSS = 20, // M462
+    PROBE_INSIDE_CORNER = 30, // M463
+    PROBE_OUTSIDE_CORNER = 40, // M464
+    PROBE_AXIS_ANGLE = 50, // M465
+    PROBE_A_AXIS = 51, // M465.1
+    PROBE_A_AXIS_WITH_OFFSET = 52, // M465.2
+    PROBE_SINGLE_AXIS_DOUBLE_TAP = 60, // M466
+    NONE = 255, // Default
+};
 
 struct probe_parameters{
     float x_axis_distance;
@@ -86,6 +102,7 @@ public:
 
     void on_module_loaded();
     void on_gcode_received(void *argument);
+    void on_main_loop(void *argument);
 
     bool check_last_probe_ok();
     bool run_probe(float& mm, float feedrate, float max_dist= -1, bool reverse= false);
@@ -116,7 +133,7 @@ private:
     void probe_boss(bool calibration = false);
     void probe_insideCorner();
     void probe_outsideCorner();
-    void probe_axisangle();
+    void probe_axisangle(bool probe_a_axis = false, bool probe_with_offset = false);
     void calibrate_probe_bore();
     void calibrate_probe_boss();
     void single_axis_probe_double_tap();
@@ -140,6 +157,7 @@ private:
     char buff[100];
     probe_parameters param;
     xy_output_coordinates out_coords;
+    machine_offsets machine_offset;
 
     Pin pin;
     Pin calibrate_pin;
@@ -153,6 +171,8 @@ private:
     volatile bool calibrating;
     volatile bool probe_detected;
     volatile bool calibrate_detected;
+
+    PROBING_CYCLES probing_cycle;
 
 
     bool bfirstHitDetected  = false;

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -143,7 +143,7 @@ private:
     void on_get_public_data(void* argument);
     uint32_t probe_doubleHit(uint32_t dummy);
     void reset_probe_tracking();
-    bool is_probe_tool();
+    uint8_t check_probe_tool();
 
     float slow_feedrate;
     float fast_feedrate;
@@ -152,6 +152,7 @@ private:
     float max_z;
     bool tool_0_3axis;
     float dwell_before_probing;
+    bool is_3dprobe_active;
 
     Gcode* gcodeBuffer;
     char buff[100];

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -75,7 +75,7 @@ extern "C" uint32_t  _sbrk(int size);
 // support upload file type definition
 #define FILETYPE	"lz"		//compressed by quicklz
 // version definition
-#define VERSION "2.0.0cPR117alpha"
+#define VERSION "2.0.0cPR125alpha"
 
 // command lookup table
 const SimpleShell::ptentry_t SimpleShell::commands_table[] = {

--- a/version.txt
+++ b/version.txt
@@ -2,8 +2,12 @@ Notice:
 To let the Carvera work perfectly, please make sure both your controller software and firmware are up to date. For firmware, download the new firmware first, then use the 'update' function to upgrade the firmware, and reset the machine after the update is complete.
 
 
-[2.0.0cPR117alpha]
-- Continous Jog Mode
+[2.0.0cPR125alpha]
+- Enhancement: Continous Jog Mode
+- Enhancement: 3D probe is now always powered on the Carvera AIR
+- Enhancement: Added M465.1 and M465.2 to probe 4th axis stock
+- Bugfix: Machine crashes during probing cycles should be fixed
+
 
 [1.0.11c]
 - fixed issue with rotated WCS and arc movements


### PR DESCRIPTION
The ZProbe now listens to the ON_MAIN_LOOP event of the Kernel. This seperates the call stack of the event ON_GCODE_RECEIVED (e.g. M465) from the probing cycles.

The 3D Probe is always active now, if the tool is >= 999990 or 0 with the setting zprobe.tool_zero_is_3axis true

M465 has been extended by M465.1 and  M465.2 to probe a workpiece in the 4th axis.
M465.1 is use to start from the current position and M465.2 probes, based on the 4th axis offset logic like when starting a job