### PR TITLE
Improve parameter handling in utils.cpp to support quoted strings

### DIFF
--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -119,8 +119,61 @@ string remove_non_number( string str )
 }
 
 // Get the first parameter, and remove it from the original string
+// Handles quoted strings properly to support file paths with spaces
 string shift_parameter( string &parameters )
 {
+    // Skip leading whitespace
+    size_t start = parameters.find_first_not_of(" \t");
+    if (start == string::npos) {
+        parameters = "";
+        return "";
+    }
+    
+    // Check if the parameter starts with a quote
+    if (parameters[start] == '"' || parameters[start] == '\'') {
+        char quote_char = parameters[start];
+        size_t end = start + 1;
+        
+        // Find the closing quote
+        while (end < parameters.length() && parameters[end] != quote_char) {
+            end++;
+        }
+        
+        if (end < parameters.length()) {
+            // Found closing quote
+            string result = parameters.substr(start + 1, end - start - 1);
+            parameters = parameters.substr(end + 1);
+            
+            // Skip whitespace after the parameter
+            size_t next_start = parameters.find_first_not_of(" \t");
+            if (next_start != string::npos) {
+                parameters = parameters.substr(next_start);
+            } else {
+                parameters = "";
+            }
+            
+            // Decode special characters
+            for (int i = 0; i < result.length(); i ++) {
+            	if (result[i] == 0x01) {
+            		result[i] = ' ';
+            	} else if (result[i] == 0x02) {
+            		result[i] = '?';
+            	} else if (result[i] == 0x03) {
+            		result[i] = '*';
+            	} else if (result[i] == 0x04) {
+            		result[i] = '!';
+            	} else if (result[i] == 0x05) {
+            		result[i] = '~';
+            	}
+            }
+            
+            return result;
+        } else {
+            // No closing quote found - treat as unquoted
+        }
+    }
+    
+    // Handle unquoted parameter (original logic)
     size_t beginning = parameters.find_first_of(" ");
     if ( beginning == string::npos ) {
         string temp = parameters;

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -965,7 +965,9 @@ void Player::on_set_public_data(void *argument)
     } else if (pdr->second_element_is(restart_job_checksum)) {
     	if (!this->last_filename.empty()) {
     		THEKERNEL->streams->printf("Job restarted: %s.\r\n", this->last_filename.c_str());
-        	this->play_command(this->last_filename, &(StreamOutput::NullStream));
+    		// Quote the filename to handle spaces properly
+    		string quoted_filename = "\"" + this->last_filename + "\"";
+        	this->play_command(quoted_filename, &(StreamOutput::NullStream));
     	}
     }
 }


### PR DESCRIPTION
Resolves #65 

The shift_parameter function was splitting strings at the first space, which broke file paths containing spaces. I've done the following:
1. Improved shift_parameter function - Now properly handles quoted strings by detecting opening quotes and finding the corresponding closing quotes
2. Added filename quoting - The restart job logic now wraps filenames in quotes before passing them to play_command