### PR TITLE
Support building on an arm64 host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   pr-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       checks: write
     if: github.event_name == 'pull_request'
@@ -31,7 +31,15 @@ jobs:
           GITHUB_SHA:              ${{ github.sha }}
           GITHUB_EVENT_PATH:       ${{ github.event_path }}
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-24.04
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runs-on }}
 
     outputs:
       version: ${{ steps.set-version.outputs.VERSION }}
@@ -53,9 +61,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLCHAIN_DIR }}
-          key:   ${{ runner.os }}-toolchain-gcc-${{ env.GCC_VERSION }}
+          key: ${{ runner.os }}-${{ matrix.arch}}-toolchain-gcc-${{ env.GCC_VERSION }}
           restore-keys: |
-            ${{ runner.os }}-toolchain-gcc-
+            ${{ runner.os }}-${{ matrix.arch }}-toolchain-gcc-
 
       - name: Build firmware
         run: |
@@ -66,19 +74,19 @@ jobs:
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{ steps.set-version.outputs.VERSION }}
+          name: firmware-${{ steps.set-version.outputs.VERSION }}-${{ matrix.arch }}
           path: firmware-${{ steps.set-version.outputs.VERSION }}.bin
           compression-level: 0
           
       - name: Upload debug symbols artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}
+          name: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}-${{ matrix.arch }}
           path: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}.tar.gz
           compression-level: 0
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -87,13 +95,13 @@ jobs:
       - name: Download firmware artifact
         uses: actions/download-artifact@v4
         with:
-          name: firmware-${{ needs.build.outputs.version }}
+          name: firmware-${{ needs.build.outputs.version }}-x86_64
           path: release-assets
 
       - name: Download debug symbols artifact
         uses: actions/download-artifact@v4
         with:
-          name: firmware-debug-symbols-${{ needs.build.outputs.version }}
+          name: firmware-debug-symbols-${{ needs.build.outputs.version }}-x86_64
           path: release-assets
 
       - name: Create GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: ['v*']
   pull_request:
     branches: ['master', 'Dev']
+  workflow_dispatch:
 env:
   GCC_VERSION: 14.2
 

--- a/build/gcc.sh
+++ b/build/gcc.sh
@@ -118,7 +118,7 @@ download_and_unpack() {
 
 # --- GCC Download Functions ---
 
-download_gcc_4_8_darwin() {
+download_gcc_4_8_darwin_x86_64() {
     local url="https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2"
     local hash="5d34d95a53ba545f1585b9136cbb6805"
     local hash_type="md5"
@@ -129,7 +129,7 @@ download_gcc_4_8_darwin() {
     download_and_unpack "$url" "$hash_type" "$hash" "$gcc_version_internal" "$archive_name" "$hash_tool"
 }
 
-download_gcc_4_8_linux() {
+download_gcc_4_8_linux_x86_64() {
     local url="https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-linux.tar.bz2"
     local hash="72b0d06ae16b303c25fd70b2883d3950"
     local hash_type="md5"
@@ -140,7 +140,7 @@ download_gcc_4_8_linux() {
     download_and_unpack "$url" "$hash_type" "$hash" "$gcc_version_internal" "$archive_name" "$hash_tool"
 }
 
-download_gcc_14_2_darwin() {
+download_gcc_14_2_darwin_arm64() {
     local url="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
     local hash="c7c78ffab9bebfce91d99d3c24da6bf4b81c01e16cf551eb2ff9f25b9e0a3818"
     local hash_type="sha256"
@@ -151,11 +151,22 @@ download_gcc_14_2_darwin() {
     download_and_unpack "$url" "$hash_type" "$hash" "$gcc_version_internal" "$archive_name" "$hash_tool"
 }
 
-download_gcc_14_2_linux() {
+download_gcc_14_2_linux_x86_64() {
     local url="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"
     local hash="62a63b981fe391a9cbad7ef51b17e49aeaa3e7b0d029b36ca1e9c3b2a9b78823"
     local hash_type="sha256"
     local archive_name="arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"
+    local hash_tool="sha256sum"
+    local gcc_version_internal="14-2"
+
+    download_and_unpack "$url" "$hash_type" "$hash" "$gcc_version_internal" "$archive_name" "$hash_tool"
+}
+
+download_gcc_14_2_linux_aarch64() {
+    local url="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-aarch64-arm-none-eabi.tar.xz"
+    local hash="87330bab085dd8749d4ed0ad633674b9dc48b237b61069e3b481abd364d0a684"
+    local hash_type="sha256"
+    local archive_name="arm-gnu-toolchain-14.2.rel1-aarch64-arm-none-eabi.tar.xz"
     local hash_tool="sha256sum"
     local gcc_version_internal="14-2"
 
@@ -204,12 +215,13 @@ check_gcc() {
         echo "GCC toolchain version $version_user not detected at ${display_path}." >&2
         echo "Downloading GCC $version_user..." >&2
         os=$(detect_os)
-        local download_func="download_gcc_${version/-/_}_${os}" # e.g., download_gcc_14_2_linux
+        arch=$(uname -m)
+        local download_func="download_gcc_${version/-/_}_${os}_${arch}" # e.g., download_gcc_14_2_linux_x86_64
 
         if declare -F "$download_func" > /dev/null; then
             "$download_func" # Call the appropriate download function
         else
-            echo "Error: No download function found for GCC $version_user on $os ($download_func)" >&2
+            echo "Error: No download function found for GCC $version_user on $os/$arch ($download_func)" >&2
             exit 1
         fi
 


### PR DESCRIPTION
The computer connected to my Carvera Air is a Raspberry Pi 4B with an arm64 CPU, and I ran into some trouble building firmware on it. The build scripts only needed small tweaks to support both x86_64 and arm64, so here's a PR for them.

Details:
- I updated the CI workflow to build on both types of runner. The release job still publishes the firmware built by the x86_64 runner
- I needed to use ubuntu 24.04 for the arm64 job (there's currently no `latest` tag for those runners), so I pinned the rest of them to that version too. This is generally a good practice so that you avoid surprise upgrades, but we could keep x86_64 on ubuntu-latest if that's preferred
- Both runner types are uploading artifacts because it seemed possibly useful for debugging the build, but they don't need to. I can switch back to only uploading the x86_64 artifacts if you want
- `workflow_dispatch` is useful for folks who want to test CI on their own branch but isn't strictly needed