### PR TITLE
Fixing a bunch of compiler errors.

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -25,6 +25,10 @@ If the path is an existing directory, the artifact will be copied into it as `ma
 If the path points to a non-existent file in an existing directory, the artifact will be copied to that path.
 The destination directory must exist.
 
+.PARAMETER Slow
+runs the build command single threaded to prevent issues with multiple threads
+writing error messages over eachother
+
 .PARAMETER Help
 Displays this help message and exits.
 
@@ -70,7 +74,10 @@ param(
     [string]$OutputPath,
 
     [Parameter(Mandatory=$false)]
-    [switch]$Help
+    [switch]$Help,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Slow
 )
 
 # --- Script Setup ---
@@ -116,7 +123,9 @@ if ($PSVersionTable.PSEdition -eq "Desktop" -or
     $cpuCount = [Environment]::ProcessorCount
     Write-Host "Using $cpuCount parallel jobs for make." -ForegroundColor Cyan
 }
-
+if ($Slow){
+    $cpuCount = "1"
+}
 Write-Host "Using GCC version: $requestedGccVersion" -ForegroundColor Cyan
 Write-Host "Using $cpuCount parallel jobs for make." -ForegroundColor Cyan
 if ($Clean) {

--- a/mbed/src/capi/pinmap_common.c
+++ b/mbed/src/capi/pinmap_common.c
@@ -44,7 +44,7 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b) {
 }
 
 uint32_t pinmap_peripheral(PinName pin, const PinMap* map) {
-    if (pin == (uint32_t)NC)
+    if (pin == NC)
         return (uint32_t)NC;
 
     while (map->pin != NC) {

--- a/mbed/src/capi/rtc_time.h
+++ b/mbed/src/capi/rtc_time.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <time.h>
 
 #ifdef __cplusplus

--- a/mbed/src/capi/wait_api.c
+++ b/mbed/src/capi/wait_api.c
@@ -25,6 +25,7 @@ void wait_ms(int ms) {
 }
 
 void wait_us(int us) {
+    if (us <= 0) return;
     uint32_t start = us_ticker_read();
-    while ((us_ticker_read() - start) < us);
+    while ((us_ticker_read() - start) < (uint32_t)us);
 }

--- a/mbed/src/vendor/NXP/capi/pinmap.c
+++ b/mbed/src/vendor/NXP/capi/pinmap.c
@@ -28,7 +28,7 @@
 #endif
 
 void pin_function(PinName pin, int function) {
-    if (pin == (uint32_t)NC) return;
+    if (pin == (PinName)NC) return;
 
 #if defined(TARGET_LPC1768) || defined(TARGET_LPC2368)
     uint32_t pin_number = (uint32_t)pin - (uint32_t)P0_0;
@@ -51,7 +51,7 @@ void pin_function(PinName pin, int function) {
 }
 
 void pin_mode(PinName pin, PinMode mode) {
-    if (pin == (uint32_t)NC) { return; }
+    if (pin == (PinName)NC) { return; }
 
 #if defined(TARGET_LPC1768) || defined(TARGET_LPC2368)
     uint32_t pin_number = (uint32_t)pin - (uint32_t)P0_0;

--- a/mbed/src/vendor/NXP/cmsis/LPC1768/core_cmFunc.h
+++ b/mbed/src/vendor/NXP/cmsis/LPC1768/core_cmFunc.h
@@ -49,7 +49,7 @@
  */
 __STATIC_INLINE uint32_t __get_CONTROL(void)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   return(__regControl);
 }
 
@@ -62,7 +62,7 @@ __STATIC_INLINE uint32_t __get_CONTROL(void)
  */
 __STATIC_INLINE void __set_CONTROL(uint32_t control)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   __regControl = control;
 }
 
@@ -75,7 +75,7 @@ __STATIC_INLINE void __set_CONTROL(uint32_t control)
  */
 __STATIC_INLINE uint32_t __get_IPSR(void)
 {
-  register uint32_t __regIPSR          __ASM("ipsr");
+  uint32_t __regIPSR          __ASM("ipsr");
   return(__regIPSR);
 }
 
@@ -88,7 +88,7 @@ __STATIC_INLINE uint32_t __get_IPSR(void)
  */
 __STATIC_INLINE uint32_t __get_APSR(void)
 {
-  register uint32_t __regAPSR          __ASM("apsr");
+  uint32_t __regAPSR          __ASM("apsr");
   return(__regAPSR);
 }
 
@@ -101,7 +101,7 @@ __STATIC_INLINE uint32_t __get_APSR(void)
  */
 __STATIC_INLINE uint32_t __get_xPSR(void)
 {
-  register uint32_t __regXPSR          __ASM("xpsr");
+  uint32_t __regXPSR          __ASM("xpsr");
   return(__regXPSR);
 }
 
@@ -114,7 +114,7 @@ __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   return(__regProcessStackPointer);
 }
 
@@ -127,7 +127,7 @@ __STATIC_INLINE uint32_t __get_PSP(void)
  */
 __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   __regProcessStackPointer = topOfProcStack;
 }
 
@@ -140,7 +140,7 @@ __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
  */
 __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   return(__regMainStackPointer);
 }
 
@@ -153,7 +153,7 @@ __STATIC_INLINE uint32_t __get_MSP(void)
  */
 __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   __regMainStackPointer = topOfMainStack;
 }
 
@@ -166,7 +166,7 @@ __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
  */
 __STATIC_INLINE uint32_t __get_PRIMASK(void)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   return(__regPriMask);
 }
 
@@ -179,7 +179,7 @@ __STATIC_INLINE uint32_t __get_PRIMASK(void)
  */
 __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   __regPriMask = (priMask);
 }
 
@@ -210,7 +210,7 @@ __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
  */
 __STATIC_INLINE uint32_t  __get_BASEPRI(void)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   return(__regBasePri);
 }
 
@@ -223,7 +223,7 @@ __STATIC_INLINE uint32_t  __get_BASEPRI(void)
  */
 __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   __regBasePri = (basePri & 0xff);
 }
 
@@ -236,7 +236,7 @@ __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
  */
 __STATIC_INLINE uint32_t __get_FAULTMASK(void)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   return(__regFaultMask);
 }
 
@@ -249,7 +249,7 @@ __STATIC_INLINE uint32_t __get_FAULTMASK(void)
  */
 __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   __regFaultMask = (faultMask & (uint32_t)1);
 }
 
@@ -267,7 +267,7 @@ __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 __STATIC_INLINE uint32_t __get_FPSCR(void)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   return(__regfpscr);
 #else
    return(0);
@@ -284,7 +284,7 @@ __STATIC_INLINE uint32_t __get_FPSCR(void)
 __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   __regfpscr = (fpscr);
 #endif
 }
@@ -409,7 +409,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -436,7 +436,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);

--- a/mri/cmsis/core_cmFunc.h
+++ b/mri/cmsis/core_cmFunc.h
@@ -63,7 +63,7 @@
  */
 __STATIC_INLINE uint32_t __get_CONTROL(void)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   return(__regControl);
 }
 
@@ -76,7 +76,7 @@ __STATIC_INLINE uint32_t __get_CONTROL(void)
  */
 __STATIC_INLINE void __set_CONTROL(uint32_t control)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   __regControl = control;
 }
 
@@ -89,7 +89,7 @@ __STATIC_INLINE void __set_CONTROL(uint32_t control)
  */
 __STATIC_INLINE uint32_t __get_IPSR(void)
 {
-  register uint32_t __regIPSR          __ASM("ipsr");
+  uint32_t __regIPSR          __ASM("ipsr");
   return(__regIPSR);
 }
 
@@ -102,7 +102,7 @@ __STATIC_INLINE uint32_t __get_IPSR(void)
  */
 __STATIC_INLINE uint32_t __get_APSR(void)
 {
-  register uint32_t __regAPSR          __ASM("apsr");
+  uint32_t __regAPSR          __ASM("apsr");
   return(__regAPSR);
 }
 
@@ -115,7 +115,7 @@ __STATIC_INLINE uint32_t __get_APSR(void)
  */
 __STATIC_INLINE uint32_t __get_xPSR(void)
 {
-  register uint32_t __regXPSR          __ASM("xpsr");
+  uint32_t __regXPSR          __ASM("xpsr");
   return(__regXPSR);
 }
 
@@ -128,7 +128,7 @@ __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   return(__regProcessStackPointer);
 }
 
@@ -141,7 +141,7 @@ __STATIC_INLINE uint32_t __get_PSP(void)
  */
 __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   __regProcessStackPointer = topOfProcStack;
 }
 
@@ -154,7 +154,7 @@ __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
  */
 __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   return(__regMainStackPointer);
 }
 
@@ -167,7 +167,7 @@ __STATIC_INLINE uint32_t __get_MSP(void)
  */
 __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   __regMainStackPointer = topOfMainStack;
 }
 
@@ -180,7 +180,7 @@ __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
  */
 __STATIC_INLINE uint32_t __get_PRIMASK(void)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   return(__regPriMask);
 }
 
@@ -193,7 +193,7 @@ __STATIC_INLINE uint32_t __get_PRIMASK(void)
  */
 __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   __regPriMask = (priMask);
 }
 
@@ -224,7 +224,7 @@ __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
  */
 __STATIC_INLINE uint32_t  __get_BASEPRI(void)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   return(__regBasePri);
 }
 
@@ -237,7 +237,7 @@ __STATIC_INLINE uint32_t  __get_BASEPRI(void)
  */
 __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   __regBasePri = (basePri & 0xff);
 }
 
@@ -250,7 +250,7 @@ __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
  */
 __STATIC_INLINE uint32_t __get_FAULTMASK(void)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   return(__regFaultMask);
 }
 
@@ -263,7 +263,7 @@ __STATIC_INLINE uint32_t __get_FAULTMASK(void)
  */
 __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   __regFaultMask = (faultMask & (uint32_t)1);
 }
 
@@ -281,7 +281,7 @@ __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 __STATIC_INLINE uint32_t __get_FPSCR(void)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   return(__regfpscr);
 #else
    return(0);
@@ -298,7 +298,7 @@ __STATIC_INLINE uint32_t __get_FPSCR(void)
 __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   __regfpscr = (fpscr);
 #endif
 }
@@ -423,7 +423,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -450,7 +450,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);

--- a/src/libs/ChaNFS/CHAN_FS/ff.cpp
+++ b/src/libs/ChaNFS/CHAN_FS/ff.cpp
@@ -2478,7 +2478,7 @@ FRESULT f_write (
     FRESULT res;
     DWORD clst, sect;
     UINT wcnt, cc;
-    const BYTE *wbuff = (BYTE*)buff;
+    const BYTE *wbuff = (const BYTE*)buff;
     BYTE csect;
 
 

--- a/src/libs/ChaNFS/CHAN_FS/ff.cpp
+++ b/src/libs/ChaNFS/CHAN_FS/ff.cpp
@@ -825,24 +825,24 @@ DWORD get_fat (    /* 0xFFFFFFFF:Disk error, 1:Internal error, Else:Cluster stat
     if (clst < 2 || clst >= fs->n_fatent)    /* Chack range */
         return 1;
 
-        switch (fs->fs_type) {
+    switch (fs->fs_type) {
         case FS_FAT12 :
-        bc = (UINT)clst; bc += bc / 2;
-        if (move_window(fs, fs->fatbase + (bc / SS(fs)))) break;
-        wc = fs->win[bc % SS(fs)]; bc++;
-        if (move_window(fs, fs->fatbase + (bc / SS(fs)))) break;
-        wc |= fs->win[bc % SS(fs)] << 8;
-        return (clst & 1) ? (wc >> 4) : (wc & 0xFFF);
+            bc = (UINT)clst; bc += bc / 2;
+            if (move_window(fs, fs->fatbase + (bc / SS(fs)))) break;
+            wc = fs->win[bc % SS(fs)]; bc++;
+            if (move_window(fs, fs->fatbase + (bc / SS(fs)))) break;
+            wc |= fs->win[bc % SS(fs)] << 8;
+            return (clst & 1) ? (wc >> 4) : (wc & 0xFFF);
 
         case FS_FAT16 :
-        if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 2)))) break;
-        p = &fs->win[clst * 2 % SS(fs)];
-        return LD_WORD(p);
+            if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 2)))) break;
+            p = &fs->win[clst * 2 % SS(fs)];
+            return LD_WORD(p);
 
         case FS_FAT32 :
-        if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 4)))) break;
-        p = &fs->win[clst * 4 % SS(fs)];
-        return LD_DWORD(p) & 0x0FFFFFFF;
+            if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 4)))) break;
+            p = &fs->win[clst * 4 % SS(fs)];
+            return LD_DWORD(p) & 0x0FFFFFFF;
     }
 
     return 0xFFFFFFFF;    /* An error occurred at the disk I/O layer */

--- a/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_gpdma.c
+++ b/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_gpdma.c
@@ -116,7 +116,7 @@ const uint32_t GPDMA_LUTPerAddr[] = {
  * @brief Lookup Table of GPDMA Channel Number matched with
  * GPDMA channel pointer
  */
-const LPC_GPDMACH_TypeDef *pGPDMACh[8] = {
+LPC_GPDMACH_TypeDef *pGPDMACh[8] = {
 		LPC_GPDMACH0,	// GPDMA Channel 0
 		LPC_GPDMACH1,	// GPDMA Channel 1
 		LPC_GPDMACH2,	// GPDMA Channel 2
@@ -365,16 +365,16 @@ Status GPDMA_Setup(GPDMA_Channel_CFG_Type *GPDMAChannelConfig)
  **********************************************************************/
 void GPDMA_ChannelCmd(uint8_t channelNum, FunctionalState NewState)
 {
-	LPC_GPDMACH_TypeDef *pDMAch;
+    LPC_GPDMACH_TypeDef *pDMAch;
 
-	// Get Channel pointer
-	pDMAch = (const LPC_GPDMACH_TypeDef *) pGPDMACh[channelNum];
+    // Get Channel pointer
+    pDMAch = (LPC_GPDMACH_TypeDef *) pGPDMACh[channelNum];
 
-	if (NewState == ENABLE) {
-		pDMAch->DMACCConfig |= GPDMA_DMACCxConfig_E;
-	} else {
-		pDMAch->DMACCConfig &= ~GPDMA_DMACCxConfig_E;
-	}
+    if (NewState == ENABLE) {
+        pDMAch->DMACCConfig |= GPDMA_DMACCxConfig_E;
+    } else {
+        pDMAch->DMACCConfig &= ~GPDMA_DMACCxConfig_E;
+    }
 }
 /*********************************************************************//**
  * @brief		Check if corresponding channel does have an active interrupt

--- a/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_i2c.c
+++ b/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_i2c.c
@@ -500,6 +500,7 @@ next_stage:
 		case I2C_I2STAT_M_TX_ARB_LOST:
 			// update status
 			txrx_setup->status |= I2C_SETUP_STATUS_ARBF;
+			// fall through
 		default:
 			goto retry;
 		}
@@ -582,6 +583,7 @@ send_slar:
 		case I2C_I2STAT_M_RX_ARB_LOST:
 			// update status
 			txrx_setup->status |= I2C_SETUP_STATUS_ARBF;
+			// fall through
 		default:
 retry:
 			// check if retransmission is available

--- a/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_nvic.c
+++ b/src/libs/LPC17xx/LPC17xxLib/src/lpc17xx_nvic.c
@@ -78,7 +78,7 @@ void NVIC_DeInit(void)
 	NVIC->ICPR[1] = 0x00000001;
 
 	/* Clear all interrupt priority */
-	for (tmp = 0; tmp < 32; tmp++) {
+	for (tmp = 0; tmp < sizeof(NVIC->IP)/sizeof(NVIC->IP[0]); tmp++) {
 		NVIC->IP[tmp] = 0x00;
 	}
 }
@@ -111,7 +111,7 @@ void NVIC_SCBDeInit(void)
 	SCB->SCR = 0x00000000;
 	SCB->CCR = 0x00000000;
 
-	for (tmp = 0; tmp < 32; tmp++) {
+	for (tmp = 0; tmp < sizeof(SCB->SHP)/sizeof(SCB->SHP[0]); tmp++) {
 		SCB->SHP[tmp] = 0x00;
 	}
 

--- a/src/libs/MemoryPool.cpp
+++ b/src/libs/MemoryPool.cpp
@@ -27,11 +27,13 @@ static void fill_pattern32(void *dest, uint32_t pattern, size_t size);
 static bool check_pattern32(const void *src, uint32_t pattern, size_t size);
 // Function prototype for validate_pool_integrity needed earlier if called by inline funcs
 static bool validate_pool_integrity_internal(const MemoryPool *pool, bool check_free_pattern);
-#endif
 
+#else
 // Need check_pattern32 declaration outside the #if for the inline pool_check
-static bool check_pattern32(const void *src, uint32_t pattern, size_t size);
+static bool check_pattern32(const void *src, uint32_t pattern, size_t size) __attribute__((unused));
 
+static bool check_pattern32(const void *src, uint32_t pattern, size_t size) {return false;}
+#endif
 // --- Inline Debug/Utility Functions ---
 
 // Conditional printf

--- a/src/libs/USBDevice/MSCFileSystem.cpp
+++ b/src/libs/USBDevice/MSCFileSystem.cpp
@@ -175,5 +175,5 @@ void MSCFileSystem::on_get_public_data(void* argument)
 
 void MSCFileSystem::on_set_public_data(void* argument)
 {
-    PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
+    //PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
 }

--- a/src/libs/USBDevice/USBHostLite/usbhost_ms.cpp
+++ b/src/libs/USBDevice/USBHostLite/usbhost_ms.cpp
@@ -331,7 +331,7 @@ USB_INT32S  MS_BulkRecv (          USB_INT32U   block_number,
                          volatile  USB_INT08U  *user_buffer)
 {
     USB_INT32S  rc;
-    int i;
+    unsigned int i;
     volatile USB_INT08U *c = user_buffer;
     for (i=0;i<MS_BlkSize*num_blocks;i++)
         *c++ = 0;

--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -335,8 +335,8 @@ void check_and_make_path( std::string origin )
 {
 	size_t pos = 0;
     std::string dir;
-    int res;
-    int ret = 0;
+    //int res;
+    //int ret = 0;
 
     while ((pos = origin.find_first_of('/', pos)) != std::string::npos) {
         dir = origin.substr(0, pos++);

--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -153,7 +153,7 @@ string shift_parameter( string &parameters )
             }
             
             // Decode special characters
-            for (int i = 0; i < result.length(); i ++) {
+            for (unsigned int i = 0; i < result.length(); i ++) {
             	if (result[i] == 0x01) {
             		result[i] = ' ';
             	} else if (result[i] == 0x02) {
@@ -178,7 +178,7 @@ string shift_parameter( string &parameters )
     if ( beginning == string::npos ) {
         string temp = parameters;
         parameters = "";
-        for (int i = 0; i < temp.length(); i ++) {
+        for (unsigned int i = 0; i < temp.length(); i ++) {
         	if (temp[i] == 0x01) {
         		temp[i] = ' ';
         	} else if (temp[i] == 0x02) {
@@ -195,7 +195,7 @@ string shift_parameter( string &parameters )
     }
     string temp = parameters.substr( 0, beginning );
     parameters = parameters.substr(beginning + 1, parameters.size());
-    for (int i = 0; i < temp.length(); i ++) {
+    for (unsigned int i = 0; i < temp.length(); i ++) {
     	if (temp[i] == 0x01) {
     		temp[i] = ' ';
     	} else if (temp[i] == 0x02) {

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -257,7 +257,8 @@ try_again:
 
 						case 30: // end of program
 							if(!THEKERNEL->is_grbl_mode()) break; // Special case M30 as it is also delete sd card file so only do this if in grbl mode
-							// fall through to M2
+							// fall through to M2. Next line informs the compiler. Do not edit it
+							// fall through
 						case 2:
 							{
 								modal_group_1= 1; // set to G1

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -153,7 +153,7 @@ float Gcode::set_variable_value() const {
                 return value;
             }
             else{
-                this->stream->printf("Probe tip input out of range, aborting \n", var_num);
+                this->stream->printf("Probe tip input out of range, aborting \n");
                 return NAN;
             }
         } else if (var_num >= 501 && var_num <= 520) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -166,7 +166,7 @@ void Robot::on_module_loaded()
     }
 
     // init
-    for (int i = 0; i < 9UL; i++){
+    for (unsigned int i = 0; i < 9UL; i++){
         this->cos_r[i] = 1;
     }
    

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -639,7 +639,7 @@ void Robot::on_gcode_received(void *argument)
                     if(n == 0) n = current_wcs; // set current coordinate system
                     else --n;
                     if(n < MAX_WCS) {
-                        float delta_ref_mz = 0;
+                        //float delta_ref_mz = 0;
                         float x, y, z, a, b;
                         std::tie(x, y, z, a, b) = wcs_offsets[n];
                         wcs_t pos= mcs2selected_wcs(machine_position, n);

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -893,7 +893,8 @@ void Robot::on_gcode_received(void *argument)
 
             case 30: // M30 end of program in grbl mode (otherwise it is delete sdcard file)
                 if(!THEKERNEL->is_grbl_mode()) break;
-                // fall through to M2
+                // fall through to M2. Next line informs the compiler, do not edit
+                // fall through
             case 2: // M2 end of program
                 //current_wcs = 0;
                 absolute_mode = true;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1694,7 +1694,11 @@ bool Robot::append_milestone(const float target[], float feed_rate, unsigned int
     if(soft_endstop_enabled && !THEKERNEL->is_zprobing()) {
         for (int i = 0; i <= Z_AXIS; ++i) {
             if(!is_homed(i)) continue;
-            if( (!isnan(soft_endstop_min[i]) && transformed_target[i] < soft_endstop_min[i]) && deltas[i] < 0 || (!isnan(soft_endstop_max[i]) && transformed_target[i] > soft_endstop_max[i]) && deltas[i] > 0) {
+            if( 
+                ( (!isnan(soft_endstop_min[i]) && transformed_target[i] < soft_endstop_min[i]) && deltas[i] < 0 ) 
+                || 
+                ( (!isnan(soft_endstop_max[i]) && transformed_target[i] > soft_endstop_max[i]) && deltas[i] > 0 )
+            ) {
                 if(soft_endstop_halt && !THECONVEYOR->is_continuous_mode()) {
                     if(THEKERNEL->is_grbl_mode()) {
                         THEKERNEL->streams->printf("error:");

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -429,7 +429,7 @@ void ATCHandler::calibrate_set_value(Gcode *gcode)
 	} else{
 		float final_x = 0;
 		float final_y = 0;
-		float final_z = 0;
+		//float final_z = 0;
 		switch ((int)gcode->get_value('P')){
 			case 0:
 				//home off pin
@@ -850,7 +850,7 @@ void ATCHandler::fill_change_scripts(int new_tool, bool clear_z, int old_tool = 
 
 void ATCHandler::fill_manual_drop_scripts(int old_tool) {
 	char buff[100];
-	struct atc_tool *current_tool = &atc_tools[old_tool];
+	//struct atc_tool *current_tool = &atc_tools[old_tool];
 	// set atc status
 	this->script_queue.push("M497.1");
 	//make extra sure the spindle is off
@@ -886,7 +886,7 @@ void ATCHandler::fill_manual_drop_scripts(int old_tool) {
 
 void ATCHandler::fill_manual_pickup_scripts(int new_tool, bool clear_z, bool auto_calibrate = false, float custom_TLO = NAN) {
 	char buff[100];
-	struct atc_tool *current_tool = &atc_tools[new_tool];
+	//struct atc_tool *current_tool = &atc_tools[new_tool];
 	// set atc status
 	this->script_queue.push("M497.2");
 	// lift z to safe position with fast speed

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -911,7 +911,7 @@ void ATCHandler::fill_manual_pickup_scripts(int new_tool, bool clear_z, bool aut
 
 	if (auto_calibrate){
 		//print status
-		snprintf(buff, sizeof(buff), ";Tool is now installed.\nRemove hands from the machine\nResume will auto calibrate the tool and continue program\n");
+		snprintf(buff, sizeof(buff), ";Tool is now installed.\nRemove hands from the machine\nResume will auto calibrate and continue\n");
 		this->script_queue.push(buff);
 		//pause
 		snprintf(buff, sizeof(buff), "M600.5");

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1846,7 +1846,7 @@ void ATCHandler::set_tool_offset()
 
 void ATCHandler::set_tlo_by_offset(float z_axis_offset){
 	// new TLO = Current TLO - (current WCS - z_axis_offset)
-	float mpos[3];
+	float mpos[THEROBOT->get_number_registered_motors()] = {0};
 	Robot::wcs_t pos;
 	THEROBOT->get_current_machine_position(mpos);
 	// current_position/mpos includes the compensation transform so we need to get the inverse to get actual position

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -789,7 +789,7 @@ void ATCHandler::home_machine_with_pin(Gcode *gcode)//M469
 
 
 
-void ATCHandler::fill_change_scripts(int new_tool, bool clear_z, int old_tool = NAN, bool wait_after_empty = false, float custom_TLO = NAN) {
+void ATCHandler::fill_change_scripts(int new_tool, bool clear_z, int old_tool = -1, bool wait_after_empty = false, float custom_TLO = NAN) {
 	char buff[100];
 
 	// move to tool change position
@@ -803,7 +803,7 @@ void ATCHandler::fill_change_scripts(int new_tool, bool clear_z, int old_tool = 
 	this->script_queue.push("M497.2");
 
 	if (THEKERNEL->factory_set->FuncSetting & (1<<2)){
-		if (!isnan(old_tool) && old_tool != -1){
+		if (old_tool != -1){
 			// Enter tool changing waiting status
 			this->script_queue.push("M490.3");
 		}

--- a/src/modules/tools/drillingcycles/Drillingcycles.cpp
+++ b/src/modules/tools/drillingcycles/Drillingcycles.cpp
@@ -212,7 +212,7 @@ void Drillingcycles::on_gcode_received(void* argument)
         // wait for any moves left and current position is update
         THEKERNEL->conveyor->wait_for_idle();
         // get actual position from robot
-        float pos[5];
+        float pos[5] = {};
         THEROBOT->get_axis_position(pos);
         // convert to WCS
         Robot::wcs_t wpos= THEROBOT->mcs2wcs(pos);

--- a/src/modules/tools/drillingcycles/Drillingcycles.cpp
+++ b/src/modules/tools/drillingcycles/Drillingcycles.cpp
@@ -212,7 +212,7 @@ void Drillingcycles::on_gcode_received(void* argument)
         // wait for any moves left and current position is update
         THEKERNEL->conveyor->wait_for_idle();
         // get actual position from robot
-        float pos[3];
+        float pos[5];
         THEROBOT->get_axis_position(pos);
         // convert to WCS
         Robot::wcs_t wpos= THEROBOT->mcs2wcs(pos);

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -1547,7 +1547,7 @@ void Endstops::on_get_public_data(void* argument)
         *cover_state = this->cover_endstop_pin.get();
         pdr->set_taken();
     } else if (pdr->second_element_is(get_endstopAB_states_checksum)) {
-    	int index = 0;
+    	//int index = 0;
         char *data = static_cast<char *>(pdr->get_data_ptr());
         Pin motor_alarm_pin;
         motor_alarm_pin.from_string("1.16");
@@ -1556,7 +1556,7 @@ void Endstops::on_get_public_data(void* argument)
         
         pdr->set_taken();
     }else if (pdr->second_element_is(get_check_4th_checksum)) {
-    	int index = 0;
+    	//int index = 0;
         char *data = static_cast<char *>(pdr->get_data_ptr());
         check_4th(data);
         pdr->set_taken();

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -411,7 +411,7 @@ bool CartGridStrategy::load_grid(StreamOutput *stream)
     y_size = y;
 
     // keep track of worst case delta
-    float max_delta, max_z, min_z;
+    float max_delta = 0, max_z = grid[0], min_z = grid[0]; //initilize to sane values
 
     for (int y = 0; y < current_grid_y_size; y++) {
         for (int x = 0; x < current_grid_x_size; x++) {

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -1129,7 +1129,7 @@ float ZProbe::get_xyz_move_length(float x, float y, float z){
 bool ZProbe::fast_slow_probe_sequence(int axis, int direction){
     float moveBuffer[3];
     float mpos[3];
-    float old_mpos[3];
+    //float old_mpos[3];
     float retract_direction = 0;
     float x = 0;
     float y = 0;
@@ -1384,7 +1384,7 @@ void ZProbe::probe_bore(bool calibration) //M461
     THEKERNEL->streams->printf("Probing Bore/Rectangular Pocket\n");
 
     float mpos[3];
-    float old_mpos[3];
+    //float old_mpos[3];
 
     if (calibration){
         param.tool_dia = 0;
@@ -1492,7 +1492,7 @@ void ZProbe::probe_boss(bool calibration) //M462
     THEKERNEL->streams->printf("Probing Boss or Rectangular Block\n");
     
     float mpos[3];
-    float old_mpos[3];
+    //float old_mpos[3];
     bool probe_x_axis = false;
     bool probe_y_axis = false;
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -770,7 +770,8 @@ void ZProbe::on_gcode_received(void *argument)
                 gcode->stream->printf(";Probe feedrates Slow/fast(K)/Return (mm/sec) max_z (mm) height (mm) dwell (s):\nM670 S%1.2f K%1.2f R%1.2f Z%1.2f H%1.2f D%1.2f\n",
                     this->slow_feedrate, this->fast_feedrate, this->return_feedrate, this->max_z, this->probe_height, this->dwell_before_probing);
 
-                // fall through is intended so leveling strategies can handle m-codes too
+                // fall through is intended so leveling strategies can handle m-codes too. Next line informs the compiler, do not edit it
+                // fall through
 
             default:
                 for(auto s : strategies){

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -512,6 +512,8 @@ uint32_t MainButton::button_tick(uint32_t dummy)
 								this->set_led_num(0,0,0,0,0,0,0, true);
 							}
 							break;
+						} else{
+							break;
 						}
 						
 					case ALARM:

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -297,7 +297,7 @@ void MainButton::on_idle(void *argument)
 	    			}
 					else if(this->long_press_enable == "ToolChange" && !THEKERNEL->is_tool_waiting()) {
 						uint8_t atc_clamp_status;
-						uint8_t old_state = state;
+						//uint8_t old_state = state;
 						THEKERNEL->set_tool_waiting(true);
 
 						PublicData::get_value(atc_handler_checksum, get_atc_clamped_status_checksum, 0, &atc_clamp_status);

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -1298,7 +1298,7 @@ int Player::decompress(string sfilename, string dfilename, uint32_t sfilesize, S
 			k=0;
 			THEKERNEL->call_event(ON_IDLE);
 			memset(fbuff, 0, sizeof(fbuff));
-			sprintf((char*)fbuff, "#Info: decompart = %u\r\n", u32BlockNum);
+			sprintf((char*)fbuff, "#Info: decompart = %lu\r\n", u32BlockNum);
 			stream->printf((char*)fbuff);
 		}
 	}
@@ -1313,7 +1313,7 @@ int Player::decompress(string sfilename, string dfilename, uint32_t sfilesize, S
 	if (f_out!= NULL)
 		fclose(f_out);
 	memset(fbuff, 0, sizeof(fbuff));
-	sprintf((char*)fbuff, "#Info: decompart = %u\r\n", u32BlockNum);
+	sprintf((char*)fbuff, "#Info: decompart = %lu\r\n", u32BlockNum);
 	stream->printf((char*)fbuff);
 	return 1;
 _exit:

--- a/src/modules/utils/player/quicklz.c
+++ b/src/modules/utils/player/quicklz.c
@@ -108,7 +108,7 @@ static __inline ui32 hash_func(ui32 i)
 static __inline ui32 fast_read(void const *src, ui32 bytes)
 {
 #ifndef X86X64
-    unsigned char *p = (unsigned char *)src;
+    const unsigned char *p = (const unsigned char *)src;
     switch(bytes)
     {
         case 4:

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -832,6 +832,7 @@ void SimpleShell::mem_command( string parameters, StreamOutput *stream)
     stream->printf("Block size: %u bytes, Tickinfo size: %u bytes\n", sizeof(Block), sizeof(Block::tickinfo_t) * Block::n_actuators);
 }
 
+/*
 static uint32_t getDeviceType()
 {
 #define IAP_LOCATION 0x1FFF1FF1
@@ -849,7 +850,7 @@ static uint32_t getDeviceType()
 
     return result[1];
 }
-
+*/
 
 // get network config
 void SimpleShell::time_command( string parameters, StreamOutput *stream)
@@ -2078,7 +2079,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
     }
 
     bool cont_mode= false;
-    bool send_ok= false;
+    //bool send_ok= false;
     while(!parameters.empty()) {
         string p= shift_parameter(parameters);
 
@@ -2089,7 +2090,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
                     cont_mode= true;
                     break;
                 case 'R': // send ok when done use this when sending $J in a gcode file
-                    send_ok= true;
+                    //send_ok= true;
                     break;
                 default:
                     stream->printf("error:illegal option %c\n", p[1]);
@@ -2175,8 +2176,8 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
 
     float dist_to_min[3] ={0,0,0};
     float dist_to_max[3] ={0,0,0};
-    int min_axis = 0;
-    int max_axis = 0;
+    //int min_axis = 0;
+    //int max_axis = 0;
 
     float min_time= 0.05;
     if(cont_mode) {
@@ -2297,7 +2298,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
 
         this->keep_alive_time = us_ticker_read() / 1000;
         uint32_t block_interval_ms = (uint32_t)((ta + 0.5 *min_time) * 1000.0f);
-        float time_start_to_end_block = 0;
+        //float time_start_to_end_block = 0;
         int stage = 0;
         THECONVEYOR->set_continuous_mode(true);
 
@@ -2339,7 +2340,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
                 
                 THEROBOT->delta_move(delta_const, fr, n_motors);
                 if(stage == 0) {
-                    time_start_to_end_block = current_time - last_block_time;
+                    //time_start_to_end_block = current_time - last_block_time;
                     block_interval_ms = (uint32_t)((min_time) * 1000.0f);
                     stage++;
                 }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -877,7 +877,7 @@ void SimpleShell::time_command( string parameters, StreamOutput *stream)
     	set_time(new_time);
     } else {
     	time_t old_time = time(NULL);
-    	stream->printf("time = %ld\n", old_time);
+    	stream->printf("time = %lld\n", old_time);
     }
 }
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1376,7 +1376,7 @@ void SimpleShell::test_led_command( string parameters, StreamOutput *stream )
 // set factory settings
 void SimpleShell::fset_command( string parameters, StreamOutput *stream)
 {
-	uint8_t channel;
+	//uint8_t channel;
 	char buff[32];
 	memset(buff, 0, sizeof(buff));
     if (!parameters.empty() ) {
@@ -2441,7 +2441,7 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
 
 void SimpleShell::spindle_override(string parameters, StreamOutput *stream) //M223 SXXX equivalent
 {
-    bool send_ok = false;
+    //bool send_ok = false;
     // $S is first parameter
     shift_parameter(parameters);
     if(parameters.empty()) {
@@ -2480,7 +2480,7 @@ void SimpleShell::spindle_override(string parameters, StreamOutput *stream) //M2
 
 void SimpleShell::feed_override(string parameters, StreamOutput *stream) //M220 SXXX equivalent
 {
-    bool send_ok = false;
+    //bool send_ok = false;
     // $S is first parameter
     shift_parameter(parameters);
     if(parameters.empty()) {

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -206,10 +206,12 @@ void WifiProvider::int_to_ip(uint32_t i_ip, char *ip_addr, size_t buffer_size) {
 	snprintf(ip_addr, buffer_size, "%d.%d.%d.%d", bytes[3], bytes[2], bytes[1], bytes[0]);
 }
 
-uint32_t WifiProvider::ip_to_int(char* ip_addr) {
-  unsigned char bytes[4];
-  sscanf(ip_addr, "%u.%u.%u.%u", &bytes[0], &bytes[1], &bytes[2], &bytes[3]);
-  return bytes[0] * 16777216 + bytes[1] * 65536 + bytes[2] * 256 + bytes[3];
+uint32_t WifiProvider::ip_to_int(const char* ip_addr) {
+    unsigned int bytes[4];
+    if (sscanf(ip_addr, "%u.%u.%u.%u", &bytes[0], &bytes[1], &bytes[2], &bytes[3]) != 4) {
+        return 0;
+    }
+    return (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
 }
 
 void WifiProvider::on_second_tick(void *)

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -55,7 +55,7 @@ private:
     void init_wifi_module(bool reset);
     void query_wifi_status();
 
-    uint32_t ip_to_int(char* ip_addr);
+    uint32_t ip_to_int(const char* ip_addr);
     void int_to_ip(uint32_t i_ip, char *ip_addr, size_t buffer_size);
     void get_broadcast_from_ip_and_netmask(char *broadcast_addr, size_t broadcast_buffer_size, char *ip_addr, char *netmask);
 

--- a/version.txt
+++ b/version.txt
@@ -4,6 +4,7 @@
 - Fixed: fixing type mismatch bug in wifiprovider that could lead to a memory overflow
 - Fixed: Removed possible memory overflow with get_current machine position writing past mpos
 - Fixed: Overly long strings in some zprobe print commands 
+- Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.

--- a/version.txt
+++ b/version.txt
@@ -10,6 +10,7 @@
 - Fixed: added // fall through to switch statements when it is intended to remove console error
 - Fixed: initialize sane values in probe grid max delta calculation
 - Fixed: writing past the end of a buffer in Drillingcycles::on_gcode_received
+- Fixed: int declared as NAN in ATCHandler::fill_change_scripts, fixed by setting to -1 and updating code accordingly
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,9 @@
 [Unreleased]
 - Fixed: Unused Variables removed
+- Fixed: Removing unused code blocks in simpleshell
+- Fixed: fixing type mismatch bug in wifiprovider that could lead to a memory overflow
+- Fixed: Removed possible memory overflow with get_current machine position writing past mpos
+- Fixed: Overly long strings in some zprobe print commands 
 
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.

--- a/version.txt
+++ b/version.txt
@@ -9,6 +9,7 @@
 - Fixed: type mismatch in print string in decompress function in player.cpp
 - Fixed: added // fall through to switch statements when it is intended to remove console error
 - Fixed: initialize sane values in probe grid max delta calculation
+- Fixed: writing past the end of a buffer in Drillingcycles::on_gcode_received
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -8,6 +8,7 @@
 - Fixed: Type mismatch in time command.
 - Fixed: type mismatch in print string in decompress function in player.cpp
 - Fixed: added // fall through to switch statements when it is intended to remove console error
+- Fixed: initialize sane values in probe grid max delta calculation
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,6 @@
+[Unreleased]
+- Fixed: Unused Variables removed
+
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.
 - Enhancement: Tool setter sensor location can now be configured separately. Use config items coordinate.probe_mcs_x coordinate.probe_mcs_y and coordinate.probe_mcs_z. If unset, the original hardcoded values will be used.

--- a/version.txt
+++ b/version.txt
@@ -11,6 +11,7 @@
 - Fixed: initialize sane values in probe grid max delta calculation
 - Fixed: writing past the end of a buffer in Drillingcycles::on_gcode_received
 - Fixed: int declared as NAN in ATCHandler::fill_change_scripts, fixed by setting to -1 and updating code accordingly
+- Fixed: comparison of integer expressions of different signedness
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -4,6 +4,7 @@
 - Fixed: fixing type mismatch bug in wifiprovider that could lead to a memory overflow
 - Fixed: Removed possible memory overflow with get_current machine position writing past mpos
 - Fixed: Overly long strings in some zprobe print commands 
+- Fixed: remove extra parameter in print string in ZProbe
 - Fixed: Type mismatch in time command.
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 

--- a/version.txt
+++ b/version.txt
@@ -6,6 +6,7 @@
 - Fixed: Overly long strings in some zprobe print commands 
 - Fixed: remove extra parameter in print string in ZProbe
 - Fixed: Type mismatch in time command.
+- Fixed: type mismatch in print string in decompress function in player.cpp
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -7,6 +7,7 @@
 - Fixed: remove extra parameter in print string in ZProbe
 - Fixed: Type mismatch in time command.
 - Fixed: type mismatch in print string in decompress function in player.cpp
+- Fixed: added // fall through to switch statements when it is intended to remove console error
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -4,6 +4,7 @@
 - Fixed: fixing type mismatch bug in wifiprovider that could lead to a memory overflow
 - Fixed: Removed possible memory overflow with get_current machine position writing past mpos
 - Fixed: Overly long strings in some zprobe print commands 
+- Fixed: Type mismatch in time command.
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 
 [2.1.0c-RC1]

--- a/version.txt
+++ b/version.txt
@@ -13,6 +13,7 @@
 - Fixed: int declared as NAN in ATCHandler::fill_change_scripts, fixed by setting to -1 and updating code accordingly
 - Fixed: comparison of integer expressions of different signedness
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
+- Change: removed register specifiers in LPC1768 and mbded libraries used by the project. register has been depreciated for a long time and now falls back to being completely ignored. Looked for library updates first, they haven't been updated.
 
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.

--- a/version.txt
+++ b/version.txt
@@ -12,6 +12,7 @@
 - Fixed: writing past the end of a buffer in Drillingcycles::on_gcode_received
 - Fixed: int declared as NAN in ATCHandler::fill_change_scripts, fixed by setting to -1 and updating code accordingly
 - Fixed: comparison of integer expressions of different signedness
+- Fixed: wait_us could run into issues if the value given is less than zero. Now ignores times less than 0
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 - Change: removed register specifiers in LPC1768 and mbded libraries used by the project. register has been depreciated for a long time and now falls back to being completely ignored. Looked for library updates first, they haven't been updated.
 


### PR DESCRIPTION
- Fixed: Unused Variables removed
- Fixed: Removing unused code blocks in simpleshell
- Fixed: fixing type mismatch bug in wifiprovider that could lead to a memory overflow
- Fixed: Removed possible memory overflow with get_current machine position writing past mpos
- Fixed: Overly long strings in some zprobe print commands 
- Fixed: remove extra parameter in print string in ZProbe
- Fixed: Type mismatch in time command.
- Fixed: type mismatch in print string in decompress function in player.cpp
- Fixed: added // fall through to switch statements when it is intended to remove console error
- Fixed: initialize sane values in probe grid max delta calculation
- Fixed: writing past the end of a buffer in Drillingcycles::on_gcode_received
- Fixed: int declared as NAN in ATCHandler::fill_change_scripts, fixed by setting to -1 and updating code accordingly
- Fixed: comparison of integer expressions of different signedness
- Fixed: wait_us could run into issues if the value given is less than zero. Now ignores times less than 0
- Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
- Change: removed register specifiers in LPC1768 and mbded libraries used by the project. register has been depreciated for a long time and now falls back to being completely ignored. Looked for library updates first, they haven't been updated.
