### PR TITLE
M469.4  probing 5mm back

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -380,7 +380,8 @@ void ATCHandler::calibrate_a_axis_headstock(Gcode *gcode)//M469.4
 	this->script_queue.push(buff);
 
 	//move to probe position
-	snprintf(buff, sizeof(buff), "G91 G53 G0 X%.3f", this->anchor1_x + this->rotation_offset_x);
+	// rotation_offset_x is where the 4th axis head finishes and the chuck starts. Probing 5mm back from this to ensure it touches the 4th axis module body
+	snprintf(buff, sizeof(buff), "G91 G53 G0 X%.3f", this->anchor1_x + this->rotation_offset_x - 5); 
 	this->script_queue.push(buff);
 	snprintf(buff, sizeof(buff), "G91 G53 G0 Y%.3f", this->anchor1_y + this->rotation_offset_y);
 	this->script_queue.push(buff);

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,6 @@
 [unreleased]
 - Fixed: When probing an angle with the L parameter > 1, it shows the results of each run instead of the average
+- Fixed: M469.4 was probing where the 4th axis module ends and the chuck starts, now it probes 5mm back in X to ensure the 4th axis module body is probed.
 
 [v2.0.0c-RC2]
 - Fixed: Scanning wifi scan no longer causes a machine crash


### PR DESCRIPTION
M469.4 was probing where the 4th axis module ends and the chuck starts, now it probes 5mm back in X to ensure the 4th axis module body is probed.

Probing 10mm is actually off the bed on the original Carvera, and triggers soft limits but 5mm was fine for me.

Resolves #174 