### PR TITLE
Fix wifi scan crash

### DIFF
--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -958,7 +958,7 @@ void SimpleShell::wlan_command( string parameters, StreamOutput *stream)
         if (ok) {
             char *str = (char *)returned_data;
             stream->printf("%s", str);
-            free(str);
+            AHB.dealloc(str);
         	if (send_eof) {
             	stream->_putc(EOT);
         	}


### PR DESCRIPTION
Fixes #146. The memory being freed here is [allocated with AHB](https://github.com/Carvera-Community/Carvera_Community_Firmware/blob/d13d3ef6782bb11bb2ffdf3e306b43d259bc95db/src/modules/utils/wifi/WifiProvider.cpp#L688), so AHB needs to handle dealloc too. See the linked issue for details.