### PR TITLE
Ext out failsafe

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -143,6 +143,7 @@ switch.spindlefan.input_on_command			M811			# Command that will turn this switch
 switch.spindlefan.input_off_command			M812			# Command that will turn this switch off
 switch.spindlefan.output_pin				2.1				# Pin this module controls
 switch.spindlefan.output_type				hwpwm			# Digital means this is just an on or off pin
+switch.spindlefan.failsafe					1				# 
 switch.spindlefan.default_on_value			50				#
 
 switch.light.enable							true			# Enable this module

--- a/src/config2.default
+++ b/src/config2.default
@@ -133,6 +133,7 @@ switch.powerfan.input_on_command			M801			# Command that will turn this switch o
 switch.powerfan.input_off_command			M802			# Command that will turn this switch off
 switch.powerfan.output_pin					2.3			# Pin this module controls
 switch.powerfan.output_type					hwpwm			# Digital means this is just an on or off pin
+switch.powerfan.failsafe					1				#
 switch.powerfan.default_on_value			30				#
 
 switch.spindlefan.enable					true			# Enable this module
@@ -140,6 +141,7 @@ switch.spindlefan.input_on_command			M811			# Command that will turn this switch
 switch.spindlefan.input_off_command			M812			# Command that will turn this switch off
 switch.spindlefan.output_pin				2.1				# Pin this module controls
 switch.spindlefan.output_type				hwpwm			# Digital means this is just an on or off pin
+switch.spindlefan.failsafe					1				# 
 switch.spindlefan.default_on_value			50				#
 
 switch.light.enable							true			# Enable this module

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -70,7 +70,14 @@ void Switch::on_halt(void *arg)
         switch(this->output_type) {
             case DIGITAL: this->digital_pin->set(this->failsafe); break;
             case SIGMADELTA: this->sigmadelta_pin->set(this->failsafe); break;
-            case HWPWM: this->pwm_pin->write(switch_value / 100.0F); break;
+            case HWPWM: 
+                if (this->failsafe == 1){
+                    this->pwm_pin->write(switch_value / 100.0F);
+                }
+                else{
+                    this->pwm_pin->write(0 / 100.0F);
+                }
+                break;
             case SWPWM: this->swpwm_pin->write(switch_value / 100.0F); break;
             case DIGITALPWM: this->digital_pin->set(this->failsafe); break;
             case NONE: return;

--- a/version.txt
+++ b/version.txt
@@ -19,6 +19,7 @@
 - Fixed: Clamping the spindle rpm to the max rpm fixed
 - Change: added -Slow parameter to windows powershell build script to improve readability of error logs as the cost of speed.
 - Change: removed register specifiers in LPC1768 and mbded libraries used by the project. register has been depreciated for a long time and now falls back to being completely ignored. Looked for library updates first, they haven't been updated.
+- Change: Ext out on the CA1 and extend on C1 will turn off on halt (can be reverted to previous behaviour with config-set sd switch.extendout.failsafe 1)
 - Enhancement: New config setting "zprobe.three_axis_probe_tlo_correction" allows the user to correct for tlo measurement inaccuracies
 - Enhancement: New "R" Parameter for M491 and M6 to repeat TLO measurement and find the lowest cutting edge on a facemill. The user has to rotate the face mill between cycles
 - Enhancement: New "config-delete sd <key>" command that allows to delete a config setting from the config.txt. It's intended to be used when cleaning up the config.txt or when config keys got misspelled.


### PR DESCRIPTION
Extendout on the Air will turn off now during a halt.
Can be reverted to stock behaviour with: config-set sd switch.extendout.failsafe 1