### PR TITLE
Configurable Tool Setter Position and one-off calibration offset

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -390,6 +390,13 @@ coordinate.toolrack_offset_x 356		# Tool 6 X Offset relative to anchor1
 coordinate.toolrack_offset_y 0.0		# Tool 6 Y Offset relative to anchor1
 coordinate.toolrack_z -112.5			# ATC Z axis machine coordinates
 
+# Tool setter (probe) position in absolute Machine Coordinate System
+# If not set, uses hardcoded values: X=-4.158, Y=-42.568, Z=-157.0 for CARVERA
+# Set these values to configure a custom probe position, leave unset to use defaults
+#coordinate.probe_mcs_x -4.158		# Tool setter X position in MCS (mm)
+#coordinate.probe_mcs_y -42.568		# Tool setter Y position in MCS (mm)  
+#coordinate.probe_mcs_z -157.0		# Tool setter Z position in MCS (mm)
+
 coordinate.rotation_offset_x 3.5		# Rotation module X Offset relative to anchor1
 coordinate.rotation_offset_y 37.5		# Rotation module Y Offset relative to anchor1
 coordinate.rotation_offset_z 23		    # Rotation module Z Offset relative to chuck center

--- a/src/config2.default
+++ b/src/config2.default
@@ -413,6 +413,13 @@ coordinate.toolrack_offset_x 126		# Tool 6 X Offset relative to anchor1
 coordinate.toolrack_offset_y 196		# Tool 6 Y Offset relative to anchor1
 coordinate.toolrack_z -108				# ATC Z axis machine coordinates
 
+# Tool setter (probe) position in absolute Machine Coordinate System
+# If not set, uses hardcoded values: X=-165.0, Y=173.0, Z=-148.0 for CARVERA_AIR
+# Set these values to configure a custom probe position, leave unset to use defaults
+#coordinate.probe_mcs_x -165.0		# Tool setter X position in MCS (mm)
+#coordinate.probe_mcs_y 173.0		# Tool setter Y position in MCS (mm)
+#coordinate.probe_mcs_z -148.0		# Tool setter Z position in MCS (mm)
+
 coordinate.rotation_offset_x 41.5		# Rotation module X Offset relative to anchor1
 coordinate.rotation_offset_y 82.5		# Rotation module Y Offset relative to anchor1
 coordinate.rotation_offset_z 23.0		# Rotation module Z Offset relative to chuck center

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -89,6 +89,9 @@
 #define clearance_y_checksum		CHECKSUM("clearance_y")
 #define clearance_z_checksum		CHECKSUM("clearance_z")
 #define skip_path_origin_checksum	CHECKSUM("skip_path_origin")
+#define probe_mcs_x_checksum		CHECKSUM("probe_mcs_x")
+#define probe_mcs_y_checksum		CHECKSUM("probe_mcs_y")
+#define probe_mcs_z_checksum		CHECKSUM("probe_mcs_z")
 
 ATCHandler::ATCHandler()
 {
@@ -119,6 +122,12 @@ ATCHandler::ATCHandler()
     position_y = 8888;
     position_a = 88888888;
     position_b = 88888888;
+    
+    // Initialize one-off probe offsets
+    probe_oneoff_x = 0.0;
+    probe_oneoff_y = 0.0;
+    probe_oneoff_z = 0.0;
+    probe_oneoff_configured = false;
 }
 
 void ATCHandler::clear_script_queue(){
@@ -783,28 +792,40 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z) {
 	// move x and y to calibrate position
     if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
     {
-		snprintf(buff, sizeof(buff), "G53 G0 X%.3f Y%.3f", THEROBOT->from_millimeters(probe_mx_mm), THEROBOT->from_millimeters(probe_my_mm));
+		// Use one-off offsets if configured, otherwise use standard probe position
+		float probe_x = probe_mx_mm + (this->probe_oneoff_configured ? this->probe_oneoff_x : 0.0);
+		float probe_y = probe_my_mm + (this->probe_oneoff_configured ? this->probe_oneoff_y : 0.0);
+		snprintf(buff, sizeof(buff), "G53 G0 X%.3f Y%.3f", THEROBOT->from_millimeters(probe_x), THEROBOT->from_millimeters(probe_y));
 	}
 	else	//Manual Tool Change
 	{
-		snprintf(buff, sizeof(buff), "G53 G0 X%.3f Y%.3f", THEROBOT->from_millimeters(anchor1_x + 280), THEROBOT->from_millimeters(anchor1_y + 196));
+		// Use one-off offsets if configured, otherwise use standard manual position
+		float probe_x = anchor1_x + 280 + (this->probe_oneoff_configured ? this->probe_oneoff_x : 0.0);
+		float probe_y = anchor1_y + 196 + (this->probe_oneoff_configured ? this->probe_oneoff_y : 0.0);
+		snprintf(buff, sizeof(buff), "G53 G0 X%.3f Y%.3f", THEROBOT->from_millimeters(probe_x), THEROBOT->from_millimeters(probe_y));
 	}
 	this->script_queue.push(buff);
 	// do calibrate with fast speed
     if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
     {
-		snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", probe_mz_mm, probe_fast_rate);
+		// Use one-off Z offset if configured, otherwise use standard probe Z position
+		float probe_z = probe_mz_mm + (this->probe_oneoff_configured ? this->probe_oneoff_z : 0.0);
+		snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", probe_z, probe_fast_rate);
 	}
 	else	//Manual Tool Change
 	{
-		snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", toolrack_z, probe_fast_rate);
+		// Use one-off Z offset if configured, otherwise use toolrack Z position
+		float probe_z = toolrack_z + (this->probe_oneoff_configured ? this->probe_oneoff_z : 0.0);
+		snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", probe_z, probe_fast_rate);
 	}
 	this->script_queue.push(buff);
 	// lift a bit
 	snprintf(buff, sizeof(buff), "G91 G0 Z%.3f", THEROBOT->from_millimeters(probe_retract_mm));
 	this->script_queue.push(buff);
 	// do calibrate with slow speed
-	snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", -1 - probe_retract_mm, probe_slow_rate);
+	// Use one-off Z offset if configured, otherwise use standard offset
+	float slow_probe_z = -1 - probe_retract_mm + (this->probe_oneoff_configured ? this->probe_oneoff_z : 0.0);
+	snprintf(buff, sizeof(buff), "G38.6 Z%.3f F%.3f", slow_probe_z, probe_slow_rate);
 	this->script_queue.push(buff);
 	// save new tool offset
 	this->script_queue.push("M493.1");
@@ -1180,9 +1201,16 @@ void ATCHandler::on_config_reload(void *argument)
 			tool.mz_mm = this->toolrack_z - 4.5;
 			atc_tools.push_back(tool);
 		}
-		probe_mx_mm = this->anchor1_x + this->toolrack_offset_x;
-		probe_my_mm = this->anchor1_y + this->toolrack_offset_y -5 + 197;
-		probe_mz_mm = this->toolrack_z - 44.5;
+		// Calculate probe position - use configured absolute MCS coordinates if available, otherwise use hardcoded values
+		if (this->probe_position_configured) {
+			probe_mx_mm = isnan(this->probe_mcs_x) ? (this->anchor1_x + this->toolrack_offset_x) : this->probe_mcs_x;
+			probe_my_mm = isnan(this->probe_mcs_y) ? (this->anchor1_y + this->toolrack_offset_y -5 + 197) : this->probe_mcs_y;
+			probe_mz_mm = isnan(this->probe_mcs_z) ? (this->toolrack_z - 44.5) : this->probe_mcs_z;
+		} else {
+			probe_mx_mm = this->anchor1_x + this->toolrack_offset_x;
+			probe_my_mm = this->anchor1_y + this->toolrack_offset_y -5 + 197;
+			probe_mz_mm = this->toolrack_z - 44.5;
+		}
 	}
 	else
 	{
@@ -1196,9 +1224,16 @@ void ATCHandler::on_config_reload(void *argument)
 			tool.mz_mm = this->toolrack_z;
 			atc_tools.push_back(tool);
 		}
-		probe_mx_mm = this->anchor1_x + this->toolrack_offset_x;
-		probe_my_mm = this->anchor1_y + this->toolrack_offset_y + 180;
-		probe_mz_mm = this->toolrack_z - 40;
+		// Calculate probe position - use configured absolute MCS coordinates if available, otherwise use hardcoded values
+		if (this->probe_position_configured) {
+			probe_mx_mm = isnan(this->probe_mcs_x) ? (this->anchor1_x + this->toolrack_offset_x) : this->probe_mcs_x;
+			probe_my_mm = isnan(this->probe_mcs_y) ? (this->anchor1_y + this->toolrack_offset_y + 180) : this->probe_mcs_y;
+			probe_mz_mm = isnan(this->probe_mcs_z) ? (this->toolrack_z - 40) : this->probe_mcs_z;
+		} else {
+			probe_mx_mm = this->anchor1_x + this->toolrack_offset_x;
+			probe_my_mm = this->anchor1_y + this->toolrack_offset_y + 180;
+			probe_mz_mm = this->toolrack_z - 40;
+		}
 	}
 	
 	if(CARVERA == THEKERNEL->factory_set->MachineModel)
@@ -1224,6 +1259,14 @@ void ATCHandler::on_config_reload(void *argument)
 	this->rotation_width = THEKERNEL->config->value(coordinate_checksum, rotation_width_checksum)->by_default(45  )->as_number();
 
 	this->skip_path_origin = THEKERNEL->config->value(atc_checksum, skip_path_origin_checksum)->by_default(false)->as_bool();
+
+	// Load configurable probe position (absolute MCS coordinates)
+	this->probe_mcs_x = THEKERNEL->config->value(coordinate_checksum, probe_mcs_x_checksum)->by_default(NAN)->as_number();
+	this->probe_mcs_y = THEKERNEL->config->value(coordinate_checksum, probe_mcs_y_checksum)->by_default(NAN)->as_number();
+	this->probe_mcs_z = THEKERNEL->config->value(coordinate_checksum, probe_mcs_z_checksum)->by_default(NAN)->as_number();
+	
+	// Check if probe position is configured (at least one coordinate is set)
+	this->probe_position_configured = !isnan(this->probe_mcs_x) || !isnan(this->probe_mcs_y) || !isnan(this->probe_mcs_z);
 }
 
 void ATCHandler::on_halt(void* argument)
@@ -1939,6 +1982,28 @@ void ATCHandler::on_gcode_received(void *argument)
 			}
 		} else if (gcode->m == 493) {
 			if (gcode->subcode == 0 || gcode->subcode == 1) {
+				// Handle one-off probe position offsets for M493.1
+				if (gcode->has_letter('X')) {
+					this->probe_oneoff_x = gcode->get_value('X');
+					this->probe_oneoff_configured = true;
+				}
+				if (gcode->has_letter('Y')) {
+					this->probe_oneoff_y = gcode->get_value('Y');
+					this->probe_oneoff_configured = true;
+				}
+				if (gcode->has_letter('Z')) {
+					this->probe_oneoff_z = gcode->get_value('Z');
+					this->probe_oneoff_configured = true;
+				}
+				
+				// Clear one-off offsets if no parameters provided
+				if (!gcode->has_letter('X') && !gcode->has_letter('Y') && !gcode->has_letter('Z')) {
+					this->probe_oneoff_x = 0.0;
+					this->probe_oneoff_y = 0.0;
+					this->probe_oneoff_z = 0.0;
+					this->probe_oneoff_configured = false;
+				}
+				
 				if (this->active_tool == 0 || this->active_tool >= 999990){
 					THEROBOT->set_probe_tool_not_calibrated(false);
 				}
@@ -1958,6 +2023,12 @@ void ATCHandler::on_gcode_received(void *argument)
 		        	    THEKERNEL->eeprom_data->TOOL = this->active_tool;
 		        	    THEKERNEL->write_eeprom_data();
 		    		}
+		    		
+		    		// Clear one-off probe offsets when changing tools
+		    		this->probe_oneoff_x = 0.0;
+		    		this->probe_oneoff_y = 0.0;
+		    		this->probe_oneoff_z = 0.0;
+		    		this->probe_oneoff_configured = false;
 
 				} else {
 					THEKERNEL->set_halt_reason(ATC_NO_TOOL);
@@ -1995,6 +2066,16 @@ void ATCHandler::on_gcode_received(void *argument)
 				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
 			} else if (gcode->subcode == 4) { //report current TLO
 				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
+				if (this->probe_oneoff_configured) {
+					THEKERNEL->streams->printf("one-off tool setter position offsets: X[%.3f] Y[%.3f] Z[%.3f]\n", this->probe_oneoff_x, this->probe_oneoff_y, this->probe_oneoff_z);
+				} else {
+					THEKERNEL->streams->printf("no one-off tool setter position offsets configured\n");
+				}
+				if (this->probe_position_configured) {
+					THEKERNEL->streams->printf("Tool setter position (MCS): X[%.3f] Y[%.3f] Z[%.3f]\n", this->probe_mcs_x, this->probe_mcs_y, this->probe_mcs_z);
+				} else {
+					THEKERNEL->streams->printf("using default Tool setter position: X[%.3f] Y[%.3f] Z[%.3f]\n", probe_mx_mm, probe_my_mm, probe_mz_mm);
+				}
 			}
 		} else if (gcode->m == 494) {
 			if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
@@ -2230,7 +2311,7 @@ void ATCHandler::on_gcode_received(void *argument)
 			}
 			else if (gcode->subcode == 2) 
 			{
-				THEKERNEL->streams->printf("probe -- mx:%1.1f my:%1.1f mz:%1.1f\n", probe_mx_mm, probe_my_mm, probe_mz_mm);
+				THEKERNEL->streams->printf("probe (MCS) -- X:%1.1f Y:%1.1f Z:%1.1f\n", probe_mx_mm, probe_my_mm, probe_mz_mm);
 				for (int i = 0; i <=  tool_number; i ++) {
 					THEKERNEL->streams->printf("tool%d -- mx:%1.1f my:%1.1f mz:%1.1f\n", atc_tools[i].num, atc_tools[i].mx_mm, atc_tools[i].my_mm, atc_tools[i].mz_mm);
 				}

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -172,6 +172,18 @@ private:
     float probe_retract_mm;
     float probe_height_mm;
 
+    // Configurable probe position (absolute Machine Coordinate System)
+    float probe_mcs_x;
+    float probe_mcs_y;
+    float probe_mcs_z;
+    bool probe_position_configured;
+
+    // One-off probe position offsets for M493.1 (temporary offsets for specific tools)
+    float probe_oneoff_x;
+    float probe_oneoff_y;
+    float probe_oneoff_z;
+    bool probe_oneoff_configured;
+
     float last_pos[3];
 
     float anchor1_x;

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,8 @@
 [unreleased]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.
+- Enhancement: Tool setter sensor location can now be configured seperately. Use config items coordinate.probe_mcs_x coordinate.probe_mcs_y and coordinate.probe_mcs_z. If unset, the original hardcoded values will be used.
+- Enhancement: Tool TLO calibration MCode M493.1 can now be offset with parameters X/Y/Z. This enables probing of tools with off-center cutting points.
+- Enhancement: M493.4 now shows details about the current tool setter position config
 
 [v2.0.0c-RC2]
 - Fixed: Scanning wifi scan no longer causes a machine crash


### PR DESCRIPTION
Tool setter sensor location can now be configured seperately. Use config items coordinate.probe_mcs_x coordinate.probe_mcs_y and coordinate.probe_mcs_z. If unset, the original hardcoded values will be used.


Tool TLO calibration MCode M493.1 can now be offset with parameters X/Y/Z. This enables probing of tools with off-center cutting points.


M493.4 now shows details about the current tool setter position config
<img width="993" height="136" alt="image" src="https://github.com/user-attachments/assets/c8463d0b-6a3f-4b04-a055-16d05ce564d0" />


