### PR TITLE
Add open-loop spindle mode option

### DIFF
--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -43,6 +43,7 @@
 #define spindle_stall_s_checksum			CHECKSUM("stall_s")
 #define spindle_stall_count_rpm_checksum	CHECKSUM("stall_count_rpm")
 #define spindle_stall_alarm_rpm_checksum	CHECKSUM("stall_alarm_rpm")
+#define spindle_open_loop_checksum          CHECKSUM("open_loop")
 #define spindle_max_rpm_checksum            CHECKSUM("max_rpm")
 
 #define UPDATE_FREQ 100
@@ -82,6 +83,9 @@ void PWMSpindleControl::on_module_loaded()
     stall_alarm_rpm = THEKERNEL->config->value(spindle_checksum, spindle_stall_alarm_rpm_checksum)->by_default(5000)->as_number();
     acc_ratio      = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->by_default(1.0f)->as_number();
     alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->by_default("nc")->as_string())->as_input();
+
+    // Open-loop mode: bypass PID and use direct PWM scaling (like AnalogSpindleControl)
+    open_loop = THEKERNEL->config->value(spindle_checksum, spindle_open_loop_checksum)->by_default(false)->as_bool();
 
     // Smoothing value is low pass filter time constant in seconds.
     float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->by_default(0.1f)->as_number();
@@ -176,34 +180,42 @@ uint32_t PWMSpindleControl::on_update_speed(uint32_t dummy)
 		}
 	}
     if (spindle_on) {
-    	if (update_count > UPDATE_FREQ / 5) {
-    		update_count = 0;
-            float error = target_rpm * (factor / 100) - current_rpm;
-            float acc_pwm = control_P_term * error;
-            
+        if (open_loop) {
+            // Open-loop mode: direct PWM calculation like AnalogSpindleControl
+            // PWM = (target_rpm * factor%) / max_rpm, clamped to max_pwm
+            float target_with_factor = target_rpm * (factor / 100.0f);
+            current_pwm_value = confine(target_with_factor / max_rpm * max_pwm, 0.0f, max_pwm);
+        } else {
+            // Closed-loop PID mode (original behavior)
+            if (update_count > UPDATE_FREQ / 5) {
+                update_count = 0;
+                float error = target_rpm * (factor / 100) - current_rpm;
+                float acc_pwm = control_P_term * error;
+
+                if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
+                {
+                    if(target_change_count>UPDATE_FREQ*5)	//when speed changed time < 7s,we didn't use D_ter,to rapid speed up/down
+                    {
+                        acc_pwm += control_D_term * (error - prev_error);
+                        target_change_count = UPDATE_FREQ*5;
+                    }
+                }
+                float new_pwm = current_pwm_value + acc_pwm;
+                new_pwm = confine(new_pwm, 0.0f, max_pwm);
+
+                prev_error = error;
+                current_pwm_value = new_pwm;
+            }
+            update_count++;
             if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
             {
-            	if(target_change_count>UPDATE_FREQ*5)	//when speed changed time < 7s,we didn't use D_ter,to rapid speed up/down
-	            {
-	            	acc_pwm += control_D_term * (error - prev_error);
-	            	target_change_count = UPDATE_FREQ*5;
-            	}
+                target_change_count++;
             }
-            float new_pwm = current_pwm_value + acc_pwm;
-            new_pwm = confine(new_pwm, 0.0f, max_pwm);
+        }
 
-            prev_error = error;
-            current_pwm_value = new_pwm;
-    	}
-    	update_count ++;
-    	if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
-        {
-			target_change_count ++;
-		}
-
-		if (current_pwm_value > max_pwm) {
-			current_pwm_value = max_pwm;
-		}
+        if (current_pwm_value > max_pwm) {
+            current_pwm_value = max_pwm;
+        }
     } else {
         current_I_value = 0;
         current_pwm_value = 0;

--- a/src/modules/tools/spindle/PWMSpindleControl.h
+++ b/src/modules/tools/spindle/PWMSpindleControl.h
@@ -17,7 +17,8 @@ namespace mbed {
     class InterruptIn;
 }
 
-// This module implements closed loop PID control for spindle RPM.
+// This module implements spindle RPM control with closed-loop PID or open-loop PWM modes.
+// Config: spindle.open_loop (default false) - when true, bypasses PID and uses direct PWM scaling.
 class PWMSpindleControl: public SpindleControl {
     public:
         PWMSpindleControl();
@@ -63,6 +64,7 @@ class PWMSpindleControl: public SpindleControl {
         uint32_t stall_timer;
         float acc_ratio;
         Pin alarm_pin;
+        bool open_loop;   // If true, bypass PID and use direct PWM scaling
 
         // These fields are updated by the interrupt
         uint32_t last_edge; // Timestamp of last edge


### PR DESCRIPTION
## Summary

Adds a `spindle.open_loop` config option that bypasses the closed-loop PID controller and uses direct PWM scaling instead. This allows users with external motor controllers (e.g., ESCON 50/5) that handle their own closed-loop speed regulation to send a simple proportional PWM signal rather than fighting a PID loop that expects direct motor feedback.

## Related Project

This change supports the [Carvera Spindle Controller](https://github.com/stubbsd/Carvera-Spindle-Controller) — an external RP2350-based controller that interfaces between the Carvera CNC and an ESCON 50/5 servo driver. The open-loop mode is needed so the Carvera sends a proportional PWM signal that the external controller can translate, rather than running its own PID loop.

## Motivation

When using an external servo controller between the Carvera and the spindle motor, the existing PID loop creates problems:
- The external controller already maintains speed via its own closed-loop control
- Carvera's PID sees the external controller's regulated speed and tries to compensate, causing oscillation or sluggish response
- The `AnalogSpindleControl` module already supports this direct-scaling approach, but only for analog output — this brings the same logic to the PWM output path

## Changes

- **`PWMSpindleControl.h`** — Added `bool open_loop` member and updated class comment
- **`PWMSpindleControl.cpp`** —
  - New config key `spindle.open_loop` (default `false`, fully backward compatible)
  - When `open_loop == true`: `PWM = (target_rpm * factor%) / max_rpm * max_pwm`, matching the `AnalogSpindleControl` calculation
  - When `open_loop == false`: original closed-loop PID behavior preserved exactly

## Configuration

Add to the spindle section of the config file:

```
spindle.open_loop       true    # Bypass PID, use direct PWM scaling (default: false)
```

## Testing

- Verified closed-loop path is unchanged (restructured for clarity but logic/order identical)
- Open-loop calculation matches `AnalogSpindleControl::on_update_speed()` approach
- Default `false` ensures zero behavior change for existing users
