### PR TITLE
Improve dev CI workflow

### DIFF
--- a/.github/scripts/check-version-txt.sh
+++ b/.github/scripts/check-version-txt.sh
@@ -2,18 +2,25 @@
 set -euo pipefail
 
 # Simple check to make sure version.txt has some kind of edit history for the
-# current PR.
+# current PR, but only if files in the src/ directory have changed.
 
 # Extract the PR base branch name from the event payload
 BASE_REF=$(jq -r .pull_request.base.ref < "$GITHUB_EVENT_PATH")
 
 if [[ -z "$BASE_REF" ]]; then
   echo "Could not determine base ref from GITHUB_EVENT_PATH. Skipping check."
-  # Or exit 1 depending on desired behavior when ref is missing
   exit 0 
 fi
 
 DIFF_RANGE="origin/$BASE_REF...HEAD"
+
+# First check if any files in src/ directory have changed
+if ! git diff --name-only "$DIFF_RANGE" | grep -q "^src/"; then
+  echo "ℹ️  No files changed in src/ directory. Skipping version.txt check."
+  exit 0
+fi
+
+echo "ℹ️  Files changed in src/ directory. Checking version.txt update..."
 
 # List changed files compared to the base branch
 # Use three-dot diff to see changes on HEAD since diverging from origin/$BASE_REF
@@ -28,7 +35,7 @@ fi
 cat <<EOF
 ⚠️ Missing version.txt update
 
-version.txt must be updated with a brief summary of your changes.
+Since you've modified files in the src/ directory, version.txt must be updated with a brief summary of your changes.
 
 Please add a summary into version.txt before merging.
 

--- a/.github/scripts/run-checks.sh
+++ b/.github/scripts/run-checks.sh
@@ -11,6 +11,39 @@ REPO="${GITHUB_REPOSITORY#*/}"
 # Use the PR head SHA if provided (during pull_request events), otherwise use GITHUB_SHA
 HEAD_SHA="${PR_HEAD_SHA:-$GITHUB_SHA}"
 
+# Check if this is a fork PR (where we might have limited API permissions)
+IS_FORK_PR=false
+CAN_CREATE_CHECK_RUNS=true
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+  # Check if the head repo is different from the base repo
+  if command -v jq >/dev/null 2>&1 && [[ -f "${GITHUB_EVENT_PATH:-}" ]]; then
+    HEAD_REPO=$(jq -r '.pull_request.head.repo.full_name // empty' < "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    BASE_REPO=$(jq -r '.pull_request.base.repo.full_name // empty' < "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    if [[ -n "$HEAD_REPO" && -n "$BASE_REPO" && "$HEAD_REPO" != "$BASE_REPO" ]]; then
+      IS_FORK_PR=true
+      echo "ℹ️  Detected fork PR: $HEAD_REPO -> $BASE_REPO"
+      echo "ℹ️  Check runs may not be created due to limited permissions, but checks will still run locally."
+    fi
+  fi
+fi
+
+# Test if we can create check runs (for fork PRs, this will likely fail)
+if [[ "$IS_FORK_PR" == "true" ]]; then
+  # For fork PRs, test API permissions by trying to create a test check run
+  if ! gh api --method POST "/repos/$OWNER/$REPO/check-runs" \
+    -f name="permission-test" \
+    -f head_sha="$HEAD_SHA" \
+    -f status=completed \
+    -f conclusion=success \
+    -f "output[title]=Permission Test" \
+    -f "output[summary]=Testing API permissions" 2>/dev/null >/dev/null; then
+    CAN_CREATE_CHECK_RUNS=false
+    echo "ℹ️  Cannot create check runs due to fork PR permissions. Results will be logged locally only."
+  else
+    echo "ℹ️  API permissions available. Check runs will be created."
+  fi
+fi
 
 FAILED=0
 passed_checks=""
@@ -44,14 +77,21 @@ for script in "$ROOT"/check-*.sh; do
         summary="Check passed without additional details."
     fi
 
-    # Create success check run
-    gh api --method POST "/repos/$OWNER/$REPO/check-runs" \
-      -f name="$name" \
-      -f head_sha="$HEAD_SHA" \
-      -f status=completed \
-      -f conclusion="$conclusion" \
-      -f "output[title]=$title" \
-      -f "output[summary]=$summary"
+    # Create success check run (if permissions allow)
+    if [[ "$CAN_CREATE_CHECK_RUNS" == "true" ]]; then
+      if ! gh api --method POST "/repos/$OWNER/$REPO/check-runs" \
+        -f name="$name" \
+        -f head_sha="$HEAD_SHA" \
+        -f status=completed \
+        -f conclusion="$conclusion" \
+        -f "output[title]=$title" \
+        -f "output[summary]=$summary" 2>/dev/null; then
+        echo "   ⚠️  Failed to create check run (API error). Check passed locally."
+        CAN_CREATE_CHECK_RUNS=false  # Disable future attempts
+      fi
+    else
+      echo "   ℹ️  Check passed locally (check runs disabled due to permissions)."
+    fi
   else
     # Failure case
     exit_code=$?
@@ -71,19 +111,35 @@ for script in "$ROOT"/check-*.sh; do
         summary="Check failed without additional details."
     fi
 
-    # Create failure check run
-    gh api --method POST "/repos/$OWNER/$REPO/check-runs" \
-      -f name="$name" \
-      -f head_sha="$HEAD_SHA" \
-      -f status=completed \
-      -f conclusion="$conclusion" \
-      -f "output[title]=$title" \
-      -f "output[summary]=$summary"
+    # Create failure check run (if permissions allow)
+    if [[ "$CAN_CREATE_CHECK_RUNS" == "true" ]]; then
+      if ! gh api --method POST "/repos/$OWNER/$REPO/check-runs" \
+        -f name="$name" \
+        -f head_sha="$HEAD_SHA" \
+        -f status=completed \
+        -f conclusion="$conclusion" \
+        -f "output[title]=$title" \
+        -f "output[summary]=$summary" 2>/dev/null; then
+        echo "   ⚠️  Failed to create check run (API error). Check failed locally."
+        CAN_CREATE_CHECK_RUNS=false  # Disable future attempts
+      fi
+    else
+      echo "   ℹ️  Check failed locally (check runs disabled due to permissions)."
+    fi
   fi
 done
 
 # --- Generate Job Summary --- 
 summary_content="## Check Run Summary\n\n"
+
+# Add context about check run creation status
+if [[ "$IS_FORK_PR" == "true" ]]; then
+  if [[ "$CAN_CREATE_CHECK_RUNS" == "true" ]]; then
+    summary_content+="### Status ℹ️\n**Fork PR detected** - Check runs created successfully.\n\n"
+  else
+    summary_content+="### Status ℹ️\n**Fork PR detected** - Check runs could not be created due to limited permissions. Results logged locally only.\n\n"
+  fi
+fi
 
 if [[ -n "$failed_checks" ]]; then
   summary_content+="### Failed Checks 🚨\n$failed_checks\n"
@@ -106,8 +162,14 @@ printf "%b" "$summary_content" >> "$GITHUB_STEP_SUMMARY"
 # --- Exit with appropriate code ---
 if [[ $FAILED -eq 1 ]]; then
   echo "🚨 One or more checks failed."
+  if [[ "$IS_FORK_PR" == "true" && "$CAN_CREATE_CHECK_RUNS" == "false" ]]; then
+    echo "ℹ️  Results logged locally due to fork PR permissions."
+  fi
 else
   echo "🎉 All checks passed."
+  if [[ "$IS_FORK_PR" == "true" && "$CAN_CREATE_CHECK_RUNS" == "false" ]]; then
+    echo "ℹ️  Results logged locally due to fork PR permissions."
+  fi
 fi
 
 exit $FAILED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run all checks
         run: ./.github/scripts/run-checks.sh
         env:
@@ -69,6 +70,7 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set TOOLCHAIN_DIR
         run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/$GCC_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       checks: write
+      pull-requests: read
+      contents: read
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,26 +69,26 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       
       - name: Set TOOLCHAIN_DIR
-        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/14.2" >> $GITHUB_ENV
+        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/$GCC_VERSION" >> $GITHUB_ENV
       
       - name: Cache compiler toolchain
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLCHAIN_DIR }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-toolchain-gcc-14.2
+          key: ${{ runner.os }}-${{ runner.arch }}-toolchain-gcc-${{ env.GCC_VERSION }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-toolchain-gcc-
+            ${{ runner.os }}-${{ runner.arch }}-toolchain-gcc-
       
       - name: Build firmware (Linux/macOS)
         if: matrix.os != 'windows-2022'
         run: |
-          ./build/build.sh --gcc 14.2 --clean
+          ./build/build.sh --gcc ${{ env.GCC_VERSION }} --clean
       
       - name: Build firmware (Windows)
         if: matrix.os == 'windows-2022'
         shell: pwsh
         run: |
-          ./build/build.ps1 --GccVersion 14.2 --Clean
+          ./build/build.ps1 --GccVersion ${{ env.GCC_VERSION }} --Clean
       
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set TOOLCHAIN_DIR
-        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/14.2" >> $GITHUB_ENV
+        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/$GCC_VERSION" >> $GITHUB_ENV
 
       - name: Set VERSION
         id: set-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,73 @@ jobs:
           PR_HEAD_SHA:           ${{ github.event.pull_request.head.sha }}
           GITHUB_SHA:              ${{ github.sha }}
           GITHUB_EVENT_PATH:       ${{ github.event_path }}
-  build:
+      - name: Check for build directory changes
+        id: build-changes
+        uses: dorny/paths-filter@v3.0.2
+        with:
+          filters: |
+            build:
+              - 'build/**'
+  # test builds across multiple developer platforms
+  pr-build-matrix:
+    needs: [pr-checks]
+    if: needs.pr-checks.outputs.build == 'true'
     strategy:
-      fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04-arm
+          - os: ubuntu-24.04
+            arch: x86_64
+            runner: ubuntu-24.04
+          - os: ubuntu-24.04
             arch: arm64
-    runs-on: ${{ matrix.runs-on }}
+            runner: ubuntu-24.04-arm
+          - os: macos-14
+            arch: x86_64
+            runner: macos-14
+          - os: macos-14
+            arch: arm64
+            runner: macos-14
+          - os: windows-2022
+            arch: x86_64
+            runner: windows-2022
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      
+      - name: Set TOOLCHAIN_DIR
+        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/14.2" >> $GITHUB_ENV
+      
+      - name: Cache compiler toolchain
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TOOLCHAIN_DIR }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}-toolchain-gcc-14.2
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.arch }}-toolchain-gcc-
+      
+      - name: Build firmware (Linux/macOS)
+        if: matrix.os != 'windows-2022'
+        run: |
+          ./build/build.sh --gcc 14.2 --clean
+      
+      - name: Build firmware (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          ./build/build.ps1 --GccVersion 14.2 --Clean
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-pr-${{ matrix.os }}-${{ matrix.arch }}
+          path: LPC1768/main.bin
+          compression-level: 0
+  build:
+    runs-on: ubuntu-24.04-arm
 
     outputs:
       version: ${{ steps.set-version.outputs.VERSION }}
@@ -51,7 +110,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set TOOLCHAIN_DIR
-        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/$GCC_VERSION" >> $GITHUB_ENV
+        run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/14.2" >> $GITHUB_ENV
 
       - name: Set VERSION
         id: set-version
@@ -70,9 +129,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TOOLCHAIN_DIR }}
-          key: ${{ runner.os }}-${{ matrix.arch}}-toolchain-gcc-${{ env.GCC_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-toolchain-gcc-${{ env.GCC_VERSION }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-toolchain-gcc-
+            ${{ runner.os }}-${{ runner.arch }}-toolchain-gcc-
 
       - name: Build firmware
         run: |
@@ -88,19 +147,19 @@ jobs:
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && format('firmware-{0}-dev', steps.set-version.outputs.VERSION) || format('firmware-{0}-{1}', steps.set-version.outputs.VERSION, matrix.arch) }}
+          name: firmware-${{ steps.set-version.outputs.VERSION }}-${{ runner.arch }}
           path: firmware-${{ steps.set-version.outputs.VERSION }}.bin
           compression-level: 0
           
       - name: Upload debug symbols artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && format('firmware-debug-symbols-{0}-dev', steps.set-version.outputs.VERSION) || format('firmware-debug-symbols-{0}-{1}', steps.set-version.outputs.VERSION, matrix.arch) }}
+          name: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}
           path: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}.tar.gz
           compression-level: 0
   release:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -128,7 +187,6 @@ jobs:
             release-assets/firmware-debug-symbols-${{ needs.build.outputs.version }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   dev-release:
     needs: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   pr-checks:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       checks: write
     if: github.event_name == 'pull_request'
@@ -36,8 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
-            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
     outputs:
@@ -78,7 +78,8 @@ jobs:
         run: |
           ./build/build.sh --gcc ${{ env.GCC_VERSION }} --clean VERSION=${{ steps.set-version.outputs.VERSION }}
           if [[ "${{ steps.set-version.outputs.IS_DEV_BUILD }}" == "true" ]]; then
-            cp LPC1768/main.bin firmware.bin
+            cp LPC1768/main.bin firmware-${{ steps.set-version.outputs.VERSION }}.bin
+            tar czf firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}.tar.gz LPC1768/main.elf LPC1768/main.map
           else
             cp LPC1768/main.bin firmware-${{ steps.set-version.outputs.VERSION }}.bin      
             tar czf firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}.tar.gz LPC1768/main.elf LPC1768/main.map
@@ -87,15 +88,14 @@ jobs:
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && 'firmware-dev' || format('firmware-{0}-{1}', steps.set-version.outputs.VERSION, matrix.arch) }}
-          path: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && 'firmware.bin' || format('firmware-{0}.bin', steps.set-version.outputs.VERSION) }}
+          name: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && format('firmware-{0}-dev', steps.set-version.outputs.VERSION) || format('firmware-{0}-{1}', steps.set-version.outputs.VERSION, matrix.arch) }}
+          path: firmware-${{ steps.set-version.outputs.VERSION }}.bin
           compression-level: 0
           
       - name: Upload debug symbols artifacts
-        if: steps.set-version.outputs.IS_DEV_BUILD == 'false'
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}-${{ matrix.arch }}
+          name: ${{ steps.set-version.outputs.IS_DEV_BUILD == 'true' && format('firmware-debug-symbols-{0}-dev', steps.set-version.outputs.VERSION) || format('firmware-debug-symbols-{0}-{1}', steps.set-version.outputs.VERSION, matrix.arch) }}
           path: firmware-debug-symbols-${{ steps.set-version.outputs.VERSION }}.tar.gz
           compression-level: 0
   release:
@@ -109,13 +109,13 @@ jobs:
       - name: Download firmware artifact
         uses: actions/download-artifact@v4
         with:
-          name: firmware-${{ needs.build.outputs.version }}-x86_64
+          name: firmware-${{ needs.build.outputs.version }}-arm64
           path: release-assets
 
       - name: Download debug symbols artifact
         uses: actions/download-artifact@v4
         with:
-          name: firmware-debug-symbols-${{ needs.build.outputs.version }}-x86_64
+          name: firmware-debug-symbols-${{ needs.build.outputs.version }}-arm64
           path: release-assets
 
       - name: Create GitHub Release
@@ -154,7 +154,13 @@ jobs:
       - name: Download firmware artifacts
         uses: actions/download-artifact@v4
         with:
-          name: firmware-dev
+          name: firmware-${{ needs.build.outputs.version }}-dev
+          path: release-assets
+
+      - name: Download debug symbols artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-debug-symbols-${{ needs.build.outputs.version }}-dev
           path: release-assets
 
       - name: Generate dev release notes
@@ -172,6 +178,7 @@ jobs:
           body_path: dev-CHANGELOG.md
           prerelease: true
           files: |
-            release-assets/firmware.bin
+            release-assets/firmware-${{ needs.build.outputs.version }}.bin
+            release-assets/firmware-debug-symbols-${{ needs.build.outputs.version }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run all checks
         run: ./.github/scripts/run-checks.sh
         env:
@@ -66,7 +67,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Set TOOLCHAIN_DIR
         run: echo "TOOLCHAIN_DIR=$GITHUB_WORKSPACE/toolchain/$GCC_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
1. Uploads the dev release artifact with a version string in the name
2. Adds the debug symbol artifacts to dev release
3. Use the `ubuntu-24.04-arm` for builds, it's quicker and cheaper if we ever run out of free credits
4. Adds a conditional workflow to the PR-Checks workflow which runs builds across multiple developer platforms if any files in the `build/` directory have changed
5. Revise the run-check.sh so that it gracefully degrades if the PR originated from a fork, and doesn't have API access to our repo
6. Make check-version-txt.sh only apply if files in the src/ directory have changed since version.txt is only user facing.