### PR TITLE
Move non-ISR objects from AHB pool to main heap

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -101,7 +101,7 @@ Kernel::Kernel()
     this->i2c = new mbed::I2C(P0_27, P0_28);
     this->i2c->frequency(200000);
     
-    this->factory_set = new(AHB) FACTORY_SET();
+    this->factory_set = new FACTORY_SET();
     // read Factory setting data from eeprom
     this->read_Factory_data();
     // read Factory settings data from sd
@@ -109,12 +109,12 @@ Kernel::Kernel()
 
 
     // Config next, but does not load cache yet
-    this->config = new(AHB) Config();
+    this->config = new Config();
 
     // Pre-load the config cache
     this->config->config_cache_load();
 
-    this->streams = new(AHB) StreamOutputPool();
+    this->streams = new StreamOutputPool();
 
     this->current_path   = "/";
 
@@ -151,7 +151,7 @@ Kernel::Kernel()
     add_module( this->slow_ticker = new(AHB) SlowTicker());
 
     this->step_ticker = new(AHB) StepTicker();
-    this->adc = new(AHB) Adc();
+    this->adc = new Adc();
 
     // TODO : These should go into platform-specific files
     // LPC17xx-specific
@@ -187,20 +187,20 @@ Kernel::Kernel()
     this->step_ticker->set_frequency( this->base_stepping_frequency );
     this->step_ticker->set_unstep_time( microseconds_per_step_pulse );
 
-    this->eeprom_data = new(AHB) EEPROM_data();
+    this->eeprom_data = new EEPROM_data();
     // read eeprom data
     this->read_eeprom_data();
     // check eeprom data
     this->check_eeprom_data();
 
     // Core modules
-    this->add_module( this->simpleshell    = new(AHB) SimpleShell()   );
-    this->add_module( this->conveyor       = new(AHB) Conveyor()      );
-    this->add_module( this->gcode_dispatch = new(AHB) GcodeDispatch() );
-    this->add_module( this->robot          = new(AHB) Robot()         );
+    this->add_module( this->simpleshell    = new SimpleShell()   );
+    this->add_module( this->conveyor       = new(AHB) Conveyor()      ); // must stay in AHB: shares volatile queue indices with step ISR
+    this->add_module( this->gcode_dispatch = new GcodeDispatch() );
+    this->add_module( this->robot          = new Robot()         );
 
-    this->planner = new(AHB) Planner();
-    this->configurator = new(AHB) Configurator();
+    this->planner = new Planner();
+    this->configurator = new Configurator();
 }
 
 // get current state

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,21 +151,21 @@ void init() {
 #endif
 
     // Create and add main modules
-    kernel->add_module( new(AHB) Player() );
+    kernel->add_module( new Player() );
 
     // ATC Handler
-    kernel->add_module( new(AHB) ATCHandler() );
+    kernel->add_module( new ATCHandler() );
 
     // MSC File System Handler
-    kernel->add_module( new(AHB) MSCFileSystem("ud") );
+    kernel->add_module( new MSCFileSystem("ud") );
 
     // Serial Console handles IO with the wireless probe
-    kernel->add_module( new(AHB) SerialConsole2() );
+    kernel->add_module( new(AHB) SerialConsole2() ); // must stay in AHB: UART RxIrq writes RingBuffer
 
-    kernel->add_module( new(AHB) MainButton() );
+    kernel->add_module( new MainButton() );
 
     // Wifi Provider
-    kernel->add_module( new(AHB) WifiProvider);
+    kernel->add_module( new WifiProvider);
 
     // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
     #ifndef NO_TOOLS_SWITCH
@@ -183,20 +183,20 @@ void init() {
 
     // #ifndef NO_TOOLS_TEMPERATURECONTROL
     // Note order is important here must be after extruder so Tn as a parameter will get executed first
-    TemperatureControlPool *tp= new(AHB) TemperatureControlPool();
+    TemperatureControlPool *tp= new TemperatureControlPool();
     tp->load_tools();
     delete tp;
 
     // #endif
     #ifndef NO_TOOLS_ENDSTOPS
-    kernel->add_module( new(AHB) Endstops() );
+    kernel->add_module( new Endstops() );
     #endif
     #ifndef NO_TOOLS_LASER
-    kernel->add_module( new(AHB) Laser() );
+    kernel->add_module( new Laser() );
     #endif
 
     #ifndef NO_TOOLS_SPINDLE
-    SpindleMaker *sm = new(AHB) SpindleMaker();
+    SpindleMaker *sm = new SpindleMaker();
     sm->load_spindle();
     delete sm;
     //kernel->add_module( new(AHB) Spindle() );
@@ -205,23 +205,23 @@ void init() {
     // kernel->add_module( new(AHB) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new(AHB) ZProbe() );
+    kernel->add_module( new ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
-    kernel->add_module( new(AHB) SCARAcal() );
+    kernel->add_module( new SCARAcal() );
     #endif
     #ifndef NO_TOOLS_ROTARYDELTACALIBRATION
-    kernel->add_module( new(AHB) RotaryDeltaCalibration() );
+    kernel->add_module( new RotaryDeltaCalibration() );
     #endif
 //    #ifndef NONETWORK
 //    kernel->add_module( new Network() );
 //    #endif
     #ifndef NO_TOOLS_TEMPERATURESWITCH
     // Must be loaded after TemperatureControl
-    kernel->add_module( new(AHB) TemperatureSwitch() );
+    kernel->add_module( new TemperatureSwitch() );
     #endif
     #ifndef NO_TOOLS_DRILLINGCYCLES
-    kernel->add_module( new(AHB) Drillingcycles() );
+    kernel->add_module( new Drillingcycles() );
     #endif
     // Create and initialize USB stuff
     // u.init();
@@ -241,7 +241,7 @@ void init() {
     /* disable USB module
     kernel->add_module( &usbserial );
     if( kernel->config->value( second_usb_serial_enable_checksum )->by_default(false)->as_bool() ){
-        kernel->add_module( new(AHB) USBSerial(&u) );
+        kernel->add_module( new USBSerial(&u) );
     }
     */
 
@@ -256,7 +256,7 @@ void init() {
     float t= kernel->config->value( watchdog_timeout_checksum )->by_default(10.0F)->as_number();
     if(t > 0.1F) {
         // NOTE setting WDT_RESET with the current bootloader would leave it in DFU mode which would be suboptimal
-        kernel->add_module( new(AHB) Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
+        kernel->add_module( new Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
         kernel->streams->printf("Watchdog enabled for %1.3f seconds\n", t);
     }else{
         kernel->streams->printf("WARNING Watchdog is disabled\n");

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -81,12 +81,12 @@ void WifiProvider::on_module_loaded()
     this->init_wifi_module(false);
 
     // Add interrupt for WIFI data receving
-    Pin *smoothie_pin = new(AHB) Pin();
+    Pin *smoothie_pin = new Pin();
     smoothie_pin->from_string(THEKERNEL->config->value(wifi_checksum, wifi_interrupt_pin_checksum)->by_default("2.11")->as_string());
     smoothie_pin->as_input();
     if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
         PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
-        wifi_interrupt_pin = new(AHB) mbed::InterruptIn(pinname);
+        wifi_interrupt_pin = new mbed::InterruptIn(pinname);
         wifi_interrupt_pin->rise(this, &WifiProvider::on_pin_rise);
         NVIC_SetPriority(EINT3_IRQn, 16);
     } else {


### PR DESCRIPTION
Objects that share data with ISRs remain in AHB SRAM:
- Conveyor (volatile queue indices shared with step ISR)
- StepTicker (TIMER0/TIMER1 ISR state)
- SlowTicker (TIMER2 ISR hook iteration)
- SerialConsole (UART RxIrq writes to RingBuffer)
- SerialConsole2 (same)

All other objects are only accessed from the main loop and have no DMA or ISR involvement. Moving them to main heap frees ~5 KB in the AHB dynamic pool (where the Block queue lives and space is critically tight) at the cost of ~5 KB in main heap (which has ~17-24 KB available).

WiFi SPI DMA is disabled (M8266WIFI_SPI_ACCESS_USE_DMA commented out in brd_cfg.h), so WifiProvider and its buffers are safe to move. USB host hardware buffers (HCCA, TDBuffer, HostBuf) are static in .bss, not inside MSCFileSystem. ADC ISR reads hardware registers directly, not the Adc object.

Flash delta: -72 bytes (fewer AHB.alloc + placement new calls).

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.
