### PR TITLE
Use a default version string when a git branch isn't checked out

### DIFF
--- a/src/generate-version.bat
+++ b/src/generate-version.bat
@@ -1,6 +1,6 @@
 @for /f "delims=" %%a in ('git symbolic-ref HEAD') do @set myvar=%%a
 @for /f "delims=" %%b in ('git log "--pretty=format:%%h" -1') do @set myvar2=%%b
+@if not defined myvar set myvar=refs/heads/2.0.0c
 @REM the 11 is derived from generate-version.sh "cut -b 12" by subtracting 1 
 @echo %myvar:~11%-%myvar2%
 @copy /b  version.cpp+,, >NUL:
-

--- a/src/generate-version.sh
+++ b/src/generate-version.sh
@@ -1,2 +1,7 @@
-echo `git symbolic-ref HEAD 2> /dev/null | cut -b 12-`-`git rev-parse --short=7 HEAD`
+current_branch=`git symbolic-ref HEAD 2> /dev/null | cut -b 12-`
+current_commit=`git rev-parse --short=7 HEAD`
+if [ -z "$current_branch" ]; then
+  current_branch="2.0.0c"
+fi
+echo "$current_branch-$current_commit"
 touch version.cpp


### PR DESCRIPTION
I ran the build to test #175 and noticed a bunch of features in the Controller were disabled, including the Probing button that I needed. Because of the way I checked out the PR changes with git, I was on a commit rather than a branch. This broke the version handling in `generate-version.sh`, which pulls the branch name from `git symbolic-ref` and assumes that you're on a branch. The resulting version string was `-e1a45fe`, which the controller interpreted as a non-community build.

I could have avoided this by passing `VERSION=2.0.0c` to the build, but it would be nice if it defaulted to a community-coded string.

This PR tweaks the `generate-version.*` scripts to do that. If we can't get a branch name from git, then we'll use `2.0.0c` as the branch name.