### PR TITLE
Custom tool slot support

### DIFF
--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -116,8 +116,6 @@ private:
     void calibrate_set_value(Gcode *gcode);
 
     void clear_script_queue();
-    void load_custom_tool_slots();
-    bool is_custom_tool_defined(int tool_num);
 
     void rapid_move(bool mc, float x, float y, float z, float a, float b);
     void beep_complete();
@@ -221,9 +219,9 @@ private:
         float x_mm;
         float y_mm; 
         float z_mm;
-        bool enabled;
+        bool valid;
         
-        ToolSlot() : tool_number(0), x_mm(0), y_mm(0), z_mm(0), enabled(false) {}
+        ToolSlot() : tool_number(0), x_mm(0), y_mm(0), z_mm(0), valid(false) {}
     };
 
     vector<struct atc_tool> atc_tools;
@@ -245,6 +243,10 @@ private:
     float tool_offset;
     int beep_state;
     int beep_count;
+
+    // Custom tool slots functions
+    void load_custom_tool_slots();
+    bool is_custom_tool_defined(int tool_num);
 
 };
 

--- a/version.txt
+++ b/version.txt
@@ -3,7 +3,7 @@
 - Enhancement: Tool setter sensor location can now be configured separately. Use config items coordinate.probe_mcs_x coordinate.probe_mcs_y and coordinate.probe_mcs_z. If unset, the original hardcoded values will be used.
 - Enhancement: Tool TLO calibration MCode M491.1 can now be offset with parameters X/Y/Z. This enables probing of tools with off-centre cutting points.
 - Enhancement: M493.4 now shows details about the current tool setter position config
-- Enhancement: Added capability to configure custom tool slots up to 99. If any tool_slots are defined the machine defaults are ignored. The X/Y/Z MCS centre position is defined per tool. Use tool_slots.T.x, tool_slots.T.y, tool_slots.T.z, tool_slots.T.enable for config, where T is the slot number. Eg for slot 1 `config-set sd tool_slots.1.x -11.450`
+- Enhancement: Added capability to configure custom tool slots up to 99. If any tool_slots are defined the machine defaults are ignored. The X/Y/Z MCS centre position is defined per tool. Use tool_slots.T.x, tool_slots.T.y, tool_slots.T.z for config, where T is the slot number. Eg for slot 1 `config-set sd tool_slots.1.x -11.450`
 - Enhancement: Added M889 to show current tool slot configuration. If no custom tool slots are defined it shows the current stock tool slot config. This is useful for converting the stock slots to custom ones.
 - Fixed: When probing an angle with the L parameter > 1, it shows the results of each run instead of the average
 - Fixed: M469.4 was probing where the 4th axis module ends and the chuck starts, now it probes 5mm back in X to ensure the 4th axis module body is probed.


### PR DESCRIPTION
This PR adds the following new functionality:

1. Capability to configure custom tool slots up to 99. If any tool_slots are defined the machine defaults are ignored. The X/Y/Z MCS centre position is defined per tool. Each tool has it's own config hierarchy, where T is the slot number:
    * tool_slots.T.x
    * tool_slots.T.y
    * tool_slots.T.z

Eg for slot 1 `config-set sd tool_slots.1.x -11.450`

2. Added `M889` to show current tool slot configuration. If no custom tool slots are defined it shows the current stock tool slot config. This is useful for converting the stock slots to custom ones.

Eg. Output when using the machine default slot config (based on anchor 1)
```
Default Tool Slots Configuration:
Tool 0: X=-4.965 Y=-24.480 Z=-114.400
Tool 1: X=-4.965 Y=-84.480 Z=-114.400
Tool 2: X=-4.965 Y=-114.480 Z=-114.400
Tool 3: X=-4.965 Y=-144.480 Z=-114.400
Tool 4: X=-4.965 Y=-174.480 Z=-114.400
Tool 5: X=-4.965 Y=-204.480 Z=-114.400
Tool 6: X=-4.965 Y=-234.480 Z=-114.400
```

Output when using custom slots:
```
Custom Tool Slots Configuration:
Tool 1: X=-11.450 Y=-21.525 Z=-117.000
Tool 2: X=-3.500 Y=-33.517 Z=-117.000
Tool 3: X=-11.330 Y=-45.550 Z=-117.000
Tool 4: X=-3.525 Y=-61.640 Z=-117.000
```