### PR TITLE
Enable LTO and remove counterproductive compiler flags

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -193,6 +193,7 @@ endif
 # Compiler Options
 GCFLAGS += -O$(OPTIMIZATION) -g3 $(DEVICE_CFLAGS)
 GCFLAGS += -ffunction-sections -fdata-sections  -fno-exceptions -fno-delete-null-pointer-checks
+GCFLAGS += -flto -flto-partition=max
 GCFLAGS += $(patsubst %,-I%,$(INCDIRS))
 GCFLAGS += $(DEFINES)
 GCFLAGS += $(DEPFLAGS)
@@ -201,8 +202,7 @@ GCFLAGS += -Wall -Wextra -Wno-unused-parameter -fomit-frame-pointer \
 
 ifeq ($(IS_GCC_10_3_OR_LATER),1)
 GCFLAGS += -fanalyzer -floop-unroll-and-jam \
-	-floop-interchange -fstack-clash-protection -mfix-cortex-m3-ldrd \
- 	-ftree-vectorize
+	-floop-interchange -mfix-cortex-m3-ldrd
 endif
 
 
@@ -215,7 +215,7 @@ AS_FLAGS += -g3 $(DEVICE_FLAGS)
 
 # Linker Options.
 LDFLAGS = $(DEVICE_FLAGS) -specs=$(BUILD_DIR)/startfile.spec
-LDFLAGS += -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
+LDFLAGS += -flto -flto-partition=max -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
 LDFLAGS += -T$(LSCRIPT)  -L $(EXTERNAL_DIR)/gcc/LPC1768
 #LDFLAGS += -L $(BUILD_DIR) -lM8266WIFI
 ifneq "$(NO_FLOAT_SCANF)" "1"


### PR DESCRIPTION
Enable Link-Time Optimization (-flto) for cross-translation-unit dead code elimination, inlining, and constant propagation. Uses -flto-partition=max to avoid assembler literal pool offset errors when LTO merges large translation units.

Remove two compiler flags that increase code size on Cortex-M3:
- -ftree-vectorize: Cortex-M3 has no SIMD/vector unit, so this only unrolls loops into larger scalar sequences with no performance gain.
- -fstack-clash-protection: Inserts stack probe instructions at every function with stack allocation; not useful on bare-metal with a fixed stack.

Saves ~22 KB (~4.7%) of flash on the LPC1768 target.

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.
