### PR TITLE
Disable crash detection during TLO calibration operations

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1866,6 +1866,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				this->script_queue.push(buff);
 
 				atc_status = CALI;
+				// Set TLO calibration flag to disable 3D probe crash detection
+				bool tlo_calibrating = true;
+				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
 				this->fill_cali_scripts(active_tool == 0 || active_tool >= 999990, true);
 
 				THECONVEYOR->wait_for_idle();
@@ -1918,6 +1921,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				set_inner_playing(true);
 				this->clear_script_queue();
 				atc_status = CALI;
+				// Set TLO calibration flag to disable 3D probe crash detection
+				bool tlo_calibrating = true;
+				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
 				this->fill_cali_scripts(active_tool == 0 || active_tool >= 999990, true);
 
 			}
@@ -2317,6 +2323,9 @@ void ATCHandler::on_main_loop(void *argument)
             	this->clear_script_queue();
 
 				this->atc_status = NONE;
+				// Clear TLO calibration flag to re-enable 3D probe crash detection
+				bool tlo_calibrating = false;
+				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
 				set_inner_playing(false);
 				THEKERNEL->set_atc_state(ATC_NONE);
 
@@ -2352,6 +2361,9 @@ void ATCHandler::on_main_loop(void *argument)
 		}
 
         this->atc_status = NONE;
+		// Clear TLO calibration flag to re-enable 3D probe crash detection
+		bool tlo_calibrating = false;
+		PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
 
 		set_inner_playing(false);
 

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -149,9 +149,11 @@ private:
     uint32_t read_probe(uint32_t dummy);
     uint32_t read_calibrate(uint32_t dummy);
     void on_get_public_data(void* argument);
+    void on_set_public_data(void* argument);
     uint32_t probe_doubleHit(uint32_t dummy);
     void reset_probe_tracking();
     uint8_t check_probe_tool();
+    void set_tlo_calibrating(bool state);
 
     float slow_feedrate;
     float fast_feedrate;
@@ -178,6 +180,7 @@ private:
 
     volatile bool probing;
     volatile bool calibrating;
+    volatile bool tlo_calibrating;
     volatile bool probe_detected;
     volatile bool calibrate_detected;
     volatile bool probe_triggered;

--- a/src/modules/tools/zprobe/ZProbePublicAccess.h
+++ b/src/modules/tools/zprobe/ZProbePublicAccess.h
@@ -5,5 +5,6 @@
 #define zprobe_checksum    CHECKSUM("zprobe")
 #define get_zprobe_pin_states_checksum CHECKSUM("zprobe_pin_states")
 #define get_zprobe_time_checksum CHECKSUM("zprobe_time")
+#define set_tlo_calibrating_checksum CHECKSUM("set_tlo_calibrating")
 
 #endif

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,6 @@
 [Unreleased]
-- Fix: Scanning wifi scan no longer causes a machine crash
+- Fixed: Scanning wifi scan no longer causes a machine crash
+- Fixed: Probe crash detection would incorrectly trigger with stock ZProbe during TLO calibration 
 
 [v2.0.0c-RC1]
 - Enhancement: 3D Probe crash detection
@@ -19,15 +20,15 @@
 - Enhancement: Added a sag compensation for the Carvera AIR that compensates for rotational and gravitational sag of the x axis carriage
 - Enhancement: Bed Leveling can be saved to the sd card and loaded after a reboot
 - Enhancement: Margin scan, ZProbe and Bed Leveling can be done with the 3D Probe aswell
-- Bugfix: Machine crashes during probing cycles should be fixed
+- Fixed: Machine crashes during probing cycles should be fixed
 
 [1.0.11c]
 - fixed issue with rotated WCS and arc movements
 - fixed issue with probing bosses in the Y axis
 
 [1.0.10c]
-- Bugfix: Firmware crashs associated with the LED bar problem fixed
-- Bugfix: issue with changing Z heights when changing WCS offset
+- Fixed: Firmware crashs associated with the LED bar problem fixed
+- Fixed: issue with changing Z heights when changing WCS offset
 - Added more verbose output to the print eeprom data
 - Enhancement: Always visualize the outside corner after probing
 
@@ -37,7 +38,7 @@
 
 [1.0.8c_beta]
 - New firmware version format. The base makera firmware no longer is part of the community version string.
-- Bugfix: After switching to the community firmware the offsets of G54 to G59 are now properly checked for corruption
+- Fixed: After switching to the community firmware the offsets of G54 to G59 are now properly checked for corruption
 - Includes the WCS rotation support
 
 [1.0.3c1.0.7alpha1]


### PR DESCRIPTION
I've added a `tlo_calibrating` flag here so that we can specifically ignore probe crash events during TLO calibration.

The previous code worked fine for the 3D probe but would trigger false positives with the wireless probe on the C1 when combined with the zprobe.tool_zero_is_3axis true config option (tracked as #149).

The previous code wasn't suitable for catching the TLO scenario because TLO calibration uses G38.6 commands, and there can be a scenario that after the probing has completed the probe is still sufficiently depressed into the tool setter that it's triggering. Not an issue for the initial strike, but immediately afterwards causes the crash detection timer to fire while the probe is moving upwards to hit the tool setter a second time. Because there are two tool setter presses there is a period of time between them that is movement, but not probing movement thus the existing crash detection disable doesn't work.

Feel free to reject this PR if you think we should just deprecate zprobe.tool_zero_is_3axis true, but I foresee this issue re-occurring in other scenarios.