### PR TITLE
Add lead screw pitch error compensation

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -281,10 +281,7 @@ leveling-strategy.rectangular-grid.flex_grid_x_size    				30
 leveling-strategy.rectangular-grid.flex_compensation_always_active 	false
 
 # Pitch compensation
-pitch_compensation.enable					false			# Enable screw pitch compensation
-#pitch_compensation.points.x_axis
-#pitch_compensation.points.y_axis
-#pitch_compensation.points.z_axis
+pitch_compensation.enable					false			# Enable screw pitch compensation on boot
 
 ## Network settings
 #network.enable								false			# Enable the ethernet network services

--- a/src/config.default
+++ b/src/config.default
@@ -280,6 +280,12 @@ leveling-strategy.rectangular-grid.only_by_two_corners		true
 leveling-strategy.rectangular-grid.flex_grid_x_size    				30
 leveling-strategy.rectangular-grid.flex_compensation_always_active 	false
 
+# Pitch compensation
+pitch_compensation.enable					false			# Enable screw pitch compensation
+#pitch_compensation.points.x_axis
+#pitch_compensation.points.y_axis
+#pitch_compensation.points.z_axis
+
 ## Network settings
 #network.enable								false			# Enable the ethernet network services
 #network.webserver.enable					true			# Enable the webserver

--- a/src/config2.default
+++ b/src/config2.default
@@ -302,6 +302,11 @@ leveling-strategy.rectangular-grid.only_by_two_corners		true
 leveling-strategy.rectangular-grid.flex_x_points					30
 leveling-strategy.rectangular-grid.flex_compensation_always_active 	false
 
+# Pitch compensation
+pitch_compensation.enable					false			# Enable screw pitch compensation
+#pitch_compensation.points.x_axis
+#pitch_compensation.points.y_axis
+#pitch_compensation.points.z_axis
 
 ## Network settings
 #network.enable								false			# Enable the ethernet network services

--- a/src/config2.default
+++ b/src/config2.default
@@ -303,10 +303,7 @@ leveling-strategy.rectangular-grid.flex_x_points					30
 leveling-strategy.rectangular-grid.flex_compensation_always_active 	false
 
 # Pitch compensation
-pitch_compensation.enable					false			# Enable screw pitch compensation
-#pitch_compensation.points.x_axis
-#pitch_compensation.points.y_axis
-#pitch_compensation.points.z_axis
+pitch_compensation.enable					false			# Enable screw pitch compensation on boot
 
 ## Network settings
 #network.enable								false			# Enable the ethernet network services

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -268,6 +268,7 @@ std::string Kernel::get_query_string()
         float mpos[5];
         robot->get_current_machine_position(mpos);
         // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+        if(robot->pitchCompensationTransform) robot->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
         if(robot->compensationTransform) robot->compensationTransform(mpos, true, false); // get inverse compensation transform
 
         // machine position

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "modules/tools/temperatureswitch/TemperatureSwitch.h"
 #include "modules/tools/drillingcycles/Drillingcycles.h"
 #include "modules/tools/atc/ATCHandler.h"
+#include "modules/tools/pitchcompensation/PitchCompensation.h"
 #include "modules/utils/wifi/WifiProvider.h"
 #include "modules/robot/Conveyor.h"
 #include "modules/utils/simpleshell/SimpleShell.h"
@@ -155,6 +156,9 @@ void init() {
 
     // ATC Handler
     kernel->add_module( new(AHB) ATCHandler() );
+
+    // Pitch Compensation
+    kernel->add_module( new(AHB) PitchCompensation() );
 
     // MSC File System Handler
     kernel->add_module( new(AHB) MSCFileSystem("ud") );

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -241,18 +241,21 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 case 5021: //current machine X position
                     THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     return mpos[X_AXIS];
                     break;
                 case 5022: //current machine Y position
                     THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     return mpos[Y_AXIS];
                     break;
                 case 5023: //current machine Z position
                     THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     return mpos[Z_AXIS];
                     break;
@@ -265,6 +268,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 case 5041: //current WCS X position
                      THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     pos= THEROBOT->mcs2wcs(mpos);
                     return THEROBOT->from_millimeters(std::get<X_AXIS>(pos));
@@ -273,6 +277,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 case 5042: //current WCS Y position
                      THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     pos= THEROBOT->mcs2wcs(mpos);
                     return THEROBOT->from_millimeters(std::get<Y_AXIS>(pos));
@@ -281,6 +286,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 case 5043: //current WCS A position
                      THEROBOT->get_current_machine_position(mpos);
                     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+                    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
                     if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
                     pos= THEROBOT->mcs2wcs(mpos);
                     return THEROBOT->from_millimeters(std::get<Z_AXIS>(pos));

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1554,6 +1554,11 @@ void Robot::reset_axis_position(float x, float y, float z)
     compensated_machine_position[Y_AXIS]= machine_position[Y_AXIS] = y;
     compensated_machine_position[Z_AXIS]= machine_position[Z_AXIS] = z;
 
+    if(pitchCompensationTransform) {
+        // apply inverse transform to get machine_position
+        pitchCompensationTransform(machine_position, true, false);
+    }
+
     if(compensationTransform) {
         // apply inverse transform to get machine_position
         compensationTransform(machine_position, true, false);

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -85,6 +85,8 @@ class Robot : public Module {
 
         // set by a leveling strategy to transform the target of a move according to the current plan
         std::function<void(float*, bool, bool)> compensationTransform;
+        // set by pitch compensation strategy
+        std::function<void(float*, bool, bool)> pitchCompensationTransform;
         // set by an active extruder, returns the amount to scale the E parameter by (to convert mm³ to mm)
         std::function<float(void)> get_e_scale_fnc;
 

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1817,6 +1817,7 @@ void ATCHandler::set_tlo_by_offset(float z_axis_offset){
 	Robot::wcs_t pos;
 	THEROBOT->get_current_machine_position(mpos);
 	// current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+	if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
 	if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
 	pos = THEROBOT->mcs2wcs(mpos);
 	cur_tool_mz = cur_tool_mz + THEROBOT->from_millimeters(std::get<Z_AXIS>(pos)) - z_axis_offset;

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -1060,6 +1060,10 @@ void Endstops::process_home_command(Gcode* gcode)
     auto savect= THEROBOT->compensationTransform;
     THEROBOT->compensationTransform= nullptr;
 
+    // also turn off pitch compensation during homing
+    auto savepct = THEROBOT->pitchCompensationTransform;
+    THEROBOT->pitchCompensationTransform = nullptr;
+
     // deltas always home Z axis only, which moves all three actuators
     bool home_in_z_only = this->is_delta || this->is_rdelta;
 
@@ -1145,6 +1149,9 @@ void Endstops::process_home_command(Gcode* gcode)
 
     // restore compensationTransform
     THEROBOT->compensationTransform= savect;
+
+    // restore pitchCompensationTransform
+    THEROBOT->pitchCompensationTransform = savepct;
 
     // check if on_halt (eg kill or fail)
     if(THEKERNEL->is_halted()) {

--- a/src/modules/tools/pitchcompensation/PitchCompensation.cpp
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.cpp
@@ -1,0 +1,244 @@
+#include "PitchCompensation.h"
+#include "libs/Kernel.h"
+#include "libs/nuts_bolts.h"
+#include "libs/utils.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "modules/robot/Robot.h"
+#include "ConfigValue.h"
+#include "StreamOutput.h"
+#include "libs/StreamOutputPool.h"
+
+#include <string>
+#include <cmath>
+#include <functional>
+#include <algorithm>
+#include <cstring>
+
+#define pitch_compensation_checksum CHECKSUM("pitch_compensation")
+#define enable_checksum             CHECKSUM("enable")
+#define points_checksum             CHECKSUM("points")
+
+using namespace std;
+
+PitchCompensation::PitchCompensation() {
+    this->enable = false;
+}
+
+void PitchCompensation::on_module_loaded() {
+    this->config_load();
+
+    if(this->enable) {
+        // Register compensation transform
+        using std::placeholders::_1;
+        using std::placeholders::_2;
+        using std::placeholders::_3;
+        THEROBOT->pitchCompensationTransform = std::bind(&PitchCompensation::do_compensation, this, _1, _2, _3);
+    }
+}
+
+void PitchCompensation::config_load() {
+    this->enable = THEKERNEL->config->value(pitch_compensation_checksum, enable_checksum)->by_default(false)->as_bool();
+
+    if(!this->enable) return;
+
+    // Load axis configurations
+    // pitch_compensation.points.x_axis = ...
+    string axes = "XYZ";
+    for(char c : axes) {
+        uint16_t axis_chk = 0;
+        if(c == 'X') axis_chk = CHECKSUM("x_axis");
+        else if(c == 'Y') axis_chk = CHECKSUM("y_axis");
+        else if(c == 'Z') axis_chk = CHECKSUM("z_axis");
+
+        string points_str = THEKERNEL->config->value(pitch_compensation_checksum, points_checksum, axis_chk)->by_default("")->as_string();
+
+        if(!points_str.empty()) {
+            AxisCompensation axis_comp;
+
+            // Parse the points string into a series of position:multiplier pairs
+            const char* str = points_str.c_str();
+            const char* start = str;
+            const char* end = str + points_str.length();
+
+            while(start < end) {
+                // Find next comma or end of string
+                const char* comma = start;
+                while(comma < end && *comma != ',') comma++;
+
+                // Find colon within this segment
+                const char* colon = start;
+                while(colon < comma && *colon != ':') colon++;
+
+                if(colon < comma) {
+                    float pos = strtof(start, NULL);
+                    float mul = strtof(colon + 1, NULL);
+                    axis_comp.points.push_back({pos, mul, 0.0});
+                }
+
+                // Move to next segment
+                start = comma + 1;
+            }
+
+            if(!axis_comp.points.empty()) {
+                // Sort points by position and precompute integrals
+                std::sort(axis_comp.points.begin(), axis_comp.points.end());
+                precompute_integrals(axis_comp);
+                axis_comp.points.shrink_to_fit();
+                axis_compensations[c] = axis_comp;
+            }
+        }
+    }
+}
+
+void PitchCompensation::precompute_integrals(AxisCompensation& axis_comp) {
+    if(axis_comp.points.empty()) return;
+
+    // We set integral at P0 to be P0. This implies C(P0) = P0.
+    CompensationPoint& first = axis_comp.points[0];
+    double integral = first.pos;
+    first.integral = integral;
+
+    float prev_pos = first.pos;
+    float prev_mul = first.multiplier;
+
+    for(size_t i = 1; i < axis_comp.points.size(); ++i) {
+        CompensationPoint& cp = axis_comp.points[i];
+        float dx = cp.pos - prev_pos;
+
+        // Trapezoidal rule
+        integral += dx * (prev_mul + cp.multiplier) / 2.0;
+        cp.integral = integral;
+
+        prev_pos = cp.pos;
+        prev_mul = cp.multiplier;
+    }
+}
+
+double PitchCompensation::integrate(const AxisCompensation& axis_comp, float pos) {
+    if(axis_comp.points.empty()) return pos;
+
+    // Get the first point with position > pos
+    CompensationPoint search_val = {pos, 0, 0};
+    auto it = std::upper_bound(axis_comp.points.begin(), axis_comp.points.end(), search_val);
+
+    // Before start (using first multiplier constant)
+    if(it == axis_comp.points.begin()) {
+        const CompensationPoint& p0 = axis_comp.points.front();
+        // Extrapolate backwards using the first multiplier constant
+        // C(x) = C(p0) - (p0 - x) * m0
+        return p0.integral - (p0.pos - pos) * p0.multiplier;
+    }
+
+    // After end (using last multiplier constant)
+    if(it == axis_comp.points.end()) {
+        const CompensationPoint& p_last = axis_comp.points.back();
+        // Extrapolate forwards using the last multiplier constant
+        // C(x) = C(last) + (x - last_pos) * last_mul
+        return p_last.integral + (pos - p_last.pos) * p_last.multiplier;
+    }
+
+    // Between two points p1 and p2 where:
+    // p2 => end of the segment (it)
+    // p1 => start of the segment (it - 1, safe since it != begin)
+    const CompensationPoint& p2 = *it;
+    const CompensationPoint& p1 = *(--it);
+
+    float dx = pos - p1.pos;
+    float range = p2.pos - p1.pos;
+
+    // Interpolated multiplier at pos
+    // m(x) = m1 + (m2 - m1) * (x - p1) / range
+    // Integral = C1 + m1 * dx + 0.5 * slope * dx*dx
+    float slope = (p2.multiplier - p1.multiplier) / range;
+    return p1.integral + p1.multiplier * dx + 0.5 * slope * dx * dx;
+}
+
+float PitchCompensation::inverse_integrate(const AxisCompensation& axis_comp, double val) {
+    if(axis_comp.points.empty()) return (float)val;
+
+    // Find the first point with integral >= val
+    auto it = std::lower_bound(axis_comp.points.begin(), axis_comp.points.end(), val,
+        [](const CompensationPoint& cp, double v) {
+            return cp.integral < v;
+        });
+
+    // Before start (using first multiplier constant)
+    if(it == axis_comp.points.begin()) {
+        const CompensationPoint& p0 = axis_comp.points.front();
+        // val = C(p0) - (p0 - x) * m0
+        // val - C(p0) = -p0*m0 + x*m0
+        // x = (val - C(p0))/m0 + p0
+        return (val - p0.integral) / p0.multiplier + p0.pos;
+    }
+
+    // After end (using last multiplier constant)
+    if(it == axis_comp.points.end()) {
+        const CompensationPoint& p_last = axis_comp.points.back();
+        // val = C(last) + (x - last_pos) * last_mul
+        // val - C(last) = (x - last_pos) * last_mul
+        // x = (val - C(last))/last_mul + last_pos
+        return (val - p_last.integral) / p_last.multiplier + p_last.pos;
+    }
+
+    // Between two points p1 and p2 where:
+    // p2 => end of the segment (it)
+    // p1 => start of the segment (it - 1, safe since it != begin)
+    const CompensationPoint& p2 = *it;
+    const CompensationPoint& p1 = *(--it);
+
+    float range = p2.pos - p1.pos;
+    float slope = (p2.multiplier - p1.multiplier) / range;
+
+    // val = c1 + m1 * dx + 0.5 * slope * dx*dx
+    // 0.5*slope*dx^2 + m1*dx + (c1 - val) = 0
+    double A = 0.5 * slope;
+    double B = p1.multiplier;
+    double C = p1.integral - val;
+
+    if(abs(A) < 1e-9) {
+        // Linear: m1 * dx + C = 0 -> dx = -C / m1
+        return p1.pos + (-C / B);
+    } else {
+        // Quadratic
+        double delta = B*B - 4*A*C;
+        if(delta < 0) delta = 0;
+        double dx = (-B + sqrt(delta)) / (2*A);
+        return p1.pos + dx;
+    }
+}
+
+void PitchCompensation::do_compensation(float* target, bool inverse, bool debug) {
+    if(!enable) return;
+
+    // X axis
+    if(axis_compensations.count('X')) {
+        if(!inverse) {
+            target[0] = integrate(axis_compensations['X'], target[0]);
+        } else {
+            target[0] = inverse_integrate(axis_compensations['X'], target[0]);
+        }
+    }
+
+    // Y axis
+    if(axis_compensations.count('Y')) {
+        if(!inverse) {
+            target[1] = integrate(axis_compensations['Y'], target[1]);
+        } else {
+            target[1] = inverse_integrate(axis_compensations['Y'], target[1]);
+        }
+    }
+
+    // Z axis
+    if(axis_compensations.count('Z')) {
+        if(!inverse) {
+            target[2] = integrate(axis_compensations['Z'], target[2]);
+        } else {
+            target[2] = inverse_integrate(axis_compensations['Z'], target[2]);
+        }
+    }
+
+    if(debug) {
+        THEKERNEL->streams->printf("//DEBUG: PitchComp NEW TARGET: %f, %f, %f\n", target[0], target[1], target[2]);
+    }
+}

--- a/src/modules/tools/pitchcompensation/PitchCompensation.cpp
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.cpp
@@ -94,9 +94,9 @@ void PitchCompensation::config_load() {
 void PitchCompensation::precompute_integrals(AxisCompensation& axis_comp) {
     if(axis_comp.points.empty()) return;
 
-    // We set integral at P0 to be P0. This implies C(P0) = P0.
+    // First pass: compute integrals starting from 0 at the first point
     CompensationPoint& first = axis_comp.points[0];
-    double integral = first.pos;
+    double integral = 0.0;
     first.integral = integral;
 
     float prev_pos = first.pos;
@@ -112,6 +112,14 @@ void PitchCompensation::precompute_integrals(AxisCompensation& axis_comp) {
 
         prev_pos = cp.pos;
         prev_mul = cp.multiplier;
+    }
+
+    // Normalize so that C(0) = 0
+    // This ensures homing works correctly - when the machine homes to physical
+    // position 0, the compensated position should also be 0
+    double c_at_zero = integrate(axis_comp, 0.0f);
+    for(auto& cp : axis_comp.points) {
+        cp.integral -= c_at_zero;
     }
 }
 

--- a/src/modules/tools/pitchcompensation/PitchCompensation.cpp
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.cpp
@@ -51,7 +51,9 @@ void PitchCompensation::on_gcode_received(void* argument)
         // M381.2: Save current pitch compensation data
         // M381.3: Load pitch compensation data and enable compensation
         // M381.4: Delete compensation data for all axes and save
-        // M381.5: Add point (ex: M381.5 X10 C1.00034)
+        // M381.5: Add point by multiplier or real-world measurement
+        //         ex: M381.5 X10 C1.00034   (C = compensation multiplier, multi-axis OK)
+        //         ex: M381.5 X10 R10.0034   (R = real-world measurement, single axis only)
         // M381.6: Remove point (ex: M381.6 X10)
         // M381.7: Remove all points for the given axes (ex: M381.7 X Y)
         if(gcode->subcode == 1) {
@@ -59,7 +61,7 @@ void PitchCompensation::on_gcode_received(void* argument)
             print_compensation_data(gcode->stream);
         } else if(gcode->subcode == 2) {
             // Save pitch compensation data
-            save_points_to_file();
+            save_points_to_file(gcode->stream);
         } else if(gcode->subcode == 3) {
             // Load pitch compensation data and enable compensation
             THEKERNEL->conveyor->wait_for_idle();
@@ -70,20 +72,43 @@ void PitchCompensation::on_gcode_received(void* argument)
             // Delete pitch compensation data for all axes and save
             THEKERNEL->conveyor->wait_for_idle();
             for(char axis : axes) {
-                clear_points(axis);
+                clear_points(axis, gcode->stream);
             }
-            save_points_to_file();
+            save_points_to_file(gcode->stream);
         } else if(gcode->subcode == 5) {
-            if (!gcode->has_letter('C')) {
-                gcode->stream->printf("Pitch compensation: missing compensation value\n");
+            bool has_c = gcode->has_letter('C');
+            bool has_r = gcode->has_letter('R');
+
+            if (!has_c && !has_r) {
+                gcode->stream->printf("Pitch compensation: missing C (multiplier) or R (real-world measurement) value\n");
                 return;
+            }
+
+            if (has_c && has_r) {
+                gcode->stream->printf("Pitch compensation: C and R are mutually exclusive\n");
+                return;
+            }
+
+            if (has_r) {
+                int axis_count = 0;
+                for(char axis : axes) {
+                    if(gcode->has_letter(axis)) axis_count++;
+                }
+                if (axis_count != 1) {
+                    gcode->stream->printf("Pitch compensation: R mode requires exactly one axis\n");
+                    return;
+                }
             }
 
             // Add point
             THEKERNEL->conveyor->wait_for_idle();
             for(char axis : axes) {
                 if(gcode->has_letter(axis)) {
-                    add_point(axis, gcode->get_value(axis), gcode->get_value('C'));
+                    if (has_c) {
+                        add_point(axis, gcode->get_value(axis), gcode->get_value('C'), gcode->stream);
+                    } else {
+                        add_point_by_measurement(axis, gcode->get_value(axis), gcode->get_value('R'), gcode->stream);
+                    }
                 }
             }
         } else if(gcode->subcode == 6) {
@@ -91,7 +116,7 @@ void PitchCompensation::on_gcode_received(void* argument)
             THEKERNEL->conveyor->wait_for_idle();
             for (char axis : axes) {
                 if(gcode->has_letter(axis)) {
-                    remove_point(axis, gcode->get_value(axis));
+                    remove_point(axis, gcode->get_value(axis), gcode->stream);
                 }
             }
         } else if(gcode->subcode == 7) {
@@ -99,7 +124,7 @@ void PitchCompensation::on_gcode_received(void* argument)
             THEKERNEL->conveyor->wait_for_idle();
             for(char axis : axes) {
                 if (gcode->has_letter(axis)) {
-                    clear_points(axis);
+                    clear_points(axis, gcode->stream);
                 }
             }
         } else {
@@ -113,19 +138,23 @@ void PitchCompensation::on_gcode_received(void* argument)
 }
 
 void PitchCompensation::print_compensation_data(StreamOutput *stream) {
+    // Display enabled/disabled status
+    stream->printf("Pitch compensation: %s\n", this->enabled ? "enabled" : "disabled");
+
     const char axes[] = "XYZ";
     for(char axis : axes) {
         if (!axis_compensations.count(axis)) continue;
         stream->printf("Pitch compensation data for %c:\n", axis);
+        stream->printf("  Position      Multiplier  Compensated\n");
         for(const CompensationPoint& cp : axis_compensations[axis].points) {
-            stream->printf("  %f: %f\n", cp.pos, cp.multiplier);
+            stream->printf("  %-13.6f %-11.6f %f\n", cp.pos, cp.multiplier, cp.integral);
         }
     }
 }
 
-void PitchCompensation::add_point(char axis, float pos, float multiplier) {
+void PitchCompensation::add_point(char axis, float pos, float multiplier, StreamOutput *stream) {
     if (multiplier < 0.5f || multiplier > 1.5f) {
-        THEKERNEL->streams->printf("Pitch compensation: Multiplier %f out of range [0.5, 1.5]\n", multiplier);
+        stream->printf("Pitch compensation: Multiplier %f out of range [0.5, 1.5]\n", multiplier);
         return;
     }
 
@@ -142,16 +171,76 @@ void PitchCompensation::add_point(char axis, float pos, float multiplier) {
 
     // Add the new point
     axis_comp.points.push_back({pos, multiplier, 0.0});
+    std::sort(axis_comp.points.begin(), axis_comp.points.end());
     update_compensation_transform();
 
     if (existed) {
-        THEKERNEL->streams->printf("Pitch compensation: updated point %c%f (compensation: %f)\n", axis, pos, multiplier);
+        stream->printf("Pitch compensation: updated point %c%f (compensation: %f)\n", axis, pos, multiplier);
     } else {
-        THEKERNEL->streams->printf("Pitch compensation: added point %c%f (compensation: %f)\n", axis, pos, multiplier);
+        stream->printf("Pitch compensation: added point %c%f (compensation: %f)\n", axis, pos, multiplier);
     }
 }
 
-void PitchCompensation::remove_point(char axis, float pos) {
+void PitchCompensation::add_point_by_measurement(char axis, float machine_pos, float real_world_pos, StreamOutput *stream) {
+    AxisCompensation& axis_comp = axis_compensations[axis];
+
+    // pos=0 is an implicit identity point (C(0) = 0); reject manual changes
+    if (abs(machine_pos) < EPSILON) {
+        stream->printf("Pitch compensation: position 0 is an implicit identity point and cannot be set manually\n");
+        return;
+    }
+
+    // Save original state in case validation fails
+    std::vector<CompensationPoint> original_points = axis_comp.points;
+
+    // Remove existing point at this position
+    auto it = std::remove_if(axis_comp.points.begin(), axis_comp.points.end(),
+        [machine_pos](const CompensationPoint& cp) {
+            return abs(cp.pos - machine_pos) < EPSILON;
+        });
+    bool existed = (it != axis_comp.points.end());
+    axis_comp.points.erase(it, axis_comp.points.end());
+
+    // Ensure an identity anchor at pos=0 exists so that normalization
+    // in precompute_integrals preserves the user's measurements exactly.
+    bool has_zero = false;
+    for (auto& cp : axis_comp.points) {
+        if (abs(cp.pos) < EPSILON) {
+            cp.integral = 0.0;
+            has_zero = true;
+            break;
+        }
+    }
+    if (!has_zero) {
+        axis_comp.points.push_back({0.0f, 1.0f, 0.0});
+    }
+
+    // Add new point: integral = real_world_pos (measurement relative to 0)
+    axis_comp.points.push_back({machine_pos, 1.0f, (double)real_world_pos});
+
+    std::sort(axis_comp.points.begin(), axis_comp.points.end());
+    recompute_multipliers_from_integrals(axis_comp);
+
+    // Validate all derived multipliers
+    for (const auto& cp : axis_comp.points) {
+        if (cp.multiplier < 0.5f || cp.multiplier > 1.5f) {
+            stream->printf("Pitch compensation: derived multiplier %f at pos %f is out of range [0.5, 1.5]\n", cp.multiplier, cp.pos);
+            stream->printf("Pitch compensation: operation rejected, restoring previous state\n");
+            axis_comp.points = original_points;
+            return;
+        }
+    }
+
+    update_compensation_transform();
+
+    if (existed) {
+        stream->printf("Pitch compensation: updated point %c%f (measured: %f)\n", axis, machine_pos, real_world_pos);
+    } else {
+        stream->printf("Pitch compensation: added point %c%f (measured: %f)\n", axis, machine_pos, real_world_pos);
+    }
+}
+
+void PitchCompensation::remove_point(char axis, float pos, StreamOutput *stream) {
     AxisCompensation& axis_comp = axis_compensations[axis];
     auto it = std::remove_if(axis_comp.points.begin(), axis_comp.points.end(),
         [pos](const CompensationPoint& cp) {
@@ -161,23 +250,23 @@ void PitchCompensation::remove_point(char axis, float pos) {
     if (it != axis_comp.points.end()) {
         axis_comp.points.erase(it, axis_comp.points.end());
         update_compensation_transform();
-        THEKERNEL->streams->printf("Pitch compensation: removed point %c%f\n", axis, pos);
+        stream->printf("Pitch compensation: removed point %c%f\n", axis, pos);
     } else {
-        THEKERNEL->streams->printf("Pitch compensation: point %c%f not found\n", axis, pos);
+        stream->printf("Pitch compensation: point %c%f not found\n", axis, pos);
     }
 }
 
-void PitchCompensation::clear_points(char axis) {
+void PitchCompensation::clear_points(char axis, StreamOutput *stream) {
     AxisCompensation& axis_comp = axis_compensations[axis];
     axis_comp.points.clear();
     update_compensation_transform();
-    THEKERNEL->streams->printf("Pitch compensation: cleared points for %c\n", axis);
+    stream->printf("Pitch compensation: cleared points for %c\n", axis);
 }
 
-void PitchCompensation::save_points_to_file() {
+void PitchCompensation::save_points_to_file(StreamOutput *stream) {
     FILE *file = fopen(PITCH_COMPENSATION_FILE, "w");
     if(!file) {
-        THEKERNEL->streams->printf("error: Failed to open pitch compensation file %s\n", PITCH_COMPENSATION_FILE);
+        stream->printf("error: Failed to open pitch compensation file %s\n", PITCH_COMPENSATION_FILE);
         return;
     }
 
@@ -189,14 +278,14 @@ void PitchCompensation::save_points_to_file() {
             // Example: X 10.5 1.00034
             int retval = fprintf(file, "%c %f %f\n", axis, cp.pos, cp.multiplier);
             if(retval == EOF) {
-                THEKERNEL->streams->printf("Pitch compensation: Failed to write point %c%f %f to file (errno: %d)\n", axis, cp.pos, cp.multiplier, errno);
+                stream->printf("Pitch compensation: Failed to write point %c%f %f to file (errno: %d)\n", axis, cp.pos, cp.multiplier, errno);
                 fclose(file);
                 return;
             }
         }
     }
 
-    THEKERNEL->streams->printf("Pitch compensation data saved to %s\n", PITCH_COMPENSATION_FILE);
+    stream->printf("Pitch compensation data saved to %s\n", PITCH_COMPENSATION_FILE);
     fclose(file);
 }
 
@@ -322,6 +411,33 @@ void PitchCompensation::precompute_integrals(AxisCompensation& axis_comp) {
     double c_at_zero = integrate(axis_comp, 0.0f);
     for(auto& cp : axis_comp.points) {
         cp.integral -= c_at_zero;
+    }
+}
+
+void PitchCompensation::recompute_multipliers_from_integrals(AxisCompensation& axis_comp) {
+    size_t n = axis_comp.points.size();
+    if (n == 0) return;
+
+    if (n == 1) {
+        CompensationPoint& p = axis_comp.points[0];
+        if (abs(p.pos) < EPSILON) {
+            p.multiplier = 1.0f;
+        } else {
+            p.multiplier = (float)(p.integral / p.pos);
+        }
+        return;
+    }
+
+    // Forward propagation: exactly preserves integrals under the trapezoidal rule.
+    // m[0] = average of first segment, then m[i+1] = 2*avg[i] - m[i]
+    double first_avg = (axis_comp.points[1].integral - axis_comp.points[0].integral)
+                     / (axis_comp.points[1].pos - axis_comp.points[0].pos);
+    axis_comp.points[0].multiplier = (float)first_avg;
+
+    for (size_t i = 0; i < n - 1; ++i) {
+        double dx = axis_comp.points[i + 1].pos - axis_comp.points[i].pos;
+        double seg_avg = (axis_comp.points[i + 1].integral - axis_comp.points[i].integral) / dx;
+        axis_comp.points[i + 1].multiplier = (float)(2.0 * seg_avg - axis_comp.points[i].multiplier);
     }
 }
 

--- a/src/modules/tools/pitchcompensation/PitchCompensation.h
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.h
@@ -1,7 +1,8 @@
 #ifndef PITCH_COMPENSATION_H
 #define PITCH_COMPENSATION_H
 
-#include "libs/Module.h"
+#include "Module.h"
+#include "StreamOutputPool.h"
 #include <vector>
 #include <map>
 
@@ -11,6 +12,7 @@ public:
     virtual ~PitchCompensation() {};
 
     void on_module_loaded();
+    void on_gcode_received(void* argument);
 
     struct CompensationPoint {
         float pos; // Position of the point
@@ -29,12 +31,19 @@ public:
 private:
     void config_load();
     void do_compensation(float* target, bool inverse, bool debug);
+    void print_compensation_data(StreamOutput *stream);
+    void add_point(char axis, float pos, float multiplier);
+    void remove_point(char axis, float pos);
+    void clear_points(char axis);
+    void save_points_to_file();
+    void load_points_from_file();
+    void update_compensation_transform();
     void precompute_integrals(AxisCompensation& axis_comp);
     double integrate(const AxisCompensation& axis_comp, float pos);
     float inverse_integrate(const AxisCompensation& axis_comp, double val);
 
     std::map<char, AxisCompensation> axis_compensations;
-    bool enable;
+    bool enabled;
 };
 
 #endif

--- a/src/modules/tools/pitchcompensation/PitchCompensation.h
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.h
@@ -1,0 +1,40 @@
+#ifndef PITCH_COMPENSATION_H
+#define PITCH_COMPENSATION_H
+
+#include "libs/Module.h"
+#include <vector>
+#include <map>
+
+class PitchCompensation : public Module {
+public:
+    PitchCompensation();
+    virtual ~PitchCompensation() {};
+
+    void on_module_loaded();
+
+    struct CompensationPoint {
+        float pos; // Position of the point
+        float multiplier; // Multiplier at this point
+        double integral; // Cumulative integral up to this point
+
+        bool operator<(const CompensationPoint& other) const {
+            return pos < other.pos;
+        }
+    };
+
+    struct AxisCompensation {
+        std::vector<CompensationPoint> points;
+    };
+
+private:
+    void config_load();
+    void do_compensation(float* target, bool inverse, bool debug);
+    void precompute_integrals(AxisCompensation& axis_comp);
+    double integrate(const AxisCompensation& axis_comp, float pos);
+    float inverse_integrate(const AxisCompensation& axis_comp, double val);
+
+    std::map<char, AxisCompensation> axis_compensations;
+    bool enable;
+};
+
+#endif

--- a/src/modules/tools/pitchcompensation/PitchCompensation.h
+++ b/src/modules/tools/pitchcompensation/PitchCompensation.h
@@ -32,13 +32,15 @@ private:
     void config_load();
     void do_compensation(float* target, bool inverse, bool debug);
     void print_compensation_data(StreamOutput *stream);
-    void add_point(char axis, float pos, float multiplier);
-    void remove_point(char axis, float pos);
-    void clear_points(char axis);
-    void save_points_to_file();
+    void add_point(char axis, float pos, float multiplier, StreamOutput *stream);
+    void add_point_by_measurement(char axis, float machine_pos, float real_world_pos, StreamOutput *stream);
+    void remove_point(char axis, float pos, StreamOutput *stream);
+    void clear_points(char axis, StreamOutput *stream);
+    void save_points_to_file(StreamOutput *stream);
     void load_points_from_file();
     void update_compensation_transform();
     void precompute_integrals(AxisCompensation& axis_comp);
+    void recompute_multipliers_from_integrals(AxisCompensation& axis_comp);
     double integrate(const AxisCompensation& axis_comp, float pos);
     float inverse_integrate(const AxisCompensation& axis_comp, double val);
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -856,6 +856,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
     float pos[3];
     THEROBOT->get_axis_position(pos, 3);
 
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(pos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(pos, true, false); // get inverse compensation transform
     }
@@ -976,6 +977,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     float pos[3];
     THEROBOT->get_axis_position(pos, 3);
 
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(pos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(pos, true, false); // get inverse compensation transform
     }
@@ -1203,6 +1205,7 @@ bool ZProbe::fast_slow_probe_sequence(int axis, int direction){
     //store position
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -1403,6 +1406,7 @@ void ZProbe::probe_bore(bool calibration) //M461
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -1539,6 +1543,7 @@ void ZProbe::probe_boss(bool calibration) //M462
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -1701,6 +1706,7 @@ void ZProbe::probe_insideCorner() //M463
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -1794,6 +1800,7 @@ void ZProbe::probe_outsideCorner() //M464
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -1973,6 +1980,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);    // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
     a_axis_pos = THEROBOT->actuators[3]->get_current_position();
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }
@@ -2218,6 +2226,7 @@ void ZProbe::probe_square(){
     //save center position to use later
     THEROBOT->get_current_machine_position(mpos);
     // current_position/mpos includes the compensation transform so we need to get the inverse to get actual position
+    if(THEROBOT->pitchCompensationTransform) THEROBOT->pitchCompensationTransform(mpos, true, false); // get inverse pitch compensation transform
     if(THEKERNEL->is_flex_compensation_active()) {
         if(THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false); // get inverse compensation transform
     }


### PR DESCRIPTION
This PR aims to implement pitch compensation to correct for some ballscrew inaccuracies that were reported on Discord (not sure how widespread they are though).

I haven't had the time to test it yet and had some assistance from Gemini on the math part (hence the draft status), but if someone feels adventurous let me know how it goes.


**Edit:** see [this comment](https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/221#issuecomment-3786086464) for the current implementation

<del>
It expects a configuration in the following format:

```
pitch_compensation.enable          true
pitch_compensation.points.x_axis   -220:1.05,-100:1.02,0:0.98
```

Where each pair in `pitch_compensation.points.[N]_axis` is composed of:
- a machine position on that axis
- a multiplier that should be applied to moves around that position (interpolated between the previous and next point)
</del>