### PR TITLE
Exclude unused arm solutions, leveling strategies, and spindle types

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -123,6 +123,52 @@ EXL = $(patsubst %,$(SRC)/modules/%/%,$(EXCLUDED_MODULES))
 CPPSRCS3 = $(filter-out $(EXL),$(CPPSRCS21))
 DEFINES += $(call uc, $(subst /,_,$(patsubst %,-DNO_%,$(EXCLUDED_MODULES))))
 
+# CARTESIAN_ONLY: exclude all non-Cartesian arm solutions
+ifdef CARTESIAN_ONLY
+CPPSRCS3 := $(filter-out \
+  $(SRC)/modules/robot/arm_solutions/HBotSolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/CoreXZSolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/LinearDeltaSolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/ExperimentalDeltaSolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/RotaryDeltaSolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/MorganSCARASolution.cpp \
+  $(SRC)/modules/robot/arm_solutions/RotatableCartesianSolution.cpp \
+  ,$(CPPSRCS3))
+DEFINES += -DCARTESIAN_ONLY
+endif
+
+# CARTGRID_ONLY: exclude delta/three-point leveling strategies
+ifdef CARTGRID_ONLY
+CPPSRCS3 := $(filter-out \
+  $(SRC)/modules/tools/zprobe/DeltaGridStrategy.cpp \
+  $(SRC)/modules/tools/zprobe/DeltaCalibrationStrategy.cpp \
+  $(SRC)/modules/tools/zprobe/ThreePointStrategy.cpp \
+  ,$(CPPSRCS3))
+DEFINES += -DCARTGRID_ONLY
+endif
+
+# NO_MODBUS_SPINDLE: exclude modbus/huanyang spindle types and SoftSerial library
+ifdef NO_MODBUS_SPINDLE
+CPPSRCS3 := $(filter-out \
+  $(SRC)/modules/tools/spindle/HuanyangSpindleControl.cpp \
+  $(SRC)/modules/tools/spindle/ModbusSpindleControl.cpp \
+  $(SRC)/modules/tools/spindle/Modbus/Modbus.cpp \
+  $(SRC)/modules/tools/spindle/SoftSerial/BufferedSoftSerial.cpp \
+  $(SRC)/modules/tools/spindle/SoftSerial/SoftSerial.cpp \
+  $(SRC)/modules/tools/spindle/SoftSerial/SoftSerial_rx.cpp \
+  $(SRC)/modules/tools/spindle/SoftSerial/SoftSerial_tx.cpp \
+  ,$(CPPSRCS3))
+DEFINES += -DNO_MODBUS_SPINDLE
+endif
+
+# NO_PID_AUTOTUNE: exclude PID autotuner (not needed when no heaters are connected)
+ifdef NO_PID_AUTOTUNE
+CPPSRCS3 := $(filter-out \
+  $(SRC)/modules/tools/temperaturecontrol/PID_Autotuner.cpp \
+  ,$(CPPSRCS3))
+DEFINES += -DNO_PID_AUTOTUNE
+endif
+
 # do not compile the src/testframework as that can only be done with rake
 CPPSRCS = $(filter-out $(SRC)/testframework/%,$(CPPSRCS3))
 

--- a/src/makefile
+++ b/src/makefile
@@ -82,7 +82,13 @@ ifeq "$(EXCLUDE_MODULES)" ""
 ifeq "$(CNC)" "1"
 # CNC build excludes these
 #export EXCLUDE_MODULES = tools/filamentdetector tools/scaracal tools/temperaturecontrol tools/temperatureswitch tools/extruder
-export EXCLUDE_MODULES = tools/filamentdetector tools/scaracal tools/extruder
+export EXCLUDE_MODULES = tools/filamentdetector tools/scaracal tools/extruder tools/rotarydeltacalibration
+# Exclude non-Cartesian arm solutions, delta/3-point leveling strategies, and
+# modbus/huanyang spindle types. Only Cartesian, CartGrid, and PWM/Analog are needed.
+export CARTESIAN_ONLY = 1
+export CARTGRID_ONLY = 1
+export NO_MODBUS_SPINDLE = 1
+export NO_PID_AUTOTUNE = 1
 else
 # 3D build excludes these
 export EXCLUDE_MODULES = tools/drillingcycles tools/spindle

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -18,12 +18,14 @@
 #include "PublicData.h"
 #include "arm_solutions/BaseSolution.h"
 #include "arm_solutions/CartesianSolution.h"
+#ifndef CARTESIAN_ONLY
 #include "arm_solutions/RotatableCartesianSolution.h"
 #include "arm_solutions/LinearDeltaSolution.h"
 #include "arm_solutions/RotaryDeltaSolution.h"
 #include "arm_solutions/HBotSolution.h"
 #include "arm_solutions/CoreXZSolution.h"
 #include "arm_solutions/MorganSCARASolution.h"
+#endif
 #include "StepTicker.h"
 #include "checksumm.h"
 #include "utils.h"
@@ -202,6 +204,7 @@ void Robot::load_config()
     if (this->arm_solution) delete this->arm_solution;
     int solution_checksum = get_checksum(THEKERNEL->config->value(arm_solution_checksum)->by_default("cartesian")->as_string());
     // Note checksums are not const expressions when in debug mode, so don't use switch
+#ifndef CARTESIAN_ONLY
     if(solution_checksum == hbot_checksum || solution_checksum == corexy_checksum) {
         this->arm_solution = new HBotSolution(THEKERNEL->config);
 
@@ -220,7 +223,9 @@ void Robot::load_config()
     } else if(solution_checksum == morgan_checksum) {
         this->arm_solution = new MorganSCARASolution(THEKERNEL->config);
 
-    } else if(solution_checksum == cartesian_checksum) {
+    } else
+#endif
+    if(solution_checksum == cartesian_checksum) {
         this->arm_solution = new CartesianSolution(THEKERNEL->config);
 
     } else {

--- a/src/modules/tools/spindle/SpindleMaker.cpp
+++ b/src/modules/tools/spindle/SpindleMaker.cpp
@@ -11,7 +11,9 @@
 #include "SpindleControl.h"
 #include "PWMSpindleControl.h"
 #include "AnalogSpindleControl.h"
+#ifndef NO_MODBUS_SPINDLE
 #include "HuanyangSpindleControl.h"
+#endif
 #include "Config.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
@@ -42,13 +44,15 @@ void SpindleMaker::load_spindle(){
         spindle = new PWMSpindleControl();
     } else if ( spindle_type.compare("analog") == 0 ) {
         spindle = new AnalogSpindleControl();
+#ifndef NO_MODBUS_SPINDLE
     } else if ( spindle_type.compare("modbus") == 0 ) {
-        if(vfd_type.compare("huanyang") == 0) { 
+        if(vfd_type.compare("huanyang") == 0) {
             spindle = new HuanyangSpindleControl();
         } else {
             delete spindle;
             THEKERNEL->streams->printf("ERROR: No valid spindle VFD type defined\n");
         }
+#endif
     } else {
         delete spindle;
         THEKERNEL->streams->printf("ERROR: No valid spindle type defined\n");

--- a/src/modules/tools/temperaturecontrol/TemperatureControlPool.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControlPool.cpp
@@ -12,7 +12,9 @@ using namespace std;
 #include <vector>
 #include "TemperatureControlPool.h"
 #include "TemperatureControl.h"
+#ifndef NO_PID_AUTOTUNE
 #include "PID_Autotuner.h"
+#endif
 #include "Config.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
@@ -33,9 +35,11 @@ void TemperatureControlPool::load_tools()
         }
     }
 
+#ifndef NO_PID_AUTOTUNE
     // no need to create one of these if no heaters defined
     if(cnt > 0) {
         PID_Autotuner *pidtuner = new PID_Autotuner();
         THEKERNEL->add_module( pidtuner );
     }
+#endif
 }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -30,9 +30,11 @@
 #include "us_ticker_api.h"
 #include "ATCHandlerPublicAccess.h"
 // strategies we know about
+#ifndef CARTGRID_ONLY
 #include "DeltaCalibrationStrategy.h"
 #include "ThreePointStrategy.h"
 #include "DeltaGridStrategy.h"
+#endif
 #include "CartGridStrategy.h"
 
 #include <vector>
@@ -127,6 +129,7 @@ void ZProbe::config_load()
 
             // check with each known strategy and load it if it matches
             switch(cs) {
+#ifndef CARTGRID_ONLY
                 case delta_calibration_strategy_checksum:
                     ls= new DeltaCalibrationStrategy(this);
                     found= true;
@@ -142,7 +145,7 @@ void ZProbe::config_load()
                     ls= new DeltaGridStrategy(this);
                     found= true;
                     break;
-
+#endif
                 case cart_grid_leveling_strategy_checksum:
                     ls= new CartGridStrategy(this);
                     found= true;
@@ -164,12 +167,14 @@ void ZProbe::config_load()
 
     // default for backwards compatibility add DeltaCalibrationStrategy if a delta
     // may be deprecated
+#ifndef CARTGRID_ONLY
     if(this->strategies.empty()) {
         if(this->is_delta) {
             this->strategies.push_back(new DeltaCalibrationStrategy(this));
             this->strategies.back()->handleConfig();
         }
     }
+#endif
 
     this->probe_height  = THEKERNEL->config->value(zprobe_checksum, probe_height_checksum)->by_default(5)->as_number();
     this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(5)->as_number(); // feedrate in mm/sec


### PR DESCRIPTION
For CNC/Cartesian builds, exclude modules that are compiled but never used:

* Arm solutions: HBot, CoreXZ, LinearDelta, ExperimentalDelta, RotaryDelta, MorganSCARA, RotatableCartesian (only CartesianSolution is used).
* Leveling strategies: DeltaGrid, DeltaCalibration, ThreePoint (only CartGridStrategy is used).
* Spindle types: Modbus/Huanyang + SoftSerial library (only PWM and Analog spindles are needed).
* Calibration modules: RotaryDeltaCalibration (added to EXCLUDE_MODULES).
* PID Autotuner: no heaters on CNC (heater_pin nc), so M303 autotuning is dead code (~200 B heap + ~1.8 KB flash).

Each exclusion is controlled by a NO_* make variable and matching C preprocessor define. The source files are filtered out of compilation in common.mk, and the factory code in Robot.cpp, ZProbe.cpp, SpindleMaker.cpp, and TemperatureControlPool.cpp is guarded with #ifdef / #ifndef accordingly.

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.