### PR TITLE
Fix: Disable rotary feedrate compensation for G0 rapid moves

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1822,7 +1822,7 @@ bool Robot::append_milestone(const float target[], float feed_rate, unsigned int
 
 		float actuator_rate = d / isecs;
 
-		if (actuator == A_AXIS) {
+		if (actuator == A_AXIS && this->is_g123) {
 		    // THEKERNEL->streams->printf("d: %f, rate: %f, distance: %f, aux_move: %d, acc: %f, isecs: %f, line: %d\n", d, actuator_rate, distance, auxilliary_move, acceleration, isecs, line);
 		    float a_perimeter = PI * 2;
 			// A Axis moved, calculate real A Axis speed based on Y and Z wcs


### PR DESCRIPTION
This change disables rotary-feedrate centerline-distance compensation during G0 rapid positioning moves. 

Best practice is for cutting moves to be G1, G2, G3; and positioning moves to be G0. We don't need to slow movement of the 4th axis during positioning moves, as it would just waste time.



