### PR TITLE
Make G20 halt the machine

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -769,7 +769,14 @@ void Robot::on_gcode_received(void *argument)
             case 17: this->select_plane(X_AXIS, Y_AXIS, Z_AXIS);   break;
             case 18: this->select_plane(X_AXIS, Z_AXIS, Y_AXIS);   break;
             case 19: this->select_plane(Y_AXIS, Z_AXIS, X_AXIS);   break;
-            case 20: this->inch_mode = true;   break;
+            // Inch mode is broken see https://github.com/Carvera-Community/Carvera_Community_Firmware/issues/209
+            // case 20: this->inch_mode = true;   break;
+            case 20: {
+                THEKERNEL->streams->printf("ALARM: Imperial Units are unsupported\n");
+                THEKERNEL->call_event(ON_HALT, nullptr);
+                THEKERNEL->set_halt_reason(MANUAL);
+                return;
+            }
             case 21: this->inch_mode = false;   break;
 
             case 54: case 55: case 56: case 57: case 58: case 59:

--- a/version.txt
+++ b/version.txt
@@ -11,6 +11,7 @@
 - Enhancement: If flex compensation file is missing and autoload is active, new error informs user
 - Fix: Active measurement of flex compensation will be aborted if the machine goes to a halt
 - Fix: Restored the stock Makera probing laser behaviour if tool 0 is NOT the 3d probe
+- Change: Inch Mode (G20) now raises a machine halt. This is because there are outstanding bugs preventing it's use.
 
 [v2.0.0c]
 - Enhancement: The side depth parameter takes the probe tip diameter into account to precisely specify where the probe should make contact instead of where the end of the stylus will be


### PR DESCRIPTION
Per #209 Inch mode is not safe to use. This PR makes it halt the machine.

I'll make the cosponsoring error text enhancement to the Controller once this is merged 