### PR TITLE
AnalogSpindle uplift

### DIFF
--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -13,7 +13,14 @@
 #include "checksumm.h"
 #include "ConfigValue.h"
 #include "StreamOutputPool.h"
+#include "SlowTicker.h"
+#include "PublicDataRequest.h"
+#include "SpindlePublicAccess.h"
 #include "PwmOut.h"
+#include "InterruptIn.h"
+#include "port_api.h"
+#include "system_LPC17xx.h"
+#include "us_ticker_api.h"
 
 #define spindle_checksum                    CHECKSUM("spindle")
 #define spindle_max_rpm_checksum            CHECKSUM("max_rpm")
@@ -21,16 +28,39 @@
 #define spindle_pwm_pin_checksum            CHECKSUM("pwm_pin")
 #define spindle_pwm_period_checksum         CHECKSUM("pwm_period")
 #define spindle_switch_on_pin_checksum      CHECKSUM("switch_on_pin")
+#define spindle_feedback_pin_checksum       CHECKSUM("feedback_pin")
+#define spindle_pulses_per_rev_checksum     CHECKSUM("pulses_per_rev")
+#define spindle_control_smoothing_checksum  CHECKSUM("control_smoothing")
+#define spindle_acc_ratio_checksum          CHECKSUM("acc_ratio")
+#define spindle_alarm_pin_checksum          CHECKSUM("alarm_pin")
+
+#define UPDATE_FREQ 100
 
 void AnalogSpindleControl::on_module_loaded()
 {
-
     spindle_on = false;
     target_rpm = 0;
+    current_rpm = 0;
+    current_pwm_value = 0;
+    factor = 100;
+    irq_count = 0;
+    last_rev_time = 0;
+    rev_time = 0;
+    time_since_update = 0;
+
     min_rpm = THEKERNEL->config->value(spindle_checksum, spindle_min_rpm_checksum)->by_default(100)->as_int();
     max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(5000)->as_int();
 
-    // Get the pin for hardware pwm
+    pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->by_default(1.0f)->as_number();
+    acc_ratio = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->by_default(1.0f)->as_number();
+    alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->by_default("nc")->as_string())->as_input();
+
+    float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->by_default(0.1f)->as_number();
+    if (smoothing_time * UPDATE_FREQ < 1.0f)
+        smoothing_decay = 1.0f;
+    else
+        smoothing_decay = 1.0f / (UPDATE_FREQ * smoothing_time);
+
     {
         Pin *smoothie_pin = new Pin();
         smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->by_default("nc")->as_string());
@@ -38,86 +68,206 @@ void AnalogSpindleControl::on_module_loaded()
         output_inverted = smoothie_pin->is_inverting();
         delete smoothie_pin;
     }
-    // If we got no hardware PWM pin, delete this module
     if (pwm_pin == NULL)
     {
         THEKERNEL->streams->printf("Error: Spindle PWM pin must be P2.0-2.5 or other PWM pin\n");
         delete this;
         return;
     }
-    
-    // set pwm frequency
+
     int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->by_default(1000)->as_int();
+    THEKERNEL->Spindle_period_us = period;
     pwm_pin->period_us(period);
-    // invert pwm signal if necessary
     pwm_pin->write(output_inverted ? 1 : 0);
 
-    // Get digital out pin for switching the VFD on and off (wired to a digital input on the VFD via an optocoupler)
+    {
+        Pin *smoothie_pin = new Pin();
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_feedback_pin_checksum)->by_default("nc")->as_string());
+        feedback_pin = NULL;
+        if (smoothie_pin->valid) {
+            smoothie_pin->as_input();
+            if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
+                PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
+                feedback_pin = new mbed::InterruptIn(pinname);
+                feedback_pin->rise(this, &AnalogSpindleControl::on_pin_rise);
+                NVIC_SetPriority(EINT3_IRQn, 16);
+            } else {
+                THEKERNEL->streams->printf("Error: Spindle feedback pin has to be on P0 or P2.\n");
+                delete smoothie_pin;
+                delete this;
+                return;
+            }
+        }
+        delete smoothie_pin;
+    }
+
     std::string switch_on_pin = THEKERNEL->config->value(spindle_checksum, spindle_switch_on_pin_checksum)->by_default("nc")->as_string();
     switch_on = NULL;
     if(switch_on_pin.compare("nc") != 0) {
         switch_on = new Pin();
         switch_on->from_string(switch_on_pin)->as_output()->set(false);
     }
+
+    THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &AnalogSpindleControl::on_update_speed);
 }
 
-void AnalogSpindleControl::turn_on() 
+void AnalogSpindleControl::on_pin_rise()
 {
-    // set the output for switching the VFD on
-    if(switch_on != NULL) 
-        switch_on->set(true); 
+    if (irq_count >= pulses_per_rev) {
+        irq_count = 0;
+        uint32_t timestamp = us_ticker_read();
+        rev_time = timestamp - last_rev_time;
+        last_rev_time = timestamp;
+        time_since_update = 0;
+    }
+    irq_count++;
+}
+
+uint32_t AnalogSpindleControl::on_update_speed(uint32_t dummy)
+{
+    if (feedback_pin != NULL) {
+        if (++time_since_update > UPDATE_FREQ)
+        {
+            current_rpm = 0;
+        }
+        else
+        {
+            uint32_t t = rev_time;
+            if (t > (uint32_t)(2000 * acc_ratio))
+            {
+                float new_rpm = 1000000 * acc_ratio * 60.0f / t;
+                current_rpm = smoothing_decay * new_rpm + (1.0f - smoothing_decay) * current_rpm;
+            }
+        }
+    }
+    else
+    {
+        if (!spindle_on || target_rpm <= 0)
+            current_rpm = 0;
+        else
+        {
+            float duty = pwm_pin->read();
+            current_rpm = max_rpm * duty;
+        }
+    }
+    return 0;
+}
+
+bool AnalogSpindleControl::get_alarm(void)
+{
+    uint32_t debounce = 0;
+    while (this->alarm_pin.get()) {
+        if ( ++debounce >= 10 ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void AnalogSpindleControl::on_idle(void *argument)
+{
+    (void)argument;
+    if(THEKERNEL->is_halted()) return;
+    if (this->get_alarm()) {
+        THEKERNEL->streams->printf("ALARM: Spindle alarm triggered -  power off/on required\n");
+        THEKERNEL->set_halt_reason(SPINDLE_ALARM);
+        THEKERNEL->call_event(ON_HALT, nullptr);
+    }
+}
+
+void AnalogSpindleControl::apply_pwm_from_targets()
+{
+    if (!spindle_on || target_rpm <= 0) {
+        update_pwm(0);
+        return;
+    }
+    float cmd = target_rpm * (factor / 100.0f);
+    if (cmd > (float)max_rpm) cmd = (float)max_rpm;
+    update_pwm(1.0f / max_rpm * cmd);
+}
+
+void AnalogSpindleControl::turn_on()
+{
+    if(switch_on != NULL)
+        switch_on->set(true);
     spindle_on = true;
-
+    THEKERNEL->spindleon = true;
+    apply_pwm_from_targets();
 }
 
-
-void AnalogSpindleControl::turn_off() 
+void AnalogSpindleControl::turn_off()
 {
-    // clear the output for switching the VFD on 
-    if(switch_on != NULL) 
+    if(switch_on != NULL)
         switch_on->set(false);
     spindle_on = false;
-    // set the PWM value to 0 to make sure it stops
+    THEKERNEL->spindleon = false;
     update_pwm(0);
-
 }
 
-
-void AnalogSpindleControl::set_speed(int rpm) 
+void AnalogSpindleControl::set_speed(int rpm)
 {
-    // limit the requested RPM value
+    float tr = rpm;
     if(rpm < 0) {
-        target_rpm = 0;
+        tr = 0;
     } else if (rpm > max_rpm) {
-        target_rpm = max_rpm;
+        tr = max_rpm;
     } else if (rpm > 0 && rpm < min_rpm){
-        target_rpm = min_rpm;
-    } else {
-        target_rpm = rpm;
+        tr = min_rpm;
     }
-    // calculate the duty cycle and update the PWM
-    update_pwm(1.0f / max_rpm * target_rpm);
-
+    target_rpm = tr;
+    apply_pwm_from_targets();
 }
 
-
-void AnalogSpindleControl::report_speed() 
+void AnalogSpindleControl::report_speed()
 {
-    // report the current PWM value, calculate the current RPM value and report it as well
-    float current_pwm = pwm_pin->read();
-    THEKERNEL->streams->printf("Current RPM: %.0f Analog value: %5.3f Target RPM: %d\n",
-                               max_rpm * current_pwm, current_pwm, target_rpm);
-
+    THEKERNEL->streams->printf("State: %s, Current RPM: %5.0f  Target RPM: %5.0f  PWM value: %5.3f\n",
+            spindle_on ? "on" : "off", current_rpm, target_rpm, current_pwm_value);
 }
 
-
-void AnalogSpindleControl::update_pwm(float value) 
+void AnalogSpindleControl::update_pwm(float value)
 {
-    // set the requested PWM value, invert it if necessary
+    current_pwm_value = value;
     if(output_inverted)
         pwm_pin->write(1.0f - value);
     else
         pwm_pin->write(value);
-
 }
 
+void AnalogSpindleControl::set_factor(float new_factor)
+{
+    factor = new_factor;
+    apply_pwm_from_targets();
+}
+
+void AnalogSpindleControl::on_get_public_data(void* argument)
+{
+    PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
+    if(!pdr->starts_with(pwm_spindle_control_checksum)) return;
+    if(pdr->second_element_is(get_spindle_status_checksum)) {
+        struct spindle_status *t= static_cast<spindle_status*>(pdr->get_data_ptr());
+        t->state = this->spindle_on;
+        t->current_rpm = this->current_rpm;
+        t->target_rpm = this->target_rpm;
+        t->current_pwm_value = this->current_pwm_value;
+        t->factor= this->factor;
+        pdr->set_taken();
+    }
+}
+
+void AnalogSpindleControl::on_set_public_data(void* argument)
+{
+    PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
+    if(!pdr->starts_with(pwm_spindle_control_checksum)){
+        return;
+    }
+    if(pdr->second_element_is(get_spindle_status_checksum)) {
+        struct spindle_status *t= static_cast<spindle_status*>(pdr->get_data_ptr());
+        this->set_factor(t->factor);
+        pdr->set_taken();
+        return;
+    }
+    if(pdr->second_element_is(turn_off_spindle_checksum)) {
+        this->turn_off();
+        pdr->set_taken();
+    }
+}

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -84,7 +84,7 @@ void AnalogSpindleControl::on_module_loaded()
         Pin *smoothie_pin = new Pin();
         smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_feedback_pin_checksum)->by_default("nc")->as_string());
         feedback_pin = NULL;
-        if (smoothie_pin->valid) {
+        if (smoothie_pin->connected()) {
             smoothie_pin->as_input();
             if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
                 PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -108,7 +108,7 @@ void AnalogSpindleControl::on_module_loaded()
         delete smoothie_pin;
     }
 
-    std::string switch_on_pin = THEKERNEL->config->value(spindle_checksum, spindle_switch_on_pin_checksum)->by_default("nc")->as_string();
+    std::string switch_on_pin = THEKERNEL->config->value(spindle_checksum, spindle_switch_on_pin_checksum)->as_string("nc");
     switch_on = NULL;
     if(switch_on_pin.compare("nc") != 0) {
         switch_on = new Pin();

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -51,11 +51,11 @@ void AnalogSpindleControl::on_module_loaded()
     min_rpm = THEKERNEL->config->value(spindle_checksum, spindle_min_rpm_checksum)->by_default(100)->as_int();
     max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(5000)->as_int();
 
-    pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->by_default(1.0f)->as_number();
-    acc_ratio = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->by_default(1.0f)->as_number();
-    alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->by_default("nc")->as_string())->as_input();
+    pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->as_number(1.0f);
+    acc_ratio = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->as_number(1.0f);
+    alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->as_string("nc"))->as_input();
 
-    float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->by_default(0.1f)->as_number();
+    float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->as_number(0.1f);
     if (smoothing_time * UPDATE_FREQ < 1.0f)
         smoothing_decay = 1.0f;
     else

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -61,6 +61,7 @@ void AnalogSpindleControl::on_module_loaded()
     else
         smoothing_decay = 1.0f / (UPDATE_FREQ * smoothing_time);
 
+    // Get the pin for hardware pwm
     {
         Pin *smoothie_pin = new Pin();
         smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->as_string("nc"));
@@ -68,6 +69,7 @@ void AnalogSpindleControl::on_module_loaded()
         output_inverted = smoothie_pin->is_inverting();
         delete smoothie_pin;
     }
+    // If we got no hardware PWM pin, delete this module
     if (pwm_pin == NULL)
     {
         THEKERNEL->streams->printf("Error: Spindle PWM pin must be P2.0-2.5 or other PWM pin\n");
@@ -75,11 +77,16 @@ void AnalogSpindleControl::on_module_loaded()
         return;
     }
 
+    // set pwm frequency
     int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->as_int(1000);
     THEKERNEL->Spindle_period_us = period;
     pwm_pin->period_us(period);
+
+    // invert pwm signal if necessary
     pwm_pin->write(output_inverted ? 1 : 0);
 
+
+    // Get digital out pin for switching the spindle on and off
     {
         Pin *smoothie_pin = new Pin();
         smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_feedback_pin_checksum)->as_string("nc"));
@@ -201,7 +208,7 @@ void AnalogSpindleControl::turn_off()
         switch_on->set(false);
     spindle_on = false;
     THEKERNEL->spindleon = false;
-    update_pwm(0);
+    update_pwm(0); // set the PWM value to 0 to make sure it stops
 }
 
 void AnalogSpindleControl::set_speed(int rpm)
@@ -226,6 +233,7 @@ void AnalogSpindleControl::report_speed()
 
 void AnalogSpindleControl::update_pwm(float value)
 {
+    // set the requested PWM value, invert it if necessary
     current_pwm_value = value;
     if(output_inverted)
         pwm_pin->write(1.0f - value);

--- a/src/modules/tools/spindle/AnalogSpindleControl.h
+++ b/src/modules/tools/spindle/AnalogSpindleControl.h
@@ -9,37 +9,58 @@
 #define ANALOG_SPINDLE_MODULE_H
 
 #include "SpindleControl.h"
+#include <stdint.h>
+#include "Pin.h"
 
 namespace mbed {
     class PwmOut;
+    class InterruptIn;
 }
 
-class Pin;
-
-// This module implements control of the spindle speed by seting a PWM from 0-100% which needs
-// to be converted to 0-10V by an external circuit
+// Analog 0–10V spindle control with optional tachometer feedback and alarm input (same config keys as PWM spindle).
 class AnalogSpindleControl: public SpindleControl {
     public:
-        AnalogSpindleControl() {};
+        AnalogSpindleControl() : feedback_pin(nullptr) {};
         virtual ~AnalogSpindleControl() {};
         void on_module_loaded();
-        
+        void on_get_public_data(void* argument);
+        void on_set_public_data(void* argument);
+        void on_idle(void* argument);
+
     private:
-       
-        Pin *switch_on; // digital output for switching the VFD on 
-        mbed::PwmOut *pwm_pin; // PWM output for spindle speed control
+        void on_pin_rise();
+        uint32_t on_update_speed(uint32_t dummy);
+        bool get_alarm(void);
+
+        void apply_pwm_from_targets(void);
+
+        Pin *switch_on;
+        mbed::PwmOut *pwm_pin;
+        mbed::InterruptIn *feedback_pin;
         bool output_inverted;
-        
-        int target_rpm;
+
+        float target_rpm;
+        float current_rpm;
+        float current_pwm_value;
+        float factor;
         int min_rpm;
         int max_rpm;
+
+        float pulses_per_rev;
+        float acc_ratio;
+        float smoothing_decay;
+        int time_since_update;
+        uint32_t last_rev_time;
+        volatile uint32_t rev_time;
+        volatile uint32_t irq_count;
+        Pin alarm_pin;
 
         void turn_on(void);
         void turn_off(void);
         void set_speed(int);
         void report_speed(void);
-        void update_pwm(float); 
+        void update_pwm(float);
+        void set_factor(float);
 };
 
 #endif
-

--- a/src/modules/tools/spindle/AnalogSpindleControl.h
+++ b/src/modules/tools/spindle/AnalogSpindleControl.h
@@ -17,7 +17,6 @@ namespace mbed {
     class InterruptIn;
 }
 
-// Analog 0–10V spindle control with optional tachometer feedback and alarm input (same config keys as PWM spindle).
 class AnalogSpindleControl: public SpindleControl {
     public:
         AnalogSpindleControl() : feedback_pin(nullptr) {};

--- a/src/modules/tools/spindle/AnalogSpindleControl.h
+++ b/src/modules/tools/spindle/AnalogSpindleControl.h
@@ -17,6 +17,7 @@ namespace mbed {
     class InterruptIn;
 }
 
+// This module implements control of the spindle speed by seting a PWM from 0-100%
 class AnalogSpindleControl: public SpindleControl {
     public:
         AnalogSpindleControl() : feedback_pin(nullptr) {};

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,6 @@
+[unreleased]
+- Enhancement: AnalogSpindleControl now supports optional RPM feedback and Alarm pin functionality, same as PWMSpindleControl. Same configuration keys (spindle.feedback_pin, spindle.pulses_per_rev, spindle.acc_ratio, and spindle.control_smoothing, spindle.alarm_pin)
+
 [2.1.0c]
 - Fixed: Unused Variables removed
 - Fixed: Removing unused code blocks in simpleshell


### PR DESCRIPTION
WIP to uplift AnalogSpindleControl to:
* Match RPM feedback and Alarm pin functionality of PWMSpindleControl
* Add configurable ~~deadzones~~ (this seems to already exist via spindle.min_rpm), offset and proportional gain to the output signal

Treat the code in this PR as untested until it is ready for review