### PR TITLE
Remove MRI debug monitor from release builds

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -25,6 +25,10 @@ If the path is an existing directory, the artifact will be copied into it as `ma
 If the path points to a non-existent file in an existing directory, the artifact will be copied to that path.
 The destination directory must exist.
 
+.PARAMETER Debug
+Build with MRI debug monitor linked (BUILD_TYPE=Debug). Enables GDB attach
+via serial and __debugbreak() calls. Uses -Og optimization for debugging.
+
 .PARAMETER Slow
 runs the build command single threaded to prevent issues with multiple threads
 writing error messages over eachother
@@ -51,7 +55,7 @@ to be passed to the make command.
 
 .EXAMPLE
 # Build with default GCC and enable debug monitor
-./build/build.ps1 ENABLE_DEBUG_MONITOR=1
+./build/build.ps1 --Debug
 
 .NOTES
 Relies on ./build/gcc.ps1 being present in the same directory.
@@ -72,6 +76,9 @@ param(
 
     [Parameter(Mandatory=$false)]
     [string]$OutputPath,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Debug,
 
     [Parameter(Mandatory=$false)]
     [switch]$Help,
@@ -126,6 +133,10 @@ if ($PSVersionTable.PSEdition -eq "Desktop" -or
 if ($Slow){
     $cpuCount = "1"
 }
+# Determine build type
+$buildType = if ($Debug) { "Debug" } else { "Release" }
+
+Write-Host "Build type: $buildType" -ForegroundColor Cyan
 Write-Host "Using GCC version: $requestedGccVersion" -ForegroundColor Cyan
 Write-Host "Using $cpuCount parallel jobs for make." -ForegroundColor Cyan
 if ($Clean) {
@@ -160,6 +171,7 @@ $makeArgsList = New-Object System.Collections.Generic.List[string]
 $makeArgsList.Add("make")
 $makeArgsList.Add("-j$cpuCount")
 $makeArgsList.AddRange($BaseMakeArgs.Split(' '))
+$makeArgsList.Add("BUILD_TYPE=$buildType")
 if ($MakeExtraArgs.Length -gt 0) {
     $makeArgsList.AddRange($MakeExtraArgs)
 }

--- a/build/build.sh
+++ b/build/build.sh
@@ -49,13 +49,18 @@ print_help() {
   echo "                   Supported versions are determined by build/gcc.sh."
   echo "  --clean          Run 'make clean' before starting the build."
   echo "  --output <path>  Specify the output path for the build artifact."
+  echo "  --debug          Build with MRI debug monitor linked (BUILD_TYPE=Debug)."
+  echo "                   Enables GDB attach via serial and __debugbreak() calls."
+  echo "                   Uses -Og optimization for debugging."
+  echo "  --release        Build production firmware (default). Size-optimized (-Os),"
+  echo "                   no MRI debug monitor."
   echo "  --help           Display this help message and exit."
   echo ""
   echo "Example:"
-  echo "  $0                            # Build with default GCC (${DEFAULT_GCC_VERSION})"
-  echo "  $0 --clean                    # Clean then build with default GCC"
+  echo "  $0                            # Release build with default GCC (${DEFAULT_GCC_VERSION})"
+  echo "  $0 --clean                    # Clean then release build with default GCC"
+  echo "  $0 --debug --clean            # Clean then debug build with MRI monitor"
   echo "  $0 --gcc 4.8 --clean VERBOSE=1 # Clean then build with GCC 4.8, verbose output"
-  echo "  $0 ENABLE_DEBUG_MONITOR=1     # Build with default GCC and enable debug monitor"
 }
 
 # --- Main Execution ---
@@ -63,6 +68,7 @@ main() {
     local requested_gcc_version_user="$DEFAULT_GCC_VERSION"
     local run_clean=false
     local show_help=false
+    local build_type="Release"
     local make_extra_args=()
     local output_path=""
     local os
@@ -95,6 +101,14 @@ main() {
                 output_path="$2"
                 shift 2
                 ;;
+            --debug)
+                build_type="Debug"
+                shift 1
+                ;;
+            --release)
+                build_type="Release"
+                shift 1
+                ;;
             --help)
                 show_help=true
                 shift 1
@@ -126,6 +140,7 @@ main() {
     cpu_count=$(get_cpu_count "$os")
 
     echo "Detected OS: $os" >&2
+    echo "Build type: $build_type" >&2
     echo "Using GCC version: $requested_gcc_version_user" >&2
     echo "Using $cpu_count parallel jobs for make." >&2
     [[ "$run_clean" == true ]] && echo "Will run 'make clean' first." >&2
@@ -140,7 +155,7 @@ main() {
     # Construct the final make command
     # We need eval here to correctly handle potential spaces or special chars
     # in make_extra_args if they were quoted on the command line.
-    make_cmd=(make "-j${cpu_count}" ${BASE_MAKE_ARGS})
+    make_cmd=(make "-j${cpu_count}" ${BASE_MAKE_ARGS} "BUILD_TYPE=${build_type}")
     make_cmd+=(${make_extra_args[@]+"${make_extra_args[@]}"}) # Append extra args
 
     # --- Execution ---

--- a/build/common.mk
+++ b/build/common.mk
@@ -48,23 +48,19 @@ WRITE_BUFFER_DISABLE ?= 0
 STACK_SIZE ?= 0
 
 
-# Configure MRI variables based on BUILD_TYPE build type variable.
+# Configure MRI variables based on BUILD_TYPE variable.
+#   Release - Production firmware. Optimized for size (-Os), no MRI debug monitor.
+#   Debug   - Development firmware. Optimized for debugging (-Og), MRI debug monitor
+#             linked. Allows GDB attach via serial and __debugbreak() calls.
+#             Uses -Og (not -O0) because unoptimized code overflows flash on LPC1768.
 ifeq "$(BUILD_TYPE)" "Release"
-OPTIMIZATION ?= 2
+OPTIMIZATION ?= s
 MRI_ENABLE = 0
 MRI_SEMIHOST_STDIO ?= 0
 endif
 
-
 ifeq "$(BUILD_TYPE)" "Debug"
-OPTIMIZATION = 0
-MRI_ENABLE ?= 1
-MRI_SEMIHOST_STDIO ?= 1
-endif
-
-
-ifeq "$(BUILD_TYPE)" "Checked"
-OPTIMIZATION ?= s
+OPTIMIZATION ?= g
 MRI_ENABLE = 1
 MRI_SEMIHOST_STDIO ?= 1
 endif

--- a/makefile
+++ b/makefile
@@ -84,6 +84,15 @@ all:
 	@echo Building Smoothie
 	@ $(MAKE) -C src
 
+# Explicit build targets for release and debug profiles.
+# 'make build-release' is equivalent to the default 'make all'.
+# 'make build-debug' links the MRI debug monitor for GDB attach via serial.
+build-release:
+	@ $(MAKE) all BUILD_TYPE=Release
+
+build-debug:
+	@ $(MAKE) all BUILD_TYPE=Debug
+
 clean: $(DIRSCLEAN)
 
 $(DIRSCLEAN): %.clean:
@@ -108,7 +117,7 @@ debug:
 console:
 	@ $(MAKE) -C src console
 
-.PHONY: all $(DIRS) $(DIRSCLEAN) debug-store flash upload debug console dfu
+.PHONY: all build-release build-debug $(DIRS) $(DIRSCLEAN) debug-store flash upload debug console dfu
 
 # --- Debugging Target --- 
 # Prints the values of key toolchain variables as make sees them and exits.

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -647,9 +647,11 @@ void Kernel::call_event(_EVENT_ENUM id_event, void * argument)
     if(id_event == ON_HALT) {
         // If we just entered a halt state AND the debug flag is enabled, break into the debugger.
         // This happens after ON_HALT handlers have run, presumably stopping motion planners etc.
+#if MRI_ENABLE
         if (this->halted && this->halt_on_error_debug) {
              __debugbreak(); // Enter debugger
         }
+#endif
 
         if(!this->halted || !was_idle) {
             // if we were running and this is a HALT

--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -82,8 +82,10 @@ void SlowTicker::tick(){
 
     // Enter MRI mode if the ISP button is pressed
     // TODO: This should have it's own module
+#if MRI_ENABLE
     if (ispbtn.get() == 0)
         __debugbreak();
+#endif
 
 }
 

--- a/src/libs/Watchdog.cpp
+++ b/src/libs/Watchdog.cpp
@@ -54,5 +54,7 @@ extern "C" void WDT_IRQHandler(void)
 
     WDT_ClrTimeOutFlag(); // bootloader uses this flag to enter DFU mode
     WDT_Feed();
+#if MRI_ENABLE
     __debugbreak();
+#endif
 }

--- a/src/makefile
+++ b/src/makefile
@@ -2,11 +2,14 @@ PROJECT=main
 BUILD_DIR=../build
 DEVICES=lpc1768
 
-# BUILD_TYPE can be set to the following values:
-#  Checked - Optimizations enabled with MRI debug monitor support. (Recommended Type)
-#  Release - Optimizations enabled.
-#  Debug - Optimization disabled with MRI debug monitor support.
-BUILD_TYPE=Checked
+# BUILD_TYPE controls the firmware build profile:
+#   Release - Production firmware. Size-optimized (-Os), no MRI debug monitor.
+#   Debug   - Development firmware. Debug-optimized (-Og), MRI debug monitor linked
+#             for GDB attach via serial.
+#
+# Use 'build/build.sh --debug' or 'make build-debug' for debug builds.
+# Default is Release.
+BUILD_TYPE?=Release
 
 # Set to 1 to tag each heap allocation with the caller's return address.
 # NOTE: Can't be enabled with latest build as not compatible with newlib nano.
@@ -15,24 +18,15 @@ HEAP_TAGS=0
 # Set to 1 configure MPU to disable write buffering and eliminate imprecise bus faults.
 WRITE_BUFFER_DISABLE=0
 
-# Set to 1 to allow MRI debug monitor to take full control of UART0 and use it
-# as a dedicated debug channel.  If you are using the USB based serial port for
-# the console then this should cause you no problems.  Set MRI_BREAK_ON_INIT to
-# 0 if you don't want to break into GDB at startup.
-ENABLE_DEBUG_MONITOR?=0
-
-# this is the default UART baud rate used if it is not set in config
-# it is also the baud rate used to report any errors found while parsing the config file
+# UART baud rate used if not set in config, and for config parse error reporting.
 DEFAULT_SERIAL_BAUD_RATE?=115200
 
-ifeq "$(ENABLE_DEBUG_MONITOR)" "1"
-# Can add MRI_UART_BAUD=115200 to next line if GDB fails to connect to MRI.
-# Tends to happen on some Linux distros but not Windows and OS X.
+# MRI debug monitor UART configuration (only used when BUILD_TYPE=Debug).
 MRI_UART=MRI_UART_2 MRI_UART_BAUD=$(DEFAULT_SERIAL_BAUD_RATE)
-MRI_BREAK_ON_INIT=1
+ifeq "$(BUILD_TYPE)" "Debug"
+MRI_BREAK_ON_INIT?=0
 MRI_SEMIHOST_STDIO=1
 else
-MRI_UART=MRI_UART_2 MRI_UART_BAUD=$(DEFAULT_SERIAL_BAUD_RATE)
 MRI_BREAK_ON_INIT=0
 MRI_SEMIHOST_STDIO=0
 endif

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -104,7 +104,9 @@ void Conveyor::on_idle(void*)
     // we can garbage collect the block queue here
     if (queue.tail_i != queue.isr_tail_i) {
         if (queue.is_empty()) {
+#if MRI_ENABLE
             __debugbreak();
+#endif
         } else {
             // Cleanly delete block
             Block* block = queue.tail_ref();
@@ -264,7 +266,9 @@ bool Conveyor::get_next_block(Block **block)
     Block *b= queue.item_ref(queue.isr_tail_i);
     // we cannot use this now if it is being updated
     if(!b->locked) {
+#if MRI_ENABLE
         if(!b->is_ready) __debugbreak(); // should never happen
+#endif
 
         b->is_ticking= true;
         b->recalculate_flag= false;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -382,7 +382,10 @@ uint8_t Robot::register_motor(StepperMotor *motor)
     if(n_motors >= k_max_actuators) {
         // this is a fatal error
         THEKERNEL->streams->printf("FATAL: too many motors, increase k_max_actuators\n");
+#if MRI_ENABLE
         __debugbreak();
+#endif
+        return 0;
     }
     actuators.push_back(motor);
     motor->set_motor_id(n_motors);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1542,8 +1542,12 @@ void SimpleShell::dfu_command( string parameters, StreamOutput *stream)
 // Break out into the MRI debugging system
 void SimpleShell::break_command( string parameters, StreamOutput *stream)
 {
+#if MRI_ENABLE
     stream->printf("Entering MRI debug mode...\r\n");
     __debugbreak();
+#else
+    stream->printf("MRI debug monitor not available (release build)\r\n");
+#endif
 }
 
 static int get_active_tool()


### PR DESCRIPTION
Rework the BUILD_TYPE system from three confusing modes (Release/Debug/Checked) into two clear profiles:

*  Release (-Os, no MRI)  - Production firmware, default build.
*  Debug   (-Og, with MRI) - Development firmware with GDB debug monitor.

The previous 'Checked' mode linked MRI (~19 KB) into every production build even though nobody was using it. The 'Release' mode used -O2 (speed) which is counterproductive on a flash-constrained LPC1768.

Changes:
- build/common.mk: Simplify to Release/Debug, remove Checked. Release uses -Os (size), Debug uses -Og (debug-friendly, fits in flash unlike -O0).
- src/makefile: Default to BUILD_TYPE=Release, clean up MRI configuration.
- build/build.sh: Add --debug/--release flags (default: --release).
- build/build.ps1: Add -Debug switch for Windows builds.
- makefile: Add build-release and build-debug targets.
- Guard all __debugbreak() calls with #if MRI_ENABLE so they compile to nothing in release builds (prevents HardFault on ISP button press, etc.).

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.
