### PR TITLE
Flex compensation stays active when probing and continuous jog synchronizes better with the controller

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -208,7 +208,7 @@ alpha_max_travel							500				# Max travel in mm for alpha/X axis when homing
 alpha_fast_homing_rate_mm_s					15				# Alpha/X fast homing feedrate in mm/second
 alpha_slow_homing_rate_mm_s					3				# Alpha/X slow homing feedrate in mm/second
 alpha_limit_enable                          true            # Set to true to enable X min and max limit switches
-alpha_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for alpha/X
+alpha_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for alpha/X
 alpha_motor_alarm_pin						0.1!^				# servo motor alarm for X axis
 
 beta_min_endstop							1.1^            # Pin to read min endstop, add a ! to invert if endstop is NO connected to ground
@@ -220,7 +220,7 @@ beta_max_travel								380				# Max travel in mm for beta/Y axis when homing
 beta_fast_homing_rate_mm_s					15				# Beta/Y  fast homing feedrate in mm/second
 beta_slow_homing_rate_mm_s					3				# Beta/Y  slow homing feedrate in mm/second
 beta_limit_enable                           true            # Set to true to enable Y min and max limit switches
-beta_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for beta/Y
+beta_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for beta/Y
 beta_motor_alarm_pin						0.0!^				# servo motor alarm for Y axis
 
 #gamma_min_endstop							0.26^			# Pin to read min endstop, add a ! to invert if endstop is NO connected to ground
@@ -232,7 +232,7 @@ gamma_max_travel							150				# Max travel in mm for gamma/Z axis when homing
 gamma_fast_homing_rate_mm_s					10				# Gamma/Z fast homing feedrate in mm/second
 gamma_slow_homing_rate_mm_s					3				# Gamma/Z slow homing feedrate in mm/second
 gamma_limit_enable                          true            # Set to true to enable Z min and max limit switches
-gamma_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for gamma/Z
+gamma_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for gamma/Z
 gamma_motor_alarm_pin						3.25!^			# servo motor alarm for Z axis
 
 delta_min_endstop							0.21!^			# Pin to read min endstop, add a ! to invert if endstop is NO connected to ground

--- a/src/config2.default
+++ b/src/config2.default
@@ -228,7 +228,7 @@ alpha_max_travel							500				# Max travel in mm for alpha/X axis when homing
 alpha_fast_homing_rate_mm_s					15				# Alpha/X fast homing feedrate in mm/second
 alpha_slow_homing_rate_mm_s					3				# Alpha/X slow homing feedrate in mm/second
 alpha_limit_enable                          true            # Set to true to enable X min and max limit switches
-alpha_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for alpha/X
+alpha_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for alpha/X
 alpha_motor_alarm_pin						0.1^				# servo motor alarm for X axis
 
 beta_min_endstop							0.25^            # Pin to read min endstop, add a ! to invert if endstop is NO connected to ground
@@ -240,7 +240,7 @@ beta_max_travel								380				# Max travel in mm for beta/Y axis when homing
 beta_fast_homing_rate_mm_s					15				# Beta/Y  fast homing feedrate in mm/second
 beta_slow_homing_rate_mm_s					3				# Beta/Y  slow homing feedrate in mm/second
 beta_limit_enable                           true            # Set to true to enable Y min and max limit switches
-beta_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for beta/Y
+beta_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for beta/Y
 beta_motor_alarm_pin						0.0^				# servo motor alarm for Y axis
 
 gamma_min_endstop							1.1^			# Pin to read min endstop, add a ! to invert if endstop is NO connected to ground
@@ -252,7 +252,7 @@ gamma_max_travel							150				# Max travel in mm for gamma/Z axis when homing
 gamma_fast_homing_rate_mm_s					10				# Gamma/Z fast homing feedrate in mm/second
 gamma_slow_homing_rate_mm_s					3				# Gamma/Z slow homing feedrate in mm/second
 gamma_limit_enable                          true            # Set to true to enable Z min and max limit switches
-gamma_homing_retract_mm						1				# Distance to retract from the endstop after it is hit for gamma/Z
+gamma_homing_retract_mm						2				# Distance to retract from the endstop after it is hit for gamma/Z
 gamma_motor_alarm_pin						3.25^			# servo motor alarm for Z axis
 
 delta_min_endstop							1.9^			# Pin to read min endstop, add a ! to invert if endstop is NO connected to ground

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -190,6 +190,9 @@ class Kernel {
 
         void set_zprobing(bool f) { zprobing = f; }
         bool is_zprobing() const { return zprobing; }
+
+        void set_flex_compensation_active(bool f) { flex_compensation_active = f; }
+        bool is_flex_compensation_active() const { return flex_compensation_active; }
         
         void set_probeLaser(bool f) { probeLaserOn = f; }
         bool is_probeLaserOn() const { return probeLaserOn; }
@@ -286,6 +289,7 @@ class Kernel {
             volatile bool cachewait:1;
             bool disable_serial_console:1;
             bool halt_on_error_debug:1;
+            bool flex_compensation_active:1;
         };
         int iic_page_write(unsigned char u8PageNum, unsigned char u8len, unsigned char *pu8Array);
 

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -590,7 +590,12 @@ void CartGridStrategy::setAdjustFunction(bool on)
 }
 
 void CartGridStrategy::updateCompensationTransform()
-{
+{   
+    if(flex_compensation_active) {
+        THEKERNEL->set_flex_compensation_active(true);
+    } else {
+        THEKERNEL->set_flex_compensation_active(false);
+    }
     // Enable compensation transform if ANY compensation is active
     if(cartesian_grid_active || flex_compensation_active) {
         // set the compensationTransform in robot

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -101,4 +101,5 @@ private:
     static const ptentry_t commands_table[];
     static int reset_delay_secs;
     uint32_t keep_alive_time;
+    bool cont_mode_active;
 };

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -155,7 +155,6 @@ void WifiProvider::receive_wifi_data() {
 	        }
 			if(WifiData[i] == 'Y' - 'A' + 1) { // ^Y
 	            THEKERNEL->set_stop_request(true); // generic stop what you are doing request
-				THEKERNEL->streams->printf("^Y\n");
 	            continue;
 	        }
 			if(WifiData[i] == 'Z' - 'A' + 1) { // ^Z


### PR DESCRIPTION
Changes made:
- The continuous jog mode now sends a feedback "^Y" to the controller inform, that the continuous jog now has ended. This enables us to only send another cont jog command, when the last one has finished

-  The default homing position is now -2 on all axes. -1 Is directly on the software endstop and with the compensation or rotation enabled it might be, that you can't leave the homing position

- The flex compensation (if currently enabled) is applied on the probing outputs. That is correct, because the flex compensation fixes the machine coordinates.