### PR TITLE
Disable toolsesnor

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -441,6 +441,7 @@ atc.homing_retract_mm 0.4 				# Retract distance after homing (mm)
 atc.action_mm 1.6					 	# Action distance when drop tool (mm)
 atc.detector.detect_rate_mm_s 20		# Tool detect speed (mm / second)	
 atc.detector.detect_travel_mm 5	        # Tool detect back and forth distance (mm)
+atc.detector.enable true				# Enable or disable the toolsensor
 
 atc.safe_z_mm -20.0						# Safety Z height when clamping tool
 atc.safe_z_empty_mm -50.0				# Safety Z height when not clamping tool

--- a/src/config2.default
+++ b/src/config2.default
@@ -463,6 +463,7 @@ atc.homing_retract_mm 0					# Retract distance after homing (mm)
 atc.action_mm 70					 	# Action distance when drop tool (mm)
 atc.detector.detect_rate_mm_s 20		# Tool detect speed (mm / second)	
 atc.detector.detect_travel_mm 5	        # Tool detect back and forth distance (mm)
+atc.detector.enable true				# Enable or disable the toolsensor
 
 atc.safe_z_mm -20.0						# Safety Z height when clamping tool
 atc.safe_z_empty_mm -40.0				# Safety Z height when not clamping tool

--- a/src/libs/ConfigSource.h
+++ b/src/libs/ConfigSource.h
@@ -23,6 +23,7 @@ class ConfigSource {
         virtual bool is_named( uint16_t check_sum ) = 0;
         virtual bool write( std::string setting, std::string value ) = 0;
         virtual std::string read( uint16_t check_sums[3] ) = 0;
+        virtual bool remove( std::string setting ) { return false; }
 
     protected:
         virtual ConfigValue* process_line_from_ascii_config(const std::string& line, ConfigCache* cache);

--- a/src/libs/ConfigSources/FileConfigSource.cpp
+++ b/src/libs/ConfigSources/FileConfigSource.cpp
@@ -181,6 +181,63 @@ bool FileConfigSource::write( string setting, string value )
     return true;
 }
 
+// Remove a config setting from the file (delete the line)
+bool FileConfigSource::remove( string setting )
+{
+    if( !this->has_config_file() ) {
+        return false;
+    }
+
+    uint16_t setting_checksums[3];
+    get_checksums(setting_checksums, setting );
+
+    string config_path = this->get_config_file();
+    string tmp_path = config_path + ".tmp";
+
+    FILE *fp = fopen(config_path.c_str(), "r");
+    if( fp == nullptr ) {
+        return false;
+    }
+
+    FILE *tp = fopen(tmp_path.c_str(), "w");
+    if( tp == nullptr ) {
+        fclose(fp);
+        return false;
+    }
+
+    bool found = false;
+    int ln = 0;
+    while(!feof(fp)) {
+        string line;
+        if(readLine(line, ln++, fp)) {
+            if(!process_line_from_ascii_config(line, setting_checksums).empty()) {
+                found = true;
+                continue;  // skip this line (delete it)
+            }
+            fputs(line.c_str(), tp);
+        } else {
+            break;
+        }
+    }
+
+    fclose(fp);
+    fclose(tp);
+
+    if(!found) {
+        ::remove(tmp_path.c_str());
+        return false;
+    }
+
+    if(::remove(config_path.c_str()) != 0) {
+        ::remove(tmp_path.c_str());
+        return false;
+    }
+    if(rename(tmp_path.c_str(), config_path.c_str()) != 0) {
+        return false;
+    }
+    return true;
+}
+
 // Return the value for a specific checksum
 string FileConfigSource::read( uint16_t check_sums[3] )
 {

--- a/src/libs/ConfigSources/FileConfigSource.h
+++ b/src/libs/ConfigSources/FileConfigSource.h
@@ -24,6 +24,7 @@ public:
     void transfer_values_to_cache( ConfigCache *cache, const char * file_name );
     bool is_named( uint16_t check_sum );
     bool write( string setting, string value );
+    bool remove( string setting );
     string read( uint16_t check_sums[3] );
     bool has_config_file();
     void try_config_file(string candidate);

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -44,6 +44,7 @@
 #define STEPPER THEROBOT->actuators
 // #define STEPS_PER_MM(a) (STEPPER[a]->get_steps_per_mm())
 
+#define enable_checksum             CHECKSUM("enable")
 #define atc_checksum            	CHECKSUM("atc")
 #define probe_checksum            	CHECKSUM("probe")
 #define endstop_pin_checksum      	CHECKSUM("homing_endstop_pin")
@@ -1424,6 +1425,7 @@ void ATCHandler::on_config_reload(void *argument)
 	detector_info.detect_pin.from_string( THEKERNEL->config->value(atc_checksum, detector_checksum, detect_pin_checksum)->by_default("0.20^" )->as_string())->as_input();
 	detector_info.detect_rate = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_rate_mm_s_checksum)->by_default(1  )->as_number();
 	detector_info.detect_travel = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_travel_mm_checksum)->by_default(1  )->as_number();
+	this->disable_toolsensor = !THEKERNEL->config->value(atc_checksum, detector_checksum, enable_checksum)->by_default(true)->as_bool();
 
 	this->safe_z_mm = THEKERNEL->config->value(atc_checksum, safe_z_checksum)->by_default(-10)->as_number();
 	this->safe_z_empty_mm = THEKERNEL->config->value(atc_checksum, safe_z_empty_checksum)->by_default(-20)->as_number();
@@ -1836,7 +1838,7 @@ void ATCHandler::loose_tool()
 	THEKERNEL->streams->printf("ATC loosed!\r\n");
 }
 
-void ATCHandler::set_tool_offset(int repeat_count)
+void ATCHandler::set_tool_offset(uint8_t repeat_count)
 {
     float px, py, pz;
     uint8_t ps;
@@ -2316,7 +2318,7 @@ void ATCHandler::on_gcode_received(void *argument)
 				this->probe_oneoff_y = 0.0;
 				this->probe_oneoff_z = 0.0;
 				this->probe_oneoff_configured = false;
-				int repeat_count = 1;
+				uint8_t repeat_count = 1;
 				if (gcode->has_letter('R')) {
 					if (gcode->get_value('R') > 0) {
 						repeat_count = gcode->get_value('R');
@@ -2351,14 +2353,14 @@ void ATCHandler::on_gcode_received(void *argument)
 		} else if (gcode->m == 492) {
 			if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
 			{
-				if (gcode->subcode == 0 || gcode->subcode == 1) {
+				if ((gcode->subcode == 0 || gcode->subcode == 1) && !this->disable_toolsensor) {
 					// check true
-					if (!laser_detect() && CARVERA == THEKERNEL->factory_set->MachineModel) {
+					if (!laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
 				        THEKERNEL->call_event(ON_HALT, nullptr);
 				        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
 					}
-				} else if (gcode->subcode == 2) {
+				} else if ((gcode->subcode == 2) && !this->disable_toolsensor) {
 					// check false
 					if (laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -85,7 +85,7 @@ private:
     void abort();
 
     // set tool offset afteer calibrating
-    void set_tool_offset(int repeat_count = 1);
+    void set_tool_offset(uint8_t repeat_count = 1);
 
     //
     void fill_change_scripts(int new_tool, bool clear_z, int old_tool, bool wait_after_empty, float custom_TLO);
@@ -130,6 +130,7 @@ private:
     uint16_t debounce;
     bool atc_homing;
     bool detecting;
+    bool disable_toolsensor;
 
     bool playing_file;
     bool g28_triggered;
@@ -282,7 +283,7 @@ private:
     float ref_tool_mz;
     float cur_tool_mz;
     float tool_offset;
-    const int max_tl_mcz_values = 5;
+    const uint8_t max_tl_mcz_values = 5;
     deque<float> tl_mcz_values = deque<float>(max_tl_mcz_values, 0.0f);
     int beep_state;
     int beep_count;

--- a/src/modules/utils/configurator/Configurator.cpp
+++ b/src/modules/utils/configurator/Configurator.cpp
@@ -91,20 +91,30 @@ void Configurator::config_set_command( string parameters, StreamOutput *stream )
         }
     }
     stream->printf( "%s source does not exist\r\n", source.c_str());
+}
 
+// Delete the specified setting from the specified ConfigSource (file only; removes the line from config.txt)
+void Configurator::config_delete_command( string parameters, StreamOutput *stream )
+{
+    string source = shift_parameter(parameters);
+    string setting = shift_parameter(parameters);
+    if(source.empty() || setting.empty()) {
+        stream->printf( "Usage: config-delete source setting # where source is sd (or local), setting is the key to remove\r\n" );
+        return;
+    }
 
-    /* Live setting not really supported anymore as the cache is never left loaded
-        if (value == "") {
-            if(!THEKERNEL->config->config_cache_loaded) {
-                stream->printf( "live: setting not allowed as config cache is not loaded\r\n" );
-                return;
+    uint16_t source_checksum = get_checksum(source);
+    for(unsigned int i = 0; i < THEKERNEL->config->config_sources.size(); i++) {
+        if( THEKERNEL->config->config_sources[i]->is_named(source_checksum) ) {
+            if(THEKERNEL->config->config_sources[i]->remove(setting)) {
+                stream->printf( "%s: %s has been removed\r\n", source.c_str(), setting.c_str() );
+            } else {
+                stream->printf( "%s: %s not found or source is read-only\r\n", source.c_str(), setting.c_str() );
             }
-            value = setting;
-            setting = source;
-            source = "";
-            THEKERNEL->config->set_string(setting, value);
-            stream->printf( "live: %s has been set to %s\r\n", setting.c_str(), value.c_str() );
-    */
+            return;
+        }
+    }
+    stream->printf( "%s source does not exist\r\n", source.c_str());
 }
 
 // Reload config values from the specified ConfigSource, NOTE used for debugging by dumping the config-cache

--- a/src/modules/utils/configurator/Configurator.h
+++ b/src/modules/utils/configurator/Configurator.h
@@ -21,6 +21,7 @@ public:
 
     void config_get_command( string parameters, StreamOutput *stream );
     void config_set_command( string parameters, StreamOutput *stream );
+    void config_delete_command( string parameters, StreamOutput *stream );
     void config_load_command(string parameters, StreamOutput *stream );
 };
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -386,6 +386,9 @@ void SimpleShell::on_console_line_received( void *argument )
         } else if (cmd == "config-set"){
             THEKERNEL->configurator->config_set_command(  possible_command, new_message.stream );
 
+        } else if (cmd == "config-delete"){
+            THEKERNEL->configurator->config_delete_command(  possible_command, new_message.stream );
+
         } else if (cmd == "config-load"){
             THEKERNEL->configurator->config_load_command(  possible_command, new_message.stream );
 
@@ -2534,6 +2537,7 @@ void SimpleShell::help_command( string parameters, StreamOutput *stream )
     stream->printf("break - break into debugger\r\n");
     stream->printf("config-get [<configuration_source>] <configuration_setting>\r\n");
     stream->printf("config-set [<configuration_source>] <configuration_setting> <value>\r\n");
+    stream->printf("config-delete [<configuration_source>] <configuration_setting>\r\n");
     stream->printf("get [pos|wcs|state|status|fk|ik]\r\n");
     stream->printf("get temp [bed|hotend]\r\n");
     stream->printf("set_temp bed|hotend 185\r\n");

--- a/version.txt
+++ b/version.txt
@@ -18,6 +18,7 @@
 - Enhancement: New config setting "zprobe.three_axis_probe_tlo_correction" allows the user to correct for tlo measurement inaccuracies
 - Enhancement: New "R" Parameter for M491 to repeat TLO measurement and find the lowest cutting edge on a facemill. The user has to rotate the face mill between cycles
 - Enhancement: New "config-delete sd <key>" command that allows to delete a config setting from the config.txt. It's intended to be used when cleaning up the config.txt or when config keys got misspelled.
+- Enhancement: New config setting "atc.detector.enable" allows to disable the tool laser sensor.
 
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.

--- a/version.txt
+++ b/version.txt
@@ -17,6 +17,7 @@
 - Change: removed register specifiers in LPC1768 and mbded libraries used by the project. register has been depreciated for a long time and now falls back to being completely ignored. Looked for library updates first, they haven't been updated.
 - Enhancement: New config setting "zprobe.three_axis_probe_tlo_correction" allows the user to correct for tlo measurement inaccuracies
 - Enhancement: New "R" Parameter for M491 to repeat TLO measurement and find the lowest cutting edge on a facemill. The user has to rotate the face mill between cycles
+- Enhancement: New "config-delete sd <key>" command that allows to delete a config setting from the config.txt. It's intended to be used when cleaning up the config.txt or when config keys got misspelled.
 
 [2.1.0c-RC1]
 - Enhancement: Move G0 at the configured default_seek_rate configured, defaulting to 3000mm/min, unless a Feed parameter is provided. This returns G0 being a rapid movement command.


### PR DESCRIPTION
New setting "atc.detector.enable" allows to disable the toolsensor. This can be handy if the toolsensor breaks and the ATC still needs to be used. It's also useful for people trying the ATC mod on the Air without the toolsensor first.

Even when people position an ATC in places, where a toolsensor can't be used, it can be disabled with the setting