### PR TITLE
Shrink ConfigValue and move non-ISR objects to main heap

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -504,3 +504,10 @@ python3 $(which scan-view) .analyzer/*
 ```
 
 
+## Updating Makera Code potential issues
+
+The way config files are handled has changed, losing the ->by_default
+So to read a bool config value you would use: 
+this->config->value( disable_leds_checksum )->as_bool(false);
+instead of
+this->config->value( disable_leds_checksum )->by_default(false)->as_bool();

--- a/build/common.mk
+++ b/build/common.mk
@@ -257,7 +257,7 @@ AS_FLAGS += -g3 $(DEVICE_FLAGS)
 
 # Linker Options.
 LDFLAGS = $(DEVICE_FLAGS) -specs=$(BUILD_DIR)/startfile.spec
-LDFLAGS += -flto -flto-partition=max -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
+LDFLAGS += -flto=auto -flto-partition=max -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
 LDFLAGS += -T$(LSCRIPT)  -L $(EXTERNAL_DIR)/gcc/LPC1768
 #LDFLAGS += -L $(BUILD_DIR) -lM8266WIFI
 ifneq "$(NO_FLOAT_SCANF)" "1"

--- a/build/common.mk
+++ b/build/common.mk
@@ -257,7 +257,13 @@ AS_FLAGS += -g3 $(DEVICE_FLAGS)
 
 # Linker Options.
 LDFLAGS = $(DEVICE_FLAGS) -specs=$(BUILD_DIR)/startfile.spec
-LDFLAGS += -flto=auto -flto-partition=max -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
+ifeq "$(OS)" "Windows_NT"
+LDFLAGS += -flto
+else
+LDFLAGS += -flto=auto
+endif
+LDFLAGS += -flto-partition=max -Wl,-Map=$(OUTDIR)/$(PROJECT).map,--cref,--gc-sections,--wrap=_isatty,--wrap=malloc,--wrap=realloc,--wrap=free$(MRI_WRAPS)
+
 LDFLAGS += -T$(LSCRIPT)  -L $(EXTERNAL_DIR)/gcc/LPC1768
 #LDFLAGS += -L $(BUILD_DIR) -lM8266WIFI
 ifneq "$(NO_FLOAT_SCANF)" "1"

--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -18,6 +18,8 @@ using namespace std;
 #include "libs/utils.h"
 #include "libs/SerialMessage.h"
 #include "libs/ConfigSources/FileConfigSource.h"
+
+extern "C" caddr_t _sbrk(int);
 #include "libs/ConfigSources/FirmConfigSource.h"
 #include "StreamOutputPool.h"
 
@@ -75,6 +77,20 @@ void Config::config_cache_load(bool parse)
     this->config_cache_clear();
 
     this->config_cache= new ConfigCache;
+
+    // Verify the heap hasn't already grown into the config cache region
+    const auto heap_top = reinterpret_cast<uintptr_t>(_sbrk(0));
+    const auto cache_start = this->config_cache->start_address();
+    if(heap_top > cache_start) {
+        if(THEKERNEL->streams != NULL) {
+            THEKERNEL->streams->printf("ERROR: not enough memory to load config cache "
+                "(heap=0x%x, cache=0x%x)\n", heap_top, cache_start);
+        }
+        delete this->config_cache;
+        this->config_cache = NULL;
+        return;
+    }
+
     if(parse) {
         // For each ConfigSource in our stack
         for( ConfigSource *source : this->config_sources ) {
@@ -86,8 +102,20 @@ void Config::config_cache_load(bool parse)
 // Command to clear the config cache after init
 void Config::config_cache_clear()
 {
-    delete this->config_cache;
-    this->config_cache= NULL;
+    if(this->config_cache != NULL) {
+        // Verify the heap didn't grow into the config cache region
+        const auto heap_top = reinterpret_cast<uintptr_t>(_sbrk(0));
+        const auto cache_start = this->config_cache->start_address();
+        if(heap_top > cache_start) {
+            THEKERNEL->streams->printf("FATAL: heap collided with config cache "
+                "(heap=0x%x, cache=0x%x)\n", heap_top, cache_start);
+            system_reset(false);
+        }
+
+        this->config_cache->clear();
+        delete this->config_cache;  // frees the small ConfigCache object itself
+        this->config_cache = NULL;
+    }
 }
 
 // Three ways to read a value from the config, depending on adress length
@@ -99,8 +127,6 @@ ConfigValue *Config::value(uint16_t check_sum_a, uint16_t check_sum_b, uint16_t 
     check_sums[2] = check_sum_c;
     return this->value(check_sums);
 }
-
-static ConfigValue dummyValue;
 
 // Get a value from the configuration as a string
 // Because we don't like to waste space in Flash with lengthy config parameter names, we take a checksum instead so that the name does not have to be stored
@@ -116,11 +142,8 @@ ConfigValue *Config::value(uint16_t check_sums[])
     ConfigValue *result = this->config_cache->lookup(check_sums);
 
     if(result == NULL) {
-        // create a dummy value for this to play with, each call requires it's own value not a shared one
-        // result= new ConfigValue(check_sums);
-        // config_cache->add(result);
-        dummyValue.clear();
-        result = &dummyValue;
+        ConfigValue::dummy.clear();
+        result = &ConfigValue::dummy;
     }
 
     return result;

--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -78,14 +78,15 @@ void Config::config_cache_load(bool parse)
 
     this->config_cache= new ConfigCache;
 
-    // Verify the heap hasn't already grown into the config cache region
+    // Verify the malloc heap hasn't already grown into the config cache region.
+    // _sbrk(0) returns the current top of the newlib heap, which is what every
+    // allocation on this platform routes through.
     const auto heap_top = reinterpret_cast<uintptr_t>(_sbrk(0));
     const auto cache_start = this->config_cache->start_address();
     if(heap_top > cache_start) {
-        if(THEKERNEL->streams != NULL) {
-            THEKERNEL->streams->printf("ERROR: not enough memory to load config cache "
-                "(heap=0x%x, cache=0x%x)\n", heap_top, cache_start);
-        }
+        THEKERNEL->streams->printf("ERROR: not enough memory to load config cache "
+            "(heap=0x%x, cache=0x%x)\n", heap_top, cache_start);
+        THEKERNEL->set_config_load_error(true);
         delete this->config_cache;
         this->config_cache = NULL;
         return;
@@ -134,9 +135,14 @@ ConfigValue *Config::value(uint16_t check_sum_a, uint16_t check_sum_b, uint16_t 
 ConfigValue *Config::value(uint16_t check_sums[])
 {
     if( !is_config_cache_loaded() ) {
-        THEKERNEL->streams->printf("ERROR: calling value after config cache has been cleared\n");
-        // note this will cause whatever called it to blow up!
-        return NULL;
+        // Cache is unavailable (either failed to load due to heap collision,
+        // or value() was called after config_cache_clear()). Surface the
+        // condition and return the dummy so callers fall back to defaults
+        // instead of dereferencing NULL.
+        THEKERNEL->streams->printf("ERROR: config cache is not loaded\n");
+        THEKERNEL->set_config_load_error(true);
+        ConfigValue::dummy.clear();
+        return &ConfigValue::dummy;
     }
 
     ConfigValue *result = this->config_cache->lookup(check_sums);

--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -1,10 +1,13 @@
 #include "ConfigCache.h"
-#include "ConfigValue.h"
 
 #include "libs/StreamOutput.h"
 
 ConfigCache::ConfigCache()
 {
+    // Place the store in the gap between heap and stack — no heap allocation.
+    store = (ConfigValue *)((uintptr_t)&__StackLimit
+                            - CONFIG_CACHE_CAPACITY * sizeof(ConfigValue));
+    count = 0;
 }
 
 ConfigCache::~ConfigCache()
@@ -14,49 +17,39 @@ ConfigCache::~ConfigCache()
 
 void ConfigCache::clear()
 {
-    for (auto &kv : store)  {
-        delete kv;
-    }
-    store.clear();
-    storage_t().swap(store);   //  makes sure the vector releases its memory
-}
-
-void ConfigCache::add(ConfigValue *v)
-{
-    store.push_back(v);
+    count = 0;
 }
 
 void ConfigCache::pop()
 {
-    auto cv= store.back();
-    store.pop_back();
-    delete cv;
+    if(count > 0) count--;
 }
 
-// If we find an existing value, replace it, otherwise, push it at the back of the list
-void ConfigCache::replace_or_push_back(ConfigValue *new_value)
+// If we find an existing value, replace it, otherwise copy it to the back.
+// Returns a pointer to the entry in the store.
+ConfigValue *ConfigCache::replace_or_push_back(const ConfigValue &new_value)
 {
-    // For each already existing element
-    for(auto &cv : store) {
-        // If this configvalue matches the checksum
-        if(memcmp(new_value->check_sums, cv->check_sums, sizeof(cv->check_sums)) == 0) {
-            // Replace with the provided value
-            delete cv; // free up old one
-            cv =  new_value;
-            // printf("WARNING: duplicate config line replaced\n");
-            return;
+    for(uint16_t i = 0; i < count; i++) {
+        if(memcmp(new_value.check_sums, store[i].check_sums, sizeof(store[i].check_sums)) == 0) {
+            store[i] = new_value;
+            return &store[i];
         }
     }
 
-    // Value does not already exists, add to the list
-    store.push_back(new_value);
+    if(count < CONFIG_CACHE_CAPACITY) {
+        store[count] = new_value;
+        return &store[count++];
+    }
+
+    // Overflow — should not happen with correctly sized capacity
+    return NULL;
 }
 
-ConfigValue *ConfigCache::lookup(const uint16_t *check_sums) const
+ConfigValue *ConfigCache::lookup(const uint16_t *check_sums)
 {
-    for( auto &cv : store) {
-        if(memcmp(check_sums, cv->check_sums, sizeof(cv->check_sums)) == 0)
-            return cv;
+    for(uint16_t i = 0; i < count; i++) {
+        if(memcmp(check_sums, store[i].check_sums, sizeof(store[i].check_sums)) == 0)
+            return &store[i];
     }
 
     return NULL;
@@ -64,20 +57,18 @@ ConfigValue *ConfigCache::lookup(const uint16_t *check_sums) const
 
 void ConfigCache::collect(uint16_t family, uint16_t cs, vector<uint16_t> *list)
 {
-    for( auto &kv : store ) {
-        if( kv->check_sums[2] == cs && kv->check_sums[0] == family ) {
-            // We found a module enable for this family, add it's number
-            list->push_back(kv->check_sums[1]);
+    for(uint16_t i = 0; i < count; i++) {
+        if( store[i].check_sums[2] == cs && store[i].check_sums[0] == family ) {
+            list->push_back(store[i].check_sums[1]);
         }
     }
 }
 
 void ConfigCache::dump(StreamOutput *stream)
 {
-    int l = 1;
-    for( auto &kv : store ) {
-        ConfigValue *v = kv;
-        stream->printf("%3d - %04X %04X %04X : '%s' - found: %d, default: %d, default-double: %f, default-int: %d\n",
-                       l++, v->check_sums[0], v->check_sums[1], v->check_sums[2], v->value.c_str(), v->found, v->default_set, v->default_double, v->default_int );
+    for(uint16_t i = 0; i < count; i++) {
+        stream->printf("%3d - %04X %04X %04X : '%s'\n",
+                       i + 1, store[i].check_sums[0], store[i].check_sums[1],
+                       store[i].check_sums[2], store[i].value);
     }
 }

--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -1,6 +1,8 @@
 #include "ConfigCache.h"
 
+#include "libs/Kernel.h"
 #include "libs/StreamOutput.h"
+#include "libs/StreamOutputPool.h"
 
 ConfigCache::ConfigCache()
 {
@@ -41,7 +43,10 @@ ConfigValue *ConfigCache::replace_or_push_back(const ConfigValue &new_value)
         return &store[count++];
     }
 
-    // Overflow — should not happen with correctly sized capacity
+    THEKERNEL->streams->printf("ERROR: config cache overflow (capacity=%u), dropping key %04X:%04X:%04X\n",
+        (unsigned)CONFIG_CACHE_CAPACITY,
+        new_value.check_sums[0], new_value.check_sums[1], new_value.check_sums[2]);
+    THEKERNEL->set_config_load_error(true);
     return NULL;
 }
 

--- a/src/libs/ConfigCache.h
+++ b/src/libs/ConfigCache.h
@@ -11,10 +11,21 @@
 using namespace std;
 #include <vector>
 #include <stdint.h>
-#include <map>
 
-class ConfigValue;
+#include "ConfigValue.h"
+
 class StreamOutput;
+
+// Config cache lives in a fixed region of RAM between the heap and stack,
+// avoiding any heap allocation. The address is computed as:
+//   __StackLimit - (capacity * sizeof(ConfigValue))
+// where __StackLimit is the linker-defined bottom of the stack area.
+// This memory is unused during boot (heap hasn't grown that high, stack
+// hasn't grown that low). After config_cache_clear(), it returns to being
+// ordinary free gap between heap and stack.
+#define CONFIG_CACHE_CAPACITY 350
+
+extern unsigned int __StackLimit;
 
 class ConfigCache {
     public:
@@ -22,24 +33,25 @@ class ConfigCache {
         ~ConfigCache();
         void clear();
 
-        void add(ConfigValue* v);
         void pop();
 
-        // lookup and return the entru that matches the check sums,return NULL if not found
-        ConfigValue *lookup(const uint16_t *check_sums) const;
+        // lookup and return the entry that matches the check sums, return NULL if not found
+        ConfigValue *lookup(const uint16_t *check_sums);
 
         // collect enabled checksums of the given family
         void collect(uint16_t family, uint16_t cs, vector<uint16_t> *list);
 
-        // If we find an existing value, replace it, otherwise, push it at the back of the list
-        void replace_or_push_back(ConfigValue* new_value);
+        // If we find an existing value, replace it, otherwise copy it to the back
+        ConfigValue *replace_or_push_back(const ConfigValue &new_value);
 
         // used for debugging, dumps the cache to a stream
         void dump(StreamOutput *stream);
 
+        uintptr_t start_address() const { return reinterpret_cast<uintptr_t>(store); }
+
     private:
-        typedef vector<ConfigValue*> storage_t;
-        storage_t store;
+        ConfigValue *store;   // points into fixed RAM region, not heap
+        uint16_t count;
 };
 
 

--- a/src/libs/ConfigSource.cpp
+++ b/src/libs/ConfigSource.cpp
@@ -7,71 +7,60 @@
 
 #include "stdio.h"
 
-ConfigValue* ConfigSource::process_line(const string &buffer)
+// Parse a config line into a ConfigValue on the stack.
+// Returns true if the line is a valid key-value pair.
+bool ConfigSource::process_line(const string &buffer, ConfigValue &result)
 {
     if( buffer[0] == '#' ) {
-        return NULL;
+        return false;
     }
     if( buffer.length() < 3 ) {
-        return NULL;
+        return false;
     }
 
     size_t begin_key = buffer.find_first_not_of(" \t");
-    if(begin_key == string::npos || buffer[begin_key] == '#') return NULL; // comment line or blank line
+    if(begin_key == string::npos || buffer[begin_key] == '#') return false;
 
     size_t end_key = buffer.find_first_of(" \t", begin_key);
     if(end_key == string::npos) {
         THEKERNEL->streams->printf("ERROR: config file line %s is invalid, no key value pair found\r\n", buffer.c_str());
         THEKERNEL->set_config_load_error(true);
-        return NULL;
+        return false;
     }
 
     size_t begin_value = buffer.find_first_not_of(" \t", end_key);
     if(begin_value == string::npos || buffer[begin_value] == '#') {
         THEKERNEL->streams->printf("ERROR: config file line %s has no value\r\n", buffer.c_str());
         THEKERNEL->set_config_load_error(true);
-        return NULL;
+        return false;
     }
 
-    string key= buffer.substr(begin_key,  end_key - begin_key);
-    uint16_t check_sums[3];
-    get_checksums(check_sums, key);
-
-    ConfigValue *result = new ConfigValue;
-
-    result->found = true;
-    result->check_sums[0] = check_sums[0];
-    result->check_sums[1] = check_sums[1];
-    result->check_sums[2] = check_sums[2];
+    string key = buffer.substr(begin_key, end_key - begin_key);
+    get_checksums(result.check_sums, key);
 
     size_t end_value = buffer.find_first_of("\r\n# \t", begin_value + 1);
-    size_t vsize = end_value == string::npos ? end_value : end_value - begin_value;
-    result->value = buffer.substr(begin_value, vsize);
+    size_t vsize = end_value == string::npos ? buffer.size() - begin_value : end_value - begin_value;
+    result.set_value(buffer.c_str() + begin_value, vsize);
 
-    //printf("key: %s, value: %s\n\n", key.c_str(), result->value.c_str());
-    return result;
+    return true;
 }
 
 ConfigValue* ConfigSource::process_line_from_ascii_config(const string &buffer, ConfigCache *cache)
 {
-    ConfigValue *result = process_line(buffer);
-    if(result != NULL) {
-        // Append the newly found value to the cache we were passed
-        cache->replace_or_push_back(result);
-        return result;
+    ConfigValue cv;
+    if(process_line(buffer, cv)) {
+        return cache->replace_or_push_back(cv);
     }
     return NULL;
 }
 
 string ConfigSource::process_line_from_ascii_config(const string &buffer, uint16_t line_checksums[3])
 {
-    string value= "";
-    ConfigValue *result = process_line(buffer);
-    if(result != NULL) {
-        if(result->check_sums[0] == line_checksums[0] && result->check_sums[1] == line_checksums[1] && result->check_sums[2] == line_checksums[2]) {
-            value= result->value;
+    ConfigValue cv;
+    if(process_line(buffer, cv)) {
+        if(cv.check_sums[0] == line_checksums[0] && cv.check_sums[1] == line_checksums[1] && cv.check_sums[2] == line_checksums[2]) {
+            return cv.value;
         }
-        delete result;
     }
-    return value;
+    return "";
 }

--- a/src/libs/ConfigSource.h
+++ b/src/libs/ConfigSource.h
@@ -26,12 +26,12 @@ class ConfigSource {
         virtual bool remove( std::string setting ) { return false; }
 
     protected:
-        virtual ConfigValue* process_line_from_ascii_config(const std::string& line, ConfigCache* cache);
-        virtual std::string process_line_from_ascii_config(const std::string& line, uint16_t line_checksums[3]);
+        ConfigValue* process_line_from_ascii_config(const std::string& line, ConfigCache* cache);
+        std::string process_line_from_ascii_config(const std::string& line, uint16_t line_checksums[3]);
         uint16_t name_checksum;
 
     private:
-        ConfigValue* process_line(const std::string &buffer);
+        bool process_line(const std::string &buffer, ConfigValue &result);
 };
 
 

--- a/src/libs/ConfigSources/FileConfigSource.cpp
+++ b/src/libs/ConfigSources/FileConfigSource.cpp
@@ -82,7 +82,7 @@ void FileConfigSource::transfer_values_to_cache( ConfigCache *cache, const char 
 
             // if this line is an include directive then attempt to read the included file
             if(cv->check_sums[0] == include_checksum) {
-                string inc_file_name = cv->value.c_str();
+                string inc_file_name = cv->value;
                 cache->pop(); // we do not need to keep this around or leave it on the list
 
                 if(!file_exists(inc_file_name)) {

--- a/src/libs/ConfigValue.cpp
+++ b/src/libs/ConfigValue.cpp
@@ -2,145 +2,117 @@
 #include "StreamOutputPool.h"
 
 #include "libs/Kernel.h"
-#include "libs/utils.h"
+#include "libs/utils.h"  // remove_non_number
 #include "libs/Pin.h"
 #include "Pwm.h"
 
 
-#define printErrorandExit(...) THEKERNEL->streams->printf(__VA_ARGS__); // exit(1);
+#define reportConfigError(...) do { \
+    THEKERNEL->streams->printf(__VA_ARGS__); \
+    THEKERNEL->set_config_load_error(true); \
+} while (0)
 
 #include <vector>
 #include <stdio.h>
+
+ConfigValue ConfigValue::dummy;
 
 ConfigValue::ConfigValue()
 {
     clear();
 }
 
-void ConfigValue:: clear()
+void ConfigValue::clear()
 {
-    this->found = false;
-    this->default_set = false;
     this->check_sums[0] = 0x0000;
     this->check_sums[1] = 0x0000;
     this->check_sums[2] = 0x0000;
-    this->default_double= 0.0F;
-    this->default_int= 0;
-    this->value= "";
+    this->value[0] = '\0';
 }
 
 ConfigValue::ConfigValue(uint16_t *cs) {
     memcpy(this->check_sums, cs, sizeof(this->check_sums));
-    this->found = false;
-    this->default_set = false;
-    this->value= "";
+    this->value[0] = '\0';
 }
 
-ConfigValue::ConfigValue(const ConfigValue& to_copy)
-{
-    this->found = to_copy.found;
-    this->default_set = to_copy.default_set;
-    memcpy(this->check_sums, to_copy.check_sums, sizeof(this->check_sums));
-    this->value.assign(to_copy.value);
-}
-
-ConfigValue& ConfigValue::operator= (const ConfigValue& to_copy)
-{
-    if( this != &to_copy ){
-        this->found = to_copy.found;
-        this->default_set = to_copy.default_set;
-        memcpy(this->check_sums, to_copy.check_sums, sizeof(this->check_sums));
-        this->value.assign(to_copy.value);
+void ConfigValue::set_value(const char *s, size_t len) {
+    if (len >= sizeof(this->value)) {
+        reportConfigError("ERROR: config value '%.*s' exceeds %d char limit, truncating\r\n",
+                          (int)len, s, (int)(sizeof(this->value) - 1));
+        len = sizeof(this->value) - 1;
     }
-    return *this;
+    memcpy(this->value, s, len);
+    this->value[len] = '\0';
 }
 
 ConfigValue *ConfigValue::required()
 {
-    if( !this->found ) {
-        printErrorandExit("could not find config setting, please see http://smoothieware.org/configuring-smoothie\r\n");
+    if( !this->found() ) {
+        reportConfigError("could not find config setting, please see http://smoothieware.org/configuring-smoothie\r\n");
     }
     return this;
 }
 
 float ConfigValue::as_number()
 {
-    if( this->found == false && this->default_set == true ) {
-        return this->default_double;
-    } else {
-        char *endptr = NULL;
-        string str = remove_non_number(this->value);
-        const char *cp= str.c_str();
-        float result = strtof(cp, &endptr);
-        if( endptr <= cp ) {
-            printErrorandExit("config setting with value '%s' and checksums[%04X,%04X,%04X] is not a valid number, please see http://smoothieware.org/configuring-smoothie\r\n", this->value.c_str(), this->check_sums[0], this->check_sums[1], this->check_sums[2] );
-        }
-        return result;
+    if( !this->found() ) return 0.0f;
+    char *endptr = NULL;
+    string str = remove_non_number(this->value);
+    const char *cp = str.c_str();
+    float result = strtof(cp, &endptr);
+    if( endptr <= cp ) {
+        reportConfigError("config setting with value '%s' and checksums[%04X,%04X,%04X] is not a valid number, please see http://smoothieware.org/configuring-smoothie\r\n", this->value, this->check_sums[0], this->check_sums[1], this->check_sums[2] );
     }
+    return result;
 }
 
 int ConfigValue::as_int()
 {
-    if( this->found == false && this->default_set == true ) {
-        return this->default_int;
-    } else {
-        char *endptr = NULL;
-        string str = remove_non_number(this->value);
-        const char *cp= str.c_str();
-        int result = strtol(cp, &endptr, 10);
-        if( endptr <= cp ) {
-            printErrorandExit("config setting with value '%s' and checksums[%04X,%04X,%04X] is not a valid int, please see http://smoothieware.org/configuring-smoothie\r\n", this->value.c_str(), this->check_sums[0], this->check_sums[1], this->check_sums[2] );
-        }
-        return result;
+    if( !this->found() ) return 0;
+    char *endptr = NULL;
+    string str = remove_non_number(this->value);
+    const char *cp = str.c_str();
+    int result = strtol(cp, &endptr, 10);
+    if( endptr <= cp ) {
+        reportConfigError("config setting with value '%s' and checksums[%04X,%04X,%04X] is not a valid int, please see http://smoothieware.org/configuring-smoothie\r\n", this->value, this->check_sums[0], this->check_sums[1], this->check_sums[2] );
     }
+    return result;
 }
 
 std::string ConfigValue::as_string()
 {
-    return this->value;
+    return string(this->value);
 }
 
 bool ConfigValue::as_bool()
 {
-    if( this->found == false && this->default_set == true ) {
-        return this->default_int;
-    } else {
-        return this->value.find_first_of("ty1") != string::npos;
-    }
+    if( !this->found() ) return false;
+    return strchr(this->value, 't') || strchr(this->value, 'y') || strchr(this->value, '1');
 }
 
-ConfigValue *ConfigValue::by_default(int val)
+float ConfigValue::as_number(float dflt)
 {
-    this->default_set = true;
-    this->default_int = val;
-    this->default_double = val; // we need to set both becuase sometimes an integer is passed when it should be a float
-    return this;
+    return this->found() ? this->as_number() : dflt;
 }
 
-ConfigValue *ConfigValue::by_default(float val)
+int ConfigValue::as_int(int dflt)
 {
-    this->default_set = true;
-    this->default_double = val;
-    return this;
+    return this->found() ? this->as_int() : dflt;
 }
 
-ConfigValue *ConfigValue::by_default(string val)
+bool ConfigValue::as_bool(bool dflt)
 {
-    if( this->found ) {
-        return this;
-    }
-    this->default_set = true;
-    this->value = val;
-    return this;
+    return this->found() ? this->as_bool() : dflt;
+}
+
+string ConfigValue::as_string(const string &dflt)
+{
+    return this->found() ? this->as_string() : dflt;
 }
 
 bool ConfigValue::has_characters( const char *mask )
 {
-    if( this->value.find_first_of(mask) != string::npos ) {
-        return true;
-    } else {
-        return false;
-    }
+    return strpbrk(this->value, mask) != nullptr;
 }
 
 bool ConfigValue::is_inverted()

--- a/src/libs/ConfigValue.h
+++ b/src/libs/ConfigValue.h
@@ -10,26 +10,35 @@
 
 #include <string>
 #include <cstdint>
+#include <cstring>
 using std::string;
+
+#define CONFIGVALUE_MAX_LEN 20
 
 class ConfigValue{
     public:
         ConfigValue();
         ConfigValue(uint16_t *check_sums);
-        ConfigValue(const ConfigValue& to_copy);
-        ConfigValue& operator= (const ConfigValue& to_copy);
         void clear();
         ConfigValue* required();
         float as_number();
+        float as_number(float dflt);
         int as_int();
+        int as_int(int dflt);
         bool as_bool();
+        bool as_bool(bool dflt);
         string as_string();
+        string as_string(const string &dflt);
 
-        ConfigValue* by_default(float val);
-        ConfigValue* by_default(string val);
-        ConfigValue* by_default(int val);
         bool is_inverted();
 
+        bool found() const { return this != &dummy; }
+
+        static ConfigValue dummy; // returned by Config::value() when key is not in config
+
+        // Set value from a string, truncating to fit
+        void set_value(const char *s, size_t len);
+        void set_value(const string &s) { set_value(s.c_str(), s.size()); }
 
         friend class ConfigCache;
         friend class Config;
@@ -39,12 +48,8 @@ class ConfigValue{
 
     private:
         bool has_characters( const char* mask );
-        string value;
-        int default_int;
-        float default_double;
+        char value[CONFIGVALUE_MAX_LEN]; // config values are short; avoids per-entry heap alloc
         uint16_t check_sums[3];
-        bool found;
-        bool default_set;
 };
 
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -105,11 +105,11 @@ Kernel::Kernel()
     // Bring up streams + serial console first so factory and config parser
     // errors are visible on the host link. Baud is hard-coded here and gets
     // re-applied from config later in SerialConsole::on_module_loaded().
-    this->streams = new(AHB) StreamOutputPool();
+    this->streams = new StreamOutputPool();
     this->serial  = new(AHB) SerialConsole(P2_8, P2_9, 115200);
     this->streams->append_stream(this->serial);
 
-    this->factory_set = new(AHB) FACTORY_SET();
+    this->factory_set = new FACTORY_SET();
     // read Factory setting data from eeprom
     this->read_Factory_data();
     // read Factory settings data from sd
@@ -117,7 +117,7 @@ Kernel::Kernel()
 
 
     // Config next, but does not load cache yet
-    this->config = new(AHB) Config();
+    this->config = new Config();
 
     // Pre-load the config cache
     this->config->config_cache_load();
@@ -126,26 +126,26 @@ Kernel::Kernel()
 
     NVIC_SetPriorityGrouping(0);
     //some boards don't have leds.. TOO BAD!
-    this->use_leds = !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
+    this->use_leds = !this->config->value( disable_leds_checksum )->as_bool(false);
 
 #ifdef CNC
-    this->grbl_mode = this->config->value( grbl_mode_checksum )->by_default(true)->as_bool();
+    this->grbl_mode = this->config->value( grbl_mode_checksum )->as_bool(true);
 #else
-    this->grbl_mode = this->config->value( grbl_mode_checksum )->by_default(false)->as_bool();
+    this->grbl_mode = this->config->value( grbl_mode_checksum )->as_bool(false);
 #endif
 
-    this->enable_feed_hold = this->config->value( feed_hold_enable_checksum )->by_default(this->grbl_mode)->as_bool();
+    this->enable_feed_hold = this->config->value( feed_hold_enable_checksum )->as_bool(this->grbl_mode);
 
     // we expect ok per line now not per G code, setting this to false will return to the old (incorrect) way of ok per G code
-    this->ok_per_line = this->config->value( ok_per_line_checksum )->by_default(true)->as_bool();
+    this->ok_per_line = this->config->value( ok_per_line_checksum )->as_bool(true);
 
     // Option to disable serial console. Useful primarily if MRI is enabled and
     // you want to keep the serial port dedicated for such traffic. Or you want
     // to save some memory?
-    this->disable_serial_console = this->config->value( disable_serial_console_checksum )->by_default(false)->as_bool();
+    this->disable_serial_console = this->config->value( disable_serial_console_checksum )->as_bool(false);
     
     // Check if we should break into the debugger on halt
-    this->halt_on_error_debug = this->config->value( halt_on_error_debug_checksum )->by_default(false)->as_bool();
+    this->halt_on_error_debug = this->config->value( halt_on_error_debug_checksum )->as_bool(false);
 
     if (this->disable_serial_console) {
         this->streams->remove_stream(this->serial);
@@ -161,7 +161,7 @@ Kernel::Kernel()
     add_module( this->slow_ticker = new(AHB) SlowTicker());
 
     this->step_ticker = new(AHB) StepTicker();
-    this->adc = new(AHB) Adc();
+    this->adc = new Adc();
 
     // TODO : These should go into platform-specific files
     // LPC17xx-specific
@@ -190,27 +190,27 @@ Kernel::Kernel()
     }
 
     // Configure the step ticker
-    this->base_stepping_frequency = this->config->value(base_stepping_frequency_checksum)->by_default(100000)->as_number();
-    float microseconds_per_step_pulse = this->config->value(microseconds_per_step_pulse_checksum)->by_default(1)->as_number();
+    this->base_stepping_frequency = this->config->value(base_stepping_frequency_checksum)->as_number(100000);
+    float microseconds_per_step_pulse = this->config->value(microseconds_per_step_pulse_checksum)->as_number(1);
 
     // Configure the step ticker
     this->step_ticker->set_frequency( this->base_stepping_frequency );
     this->step_ticker->set_unstep_time( microseconds_per_step_pulse );
 
-    this->eeprom_data = new(AHB) EEPROM_data();
+    this->eeprom_data = new EEPROM_data();
     // read eeprom data
     this->read_eeprom_data();
     // check eeprom data
     this->check_eeprom_data();
 
     // Core modules
-    this->add_module( this->simpleshell    = new(AHB) SimpleShell()   );
-    this->add_module( this->conveyor       = new(AHB) Conveyor()      );
-    this->add_module( this->gcode_dispatch = new(AHB) GcodeDispatch() );
-    this->add_module( this->robot          = new(AHB) Robot()         );
+    this->add_module( this->simpleshell    = new SimpleShell()   );
+    this->add_module( this->conveyor       = new(AHB) Conveyor()      ); // must stay in AHB: shares volatile queue indices with step ISR
+    this->add_module( this->gcode_dispatch = new GcodeDispatch() );
+    this->add_module( this->robot          = new Robot()         );
 
-    this->planner = new(AHB) Planner();
-    this->configurator = new(AHB) Configurator();
+    this->planner = new Planner();
+    this->configurator = new Configurator();
 }
 
 // get current state

--- a/src/libs/USBDevice/MSCFileSystem.cpp
+++ b/src/libs/USBDevice/MSCFileSystem.cpp
@@ -136,13 +136,13 @@ int MSCFileSystem::disk_sectors() { return _numBlks; }
 void MSCFileSystem::on_module_loaded()
 {
     Pin *usb_en_pin = new Pin();
-    usb_en_pin->from_string(THEKERNEL->config->value( usb_en_pin_checksum )->by_default("1.19")->as_string());
+    usb_en_pin->from_string(THEKERNEL->config->value( usb_en_pin_checksum )->as_string("1.19"));
     usb_en_pin->as_output();
     usb_en_pin->set(0);
     delete usb_en_pin;
 
 //    Pin *usb_in_pin = new Pin();
-//    usb_in_pin->from_string(THEKERNEL->config->value( usb_in_pin_checksum )->by_default("1.22")->as_string());
+//    usb_in_pin->from_string(THEKERNEL->config->value( usb_in_pin_checksum )->as_string("1.22"));
 //    usb_in_pin->as_input();
 //    delete usb_in_pin;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ void init() {
 
 	/*
     // attempt to be able to disable msd in config
-    if(sdok && !kernel->config->value( disable_msd_checksum )->by_default(true)->as_bool()){
+    if(sdok && !kernel->config->value( disable_msd_checksum )->as_bool(true)){
         // HACK to zero the memory USBMSD uses as it and its objects seem to not initialize properly in the ctor
         size_t n= sizeof(USBMSD);
         void *v = AHB.alloc(n);
@@ -151,21 +151,21 @@ void init() {
 #endif
 
     // Create and add main modules
-    kernel->add_module( new(AHB) Player() );
+    kernel->add_module( new Player() );
 
     // ATC Handler
-    kernel->add_module( new(AHB) ATCHandler() );
+    kernel->add_module( new ATCHandler() );
 
     // MSC File System Handler
-    kernel->add_module( new(AHB) MSCFileSystem("ud") );
+    kernel->add_module( new MSCFileSystem("ud") );
 
     // Serial Console handles IO with the wireless probe
-    kernel->add_module( new(AHB) SerialConsole2() );
+    kernel->add_module( new(AHB) SerialConsole2() ); // must stay in AHB: UART RxIrq writes RingBuffer
 
-    kernel->add_module( new(AHB) MainButton() );
+    kernel->add_module( new MainButton() );
 
     // Wifi Provider
-    kernel->add_module( new(AHB) WifiProvider);
+    kernel->add_module( new WifiProvider);
 
     // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
     #ifndef NO_TOOLS_SWITCH
@@ -183,20 +183,20 @@ void init() {
 
     // #ifndef NO_TOOLS_TEMPERATURECONTROL
     // Note order is important here must be after extruder so Tn as a parameter will get executed first
-    TemperatureControlPool *tp= new(AHB) TemperatureControlPool();
+    TemperatureControlPool *tp= new TemperatureControlPool();
     tp->load_tools();
     delete tp;
 
     // #endif
     #ifndef NO_TOOLS_ENDSTOPS
-    kernel->add_module( new(AHB) Endstops() );
+    kernel->add_module( new Endstops() );
     #endif
     #ifndef NO_TOOLS_LASER
-    kernel->add_module( new(AHB) Laser() );
+    kernel->add_module( new Laser() );
     #endif
 
     #ifndef NO_TOOLS_SPINDLE
-    SpindleMaker *sm = new(AHB) SpindleMaker();
+    SpindleMaker *sm = new SpindleMaker();
     sm->load_spindle();
     delete sm;
     //kernel->add_module( new(AHB) Spindle() );
@@ -205,23 +205,23 @@ void init() {
     // kernel->add_module( new(AHB) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new(AHB) ZProbe() );
+    kernel->add_module( new ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
-    kernel->add_module( new(AHB) SCARAcal() );
+    kernel->add_module( new SCARAcal() );
     #endif
     #ifndef NO_TOOLS_ROTARYDELTACALIBRATION
-    kernel->add_module( new(AHB) RotaryDeltaCalibration() );
+    kernel->add_module( new RotaryDeltaCalibration() );
     #endif
 //    #ifndef NONETWORK
 //    kernel->add_module( new Network() );
 //    #endif
     #ifndef NO_TOOLS_TEMPERATURESWITCH
     // Must be loaded after TemperatureControl
-    kernel->add_module( new(AHB) TemperatureSwitch() );
+    kernel->add_module( new TemperatureSwitch() );
     #endif
     #ifndef NO_TOOLS_DRILLINGCYCLES
-    kernel->add_module( new(AHB) Drillingcycles() );
+    kernel->add_module( new Drillingcycles() );
     #endif
     // Create and initialize USB stuff
     // u.init();
@@ -232,7 +232,7 @@ void init() {
         kernel->add_module( msc );
     }
 #else
-    if (!kernel->config->value( disable_msd_checksum )->by_default(false)->as_bool()) {
+    if (!kernel->config->value( disable_msd_checksum )->as_bool(false)) {
         kernel->add_module( &msc );
     }
 #endif
@@ -240,12 +240,12 @@ void init() {
 
     /* disable USB module
     kernel->add_module( &usbserial );
-    if( kernel->config->value( second_usb_serial_enable_checksum )->by_default(false)->as_bool() ){
-        kernel->add_module( new(AHB) USBSerial(&u) );
+    if( kernel->config->value( second_usb_serial_enable_checksum )->as_bool(false) ){
+        kernel->add_module( new USBSerial(&u) );
     }
     */
 
-    // if( kernel->config->value( dfu_enable_checksum )->by_default(false)->as_bool() ){
+    // if( kernel->config->value( dfu_enable_checksum )->as_bool(false) ){
     //     kernel->add_module( new(AHB) DFU(&u));
     // }
 
@@ -253,10 +253,10 @@ void init() {
 
     // LUKE : DISABLED
 
-    float t= kernel->config->value( watchdog_timeout_checksum )->by_default(10.0F)->as_number();
+    float t= kernel->config->value( watchdog_timeout_checksum )->as_number(10.0F);
     if(t > 0.1F) {
         // NOTE setting WDT_RESET with the current bootloader would leave it in DFU mode which would be suboptimal
-        kernel->add_module( new(AHB) Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
+        kernel->add_module( new Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
         kernel->streams->printf("Watchdog enabled for %1.3f seconds\n", t);
     }else{
         kernel->streams->printf("WARNING Watchdog is disabled\n");

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -50,7 +50,7 @@ void SerialConsole::on_module_loaded() {
     halt_flag = false;
     diagnose_flag = false;
 
-    default_baud_rate = THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(current_baud_rate)->as_number();
+    default_baud_rate = THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->as_number(current_baud_rate);
     if (default_baud_rate != current_baud_rate) {
         this->serial->baud(default_baud_rate);
         this->current_baud_rate = default_baud_rate;

--- a/src/modules/communication/SerialConsole2.cpp
+++ b/src/modules/communication/SerialConsole2.cpp
@@ -43,13 +43,13 @@ SerialConsole2::SerialConsole2() {
 void SerialConsole2::on_module_loaded() {
 
 	this->serial = new mbed::Serial( P0_2, P0_3 );
-    this->serial->baud(THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+    this->serial->baud(THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->as_number(DEFAULT_SERIAL_BAUD_RATE));
 
     // We want to be called every time a new char is received
     this->serial->attach(this, &SerialConsole2::on_serial_char_received, mbed::Serial::RxIrq);
 
-    this->min_voltage = THEKERNEL->config->value(wp_checksum, min_voltage_checksum)->by_default(3.6F)->as_number();
-    this->max_voltage = THEKERNEL->config->value(wp_checksum, max_voltage_checksum)->by_default(4.1F)->as_number();
+    this->min_voltage = THEKERNEL->config->value(wp_checksum, min_voltage_checksum)->as_number(3.6F);
+    this->max_voltage = THEKERNEL->config->value(wp_checksum, max_voltage_checksum)->as_number(4.1F);
 
     // We only call the command dispatcher in the main loop, nowhere else
     this->register_for_event(ON_MAIN_LOOP);

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -74,8 +74,8 @@ void Conveyor::on_module_loaded()
 
     // Attach to the end_of_move stepper event
     //THEKERNEL->step_ticker->finished_fnc = std::bind( &Conveyor::all_moves_finished, this);
-    queue_size = THEKERNEL->config->value(planner_queue_size_checksum)->by_default(32)->as_number();
-    queue_delay_time_ms = THEKERNEL->config->value(queue_delay_time_ms_checksum)->by_default(100)->as_number();
+    queue_size = THEKERNEL->config->value(planner_queue_size_checksum)->as_number(32);
+    queue_delay_time_ms = THEKERNEL->config->value(queue_delay_time_ms_checksum)->as_number(100);
 }
 
 // we allocate the queue here after config is completed so we do not run out of memory during config

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -42,9 +42,9 @@ Planner::Planner()
 // Configure acceleration
 void Planner::config_load()
 {
-    this->junction_deviation = THEKERNEL->config->value(junction_deviation_checksum)->by_default(0.05F)->as_number();
-    this->z_junction_deviation = THEKERNEL->config->value(z_junction_deviation_checksum)->by_default(NAN)->as_number(); // disabled by default
-    this->minimum_planner_speed = THEKERNEL->config->value(minimum_planner_speed_checksum)->by_default(0.0f)->as_number();
+    this->junction_deviation = THEKERNEL->config->value(junction_deviation_checksum)->as_number(0.05F);
+    this->z_junction_deviation = THEKERNEL->config->value(z_junction_deviation_checksum)->as_number(NAN); // disabled by default
+    this->minimum_planner_speed = THEKERNEL->config->value(minimum_planner_speed_checksum)->as_number(0.0f);
 }
 
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -157,7 +157,7 @@ void Robot::on_module_loaded()
     float tlo[3] = {0, 0, THEKERNEL->eeprom_data->TLO};
     this->loadToolOffset(tlo);
     this->tool_not_calibrated = THEKERNEL->eeprom_data->tool_not_calibrated;
-    this->load_last_wcs = THEKERNEL->config->value(load_last_wcs_checksum)->by_default(false)->as_bool();
+    this->load_last_wcs = THEKERNEL->config->value(load_last_wcs_checksum)->as_bool(false);
     if (this->load_last_wcs)
     {
         this->current_wcs = THEKERNEL->eeprom_data->current_wcs;
@@ -202,7 +202,7 @@ void Robot::load_config()
     // To make adding those solution easier, they have their own, separate object.
     // Here we read the config to find out which arm solution to use
     if (this->arm_solution) delete this->arm_solution;
-    int solution_checksum = get_checksum(THEKERNEL->config->value(arm_solution_checksum)->by_default("cartesian")->as_string());
+    int solution_checksum = get_checksum(THEKERNEL->config->value(arm_solution_checksum)->as_string("cartesian"));
     // Note checksums are not const expressions when in debug mode, so don't use switch
 #ifndef CARTESIAN_ONLY
     if(solution_checksum == hbot_checksum || solution_checksum == corexy_checksum) {
@@ -232,24 +232,24 @@ void Robot::load_config()
         this->arm_solution = new CartesianSolution(THEKERNEL->config);
     }
 
-    this->feed_rate           = THEKERNEL->config->value(default_feed_rate_checksum   )->by_default( 1000.0F)->as_number();
-    this->seek_rate           = THEKERNEL->config->value(default_seek_rate_checksum   )->by_default( 3000.0F)->as_number();
-    this->mm_per_line_segment = THEKERNEL->config->value(mm_per_line_segment_checksum )->by_default(    5.0F)->as_number();
-    this->delta_segments_per_second = THEKERNEL->config->value(delta_segments_per_second_checksum )->by_default(0.0f   )->as_number();
-    this->mm_per_arc_segment  = THEKERNEL->config->value(mm_per_arc_segment_checksum  )->by_default(    0.0f)->as_number();
-    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error_checksum    )->by_default(   0.002f)->as_number();
-    this->arc_correction      = THEKERNEL->config->value(arc_correction_checksum      )->by_default(    5   )->as_number();
+    this->feed_rate           = THEKERNEL->config->value(default_feed_rate_checksum   )->as_number( 1000.0F);
+    this->seek_rate           = THEKERNEL->config->value(default_seek_rate_checksum   )->as_number( 3000.0F);
+    this->mm_per_line_segment = THEKERNEL->config->value(mm_per_line_segment_checksum )->as_number(    5.0F);
+    this->delta_segments_per_second = THEKERNEL->config->value(delta_segments_per_second_checksum )->as_number(0.0f   );
+    this->mm_per_arc_segment  = THEKERNEL->config->value(mm_per_arc_segment_checksum  )->as_number(    0.0f);
+    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error_checksum    )->as_number(   0.002f);
+    this->arc_correction      = THEKERNEL->config->value(arc_correction_checksum      )->as_number(    5   );
 
     // in mm/sec but specified in config as mm/min
-    this->max_speeds[X_AXIS]  = THEKERNEL->config->value(x_axis_max_speed_checksum    )->by_default(4000.0F)->as_number() / 60.0F;
-    this->max_speeds[Y_AXIS]  = THEKERNEL->config->value(y_axis_max_speed_checksum    )->by_default(4000.0F)->as_number() / 60.0F;
-    this->max_speeds[Z_AXIS]  = THEKERNEL->config->value(z_axis_max_speed_checksum    )->by_default(3000.0F)->as_number() / 60.0F;
-    this->max_speed           = THEKERNEL->config->value(max_speed_checksum           )->by_default(  -60.0F)->as_number() / 60.0F;
+    this->max_speeds[X_AXIS]  = THEKERNEL->config->value(x_axis_max_speed_checksum    )->as_number(4000.0F) / 60.0F;
+    this->max_speeds[Y_AXIS]  = THEKERNEL->config->value(y_axis_max_speed_checksum    )->as_number(4000.0F) / 60.0F;
+    this->max_speeds[Z_AXIS]  = THEKERNEL->config->value(z_axis_max_speed_checksum    )->as_number(3000.0F) / 60.0F;
+    this->max_speed           = THEKERNEL->config->value(max_speed_checksum           )->as_number(  -60.0F) / 60.0F;
 
-    this->segment_z_moves     = THEKERNEL->config->value(segment_z_moves_checksum     )->by_default(true)->as_bool();
-    this->save_g92            = THEKERNEL->config->value(save_g92_checksum            )->by_default(false)->as_bool();
-    this->save_g54            = THEKERNEL->config->value(save_g54_checksum            )->by_default(THEKERNEL->is_grbl_mode())->as_bool();
-    string g92                = THEKERNEL->config->value(set_g92_checksum             )->by_default("")->as_string();
+    this->segment_z_moves     = THEKERNEL->config->value(segment_z_moves_checksum     )->as_bool(true);
+    this->save_g92            = THEKERNEL->config->value(save_g92_checksum            )->as_bool(false);
+    this->save_g54            = THEKERNEL->config->value(save_g54_checksum            )->as_bool(THEKERNEL->is_grbl_mode());
+    string g92                = THEKERNEL->config->value(set_g92_checksum             )->as_string("");
     if(!g92.empty()) {
         // optional setting for a fixed G92 offset
         std::vector<float> t= parse_number_list(g92.c_str());
@@ -264,8 +264,8 @@ void Robot::load_config()
     }
 
     // default s value for laser
-    this->s_value = THEKERNEL->config->value(laser_module_default_power_checksum)->by_default(1.0F)->as_number()
-    					* THEKERNEL->config->value(laser_module_maximum_s_value_checksum)->by_default(1.0f)->as_number();
+    this->s_value = THEKERNEL->config->value(laser_module_default_power_checksum)->as_number(1.0F)
+    					* THEKERNEL->config->value(laser_module_maximum_s_value_checksum)->as_number(1.0f);
 
     // 2024
     /*
@@ -273,9 +273,9 @@ void Robot::load_config()
 	this->s_count = 1;
 	*/
 
-	this->laser_module_offset_x = THEKERNEL->config->value(laser_module_offset_x_checksum)->by_default(-38.0f)->as_number() ;
-	this->laser_module_offset_y = THEKERNEL->config->value(laser_module_offset_y_checksum)->by_default(5.0f)->as_number() ;
-	this->laser_module_offset_z = THEKERNEL->config->value(laser_module_offset_z_checksum)->by_default(-40.0f)->as_number() ;
+	this->laser_module_offset_x = THEKERNEL->config->value(laser_module_offset_x_checksum)->as_number(-38.0f) ;
+	this->laser_module_offset_y = THEKERNEL->config->value(laser_module_offset_y_checksum)->as_number(5.0f) ;
+	this->laser_module_offset_z = THEKERNEL->config->value(laser_module_offset_z_checksum)->as_number(-40.0f) ;
 
 
     // Make our Primary XYZ StepperMotors, and potentially A B C
@@ -295,13 +295,13 @@ void Robot::load_config()
     };
 
     // default acceleration setting, can be overriden with newer per axis settings
-    this->default_acceleration= THEKERNEL->config->value(acceleration_checksum)->by_default(100.0F )->as_number(); // Acceleration is in mm/s^2
+    this->default_acceleration= THEKERNEL->config->value(acceleration_checksum)->as_number(100.0F ); // Acceleration is in mm/s^2
 
     // make each motor
     for (size_t a = 0; a < MAX_ROBOT_ACTUATORS; a++) {
         Pin pins[3]; //step, dir, enable
         for (size_t i = 0; i < 3; i++) {
-            pins[i].from_string(THEKERNEL->config->value(motor_checksums[a][i])->by_default("nc")->as_string())->as_output();
+            pins[i].from_string(THEKERNEL->config->value(motor_checksums[a][i])->as_string("nc"))->as_output();
         }
 
         if(!pins[0].connected() || !pins[1].connected()) { // step and dir must be defined, but enable is optional
@@ -324,9 +324,9 @@ void Robot::load_config()
 
         if((THEKERNEL->factory_set->FuncSetting & (1<<0)) && (a == 3))
 		{
-			uint16_t s = THEKERNEL->config->value(motor_checksums[a][4])->by_default(3000.0F)->as_number();
+			uint16_t s = THEKERNEL->config->value(motor_checksums[a][4])->as_number(3000.0F);
 			actuators[a]->set_max_rate( s/60.0F); // it is in mm/min and converted to mm/sec
-        	float steps = THEKERNEL->config->value(motor_checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number();
+        	float steps = THEKERNEL->config->value(motor_checksums[a][3])->as_number(a == 2 ? 2560.0F : 80.0F);
         	if(CARVERA == THEKERNEL->factory_set->MachineModel)
         	{
         		steps = steps * 16.666666;
@@ -335,18 +335,18 @@ void Robot::load_config()
         }
         else
         {
-        	actuators[a]->change_steps_per_mm(THEKERNEL->config->value(motor_checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
-        	actuators[a]->change_steps_per_mm(THEKERNEL->config->value(motor_checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
-        	actuators[a]->set_max_rate(THEKERNEL->config->value(motor_checksums[a][4])->by_default(3000.0F)->as_number()/60.0F); // it is in mm/min and converted to mm/sec
+        	actuators[a]->change_steps_per_mm(THEKERNEL->config->value(motor_checksums[a][3])->as_number(a == 2 ? 2560.0F : 80.0F));
+        	actuators[a]->change_steps_per_mm(THEKERNEL->config->value(motor_checksums[a][3])->as_number(a == 2 ? 2560.0F : 80.0F));
+        	actuators[a]->set_max_rate(THEKERNEL->config->value(motor_checksums[a][4])->as_number(3000.0F)/60.0F); // it is in mm/min and converted to mm/sec
         }
-        actuators[a]->set_acceleration(THEKERNEL->config->value(motor_checksums[a][5])->by_default(NAN)->as_number()); // mm/secs²
+        actuators[a]->set_acceleration(THEKERNEL->config->value(motor_checksums[a][5])->as_number(NAN)); // mm/secs²
     }
 
     check_max_actuator_speeds(); // check the configs are sane
 
     // if we have not specified a z acceleration see if the legacy config was set
     if(isnan(actuators[Z_AXIS]->get_acceleration())) {
-        float acc= THEKERNEL->config->value(z_acceleration_checksum)->by_default(NAN)->as_number(); // disabled by default
+        float acc= THEKERNEL->config->value(z_acceleration_checksum)->as_number(NAN); // disabled by default
         if(!isnan(acc)) {
             actuators[Z_AXIS]->set_acceleration(acc);
         }
@@ -369,15 +369,15 @@ void Robot::load_config()
 
     //this->clearToolOffset();
 
-    soft_endstop_enabled= THEKERNEL->config->value(soft_endstop_checksum, enable_checksum)->by_default(true)->as_bool();
-    soft_endstop_halt = THEKERNEL->config->value(soft_endstop_checksum, halt_checksum)->by_default(true)->as_bool();
+    soft_endstop_enabled= THEKERNEL->config->value(soft_endstop_checksum, enable_checksum)->as_bool(true);
+    soft_endstop_halt = THEKERNEL->config->value(soft_endstop_checksum, halt_checksum)->as_bool(true);
 
     soft_endstop_max[X_AXIS]= -1;
     soft_endstop_max[Y_AXIS]= -1;
     soft_endstop_max[Z_AXIS]= -1;
-    soft_endstop_min[X_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, xmin_checksum)->by_default(-371.0F)->as_number();
-    soft_endstop_min[Y_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, ymin_checksum)->by_default(-250.0F)->as_number();
-    soft_endstop_min[Z_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, zmin_checksum)->by_default(-135.0F)->as_number();
+    soft_endstop_min[X_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, xmin_checksum)->as_number(-371.0F);
+    soft_endstop_min[Y_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, ymin_checksum)->as_number(-250.0F);
+    soft_endstop_min[Z_AXIS] = THEKERNEL->config->value(soft_endstop_checksum, zmin_checksum)->as_number(-135.0F);
 }
 
 uint8_t Robot::register_motor(StepperMotor *motor)
@@ -1422,7 +1422,7 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
     // G0 is non-modal for feed: without F use default seek rate; F on G0 applies only to that line
     if (motion_mode == SEEK) {
         if (THEKERNEL->config->is_config_cache_loaded()) {
-            this->seek_rate = THEKERNEL->config->value(default_seek_rate_checksum)->by_default(3000.0F)->as_number();
+            this->seek_rate = THEKERNEL->config->value(default_seek_rate_checksum)->as_number(3000.0F);
         } else {
             this->seek_rate = 3000.0F;
         }

--- a/src/modules/robot/arm_solutions/CoreXZSolution.cpp
+++ b/src/modules/robot/arm_solutions/CoreXZSolution.cpp
@@ -8,8 +8,8 @@
 
 CoreXZSolution::CoreXZSolution(Config* config)
 {
-    x_reduction = config->value(x_reduction_checksum)->by_default(1.0f)->as_number();
-    z_reduction = config->value(z_reduction_checksum)->by_default(3.0f)->as_number();
+    x_reduction = config->value(x_reduction_checksum)->as_number(1.0f);
+    z_reduction = config->value(z_reduction_checksum)->as_number(3.0f);
 }
 
 void CoreXZSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ) const {

--- a/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.cpp
@@ -20,20 +20,20 @@
 // NOTE this currently does not work, needs FK and settings
 ExperimentalDeltaSolution::ExperimentalDeltaSolution(Config* config)
 {
-    float alpha_angle  = PIOVER180 * config->value(alpha_angle_checksum)->by_default(30.0f)->as_number();
+    float alpha_angle  = PIOVER180 * config->value(alpha_angle_checksum)->as_number(30.0f);
     sin_alpha     = sinf(alpha_angle);
     cos_alpha     = cosf(alpha_angle);
-    float beta_angle   = PIOVER180 * config->value( beta_relative_angle_checksum)->by_default(120.0f)->as_number();
+    float beta_angle   = PIOVER180 * config->value( beta_relative_angle_checksum)->as_number(120.0f);
     sin_beta      = sinf(beta_angle);
     cos_beta      = cosf(beta_angle);
-    float gamma_angle  = PIOVER180 * config->value(gamma_relative_angle_checksum)->by_default(240.0f)->as_number();
+    float gamma_angle  = PIOVER180 * config->value(gamma_relative_angle_checksum)->as_number(240.0f);
     sin_gamma     = sinf(gamma_angle);
     cos_gamma     = cosf(gamma_angle);
 
     // arm_length is the length of the arm from hinge to hinge
-    arm_length         = config->value(arm_length_checksum)->by_default(250.0f)->as_number();
+    arm_length         = config->value(arm_length_checksum)->as_number(250.0f);
     // arm_radius is the horizontal distance from hinge to hinge when the effector is centered
-    arm_radius         = config->value(arm_radius_checksum)->by_default(124.0f)->as_number();
+    arm_radius         = config->value(arm_radius_checksum)->as_number(124.0f);
 
     arm_length_squared = powf(arm_length, 2);
 }

--- a/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
@@ -27,16 +27,16 @@
 LinearDeltaSolution::LinearDeltaSolution(Config* config)
 {
     // arm_length is the length of the arm from hinge to hinge
-    arm_length = config->value(arm_length_checksum)->by_default(250.0f)->as_number();
+    arm_length = config->value(arm_length_checksum)->as_number(250.0f);
     // arm_radius is the horizontal distance from hinge to hinge when the effector is centered
-    arm_radius = config->value(arm_radius_checksum)->by_default(124.0f)->as_number();
+    arm_radius = config->value(arm_radius_checksum)->as_number(124.0f);
 
-    tower1_angle = config->value(tower1_angle_checksum)->by_default(0.0f)->as_number();
-    tower2_angle = config->value(tower2_angle_checksum)->by_default(0.0f)->as_number();
-    tower3_angle = config->value(tower3_angle_checksum)->by_default(0.0f)->as_number();
-    tower1_offset = config->value(tower1_offset_checksum)->by_default(0.0f)->as_number();
-    tower2_offset = config->value(tower2_offset_checksum)->by_default(0.0f)->as_number();
-    tower3_offset = config->value(tower3_offset_checksum)->by_default(0.0f)->as_number();
+    tower1_angle = config->value(tower1_angle_checksum)->as_number(0.0f);
+    tower2_angle = config->value(tower2_angle_checksum)->as_number(0.0f);
+    tower3_angle = config->value(tower3_angle_checksum)->as_number(0.0f);
+    tower1_offset = config->value(tower1_offset_checksum)->as_number(0.0f);
+    tower2_offset = config->value(tower2_offset_checksum)->as_number(0.0f);
+    tower3_offset = config->value(tower3_offset_checksum)->as_number(0.0f);
 
     init();
 }

--- a/src/modules/robot/arm_solutions/MorganSCARASolution.cpp
+++ b/src/modules/robot/arm_solutions/MorganSCARASolution.cpp
@@ -27,23 +27,23 @@
 MorganSCARASolution::MorganSCARASolution(Config* config)
 {
     // arm1_length is the length of the inner main arm from hinge to hinge
-    arm1_length         = config->value(arm1_length_checksum)->by_default(150.0f)->as_number();
+    arm1_length         = config->value(arm1_length_checksum)->as_number(150.0f);
     // arm2_length is the length of the inner main arm from hinge to hinge
-    arm2_length         = config->value(arm2_length_checksum)->by_default(150.0f)->as_number();
+    arm2_length         = config->value(arm2_length_checksum)->as_number(150.0f);
     // morgan_offset_x is the x offset of bed zero position towards the SCARA tower center
-    morgan_offset_x     = config->value(morgan_offset_x_checksum)->by_default(100.0f)->as_number();
+    morgan_offset_x     = config->value(morgan_offset_x_checksum)->as_number(100.0f);
     // morgan_offset_y is the y offset of bed zero position towards the SCARA tower center
-    morgan_offset_y     = config->value(morgan_offset_y_checksum)->by_default(-60.0f)->as_number();
+    morgan_offset_y     = config->value(morgan_offset_y_checksum)->as_number(-60.0f);
     // Axis scaling is used in final calibration
-    morgan_scaling_x    = config->value(morgan_scaling_x_checksum)->by_default(1.0F)->as_number(); // 1 = 100% : No scaling
-    morgan_scaling_y    = config->value(morgan_scaling_y_checksum)->by_default(1.0F)->as_number();
+    morgan_scaling_x    = config->value(morgan_scaling_x_checksum)->as_number(1.0F); // 1 = 100% : No scaling
+    morgan_scaling_y    = config->value(morgan_scaling_y_checksum)->as_number(1.0F);
     // morgan_undefined is the ratio at which the SCARA position is undefined.
     // required to prevent the arm moving through singularity points
     // min: head close to tower
-    morgan_undefined_min  = config->value(morgan_undefined_min_checksum)->by_default(0.95f)->as_number();
+    morgan_undefined_min  = config->value(morgan_undefined_min_checksum)->as_number(0.95f);
     // max: head on maximum reach
-    morgan_undefined_max  = config->value(morgan_undefined_max_checksum)->by_default(0.95f)->as_number();
-    real_scara  = config->value(real_scara_checksum)->by_default(false)->as_bool();
+    morgan_undefined_max  = config->value(morgan_undefined_max_checksum)->as_number(0.95f);
+    real_scara  = config->value(real_scara_checksum)->as_bool(false);
     
     init();
 }

--- a/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
@@ -32,29 +32,29 @@ const static float tan30  = 0.57735026918962576450914878050196; //1/sqrt3
 RotaryDeltaSolution::RotaryDeltaSolution(Config *config)
 {
     // End effector length
-    delta_e = config->value(delta_e_checksum)->by_default(131.636F)->as_number();
+    delta_e = config->value(delta_e_checksum)->as_number(131.636F);
 
     // Base length
-    delta_f = config->value(delta_f_checksum)->by_default(190.526F)->as_number();
+    delta_f = config->value(delta_f_checksum)->as_number(190.526F);
 
     // Carbon rod length
-    delta_re = config->value(delta_re_checksum)->by_default(270.000F)->as_number();
+    delta_re = config->value(delta_re_checksum)->as_number(270.000F);
 
     // Servo horn length
-    delta_rf = config->value(delta_rf_checksum)->by_default(90.000F)->as_number();
+    delta_rf = config->value(delta_rf_checksum)->as_number(90.000F);
 
     // Distance from delta 8mm rod/pulley to table/bed,
     // NOTE: For OpenPnP, set the zero to be about 25mm above the bed..
-    delta_z_offset = config->value(delta_z_offset_checksum)->by_default(290.700F)->as_number();
+    delta_z_offset = config->value(delta_z_offset_checksum)->as_number(290.700F);
 
     // Ball joint plane to bottom of end effector surface
-    delta_ee_offs = config->value(delta_ee_offs_checksum)->by_default(15.000F)->as_number();
+    delta_ee_offs = config->value(delta_ee_offs_checksum)->as_number(15.000F);
 
     // Distance between end effector ball joint plane and tip of tool (PnP)
-    tool_offset = config->value(tool_offset_checksum)->by_default(30.500F)->as_number();
+    tool_offset = config->value(tool_offset_checksum)->as_number(30.500F);
 
     // mirror the XY axis
-    mirror_xy= config->value(delta_mirror_xy_checksum)->by_default(true)->as_bool();
+    mirror_xy= config->value(delta_mirror_xy_checksum)->as_bool(true);
 
     debug_flag= false;
     init();

--- a/src/modules/robot/arm_solutions/RotatableCartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotatableCartesianSolution.cpp
@@ -9,7 +9,7 @@
 
 RotatableCartesianSolution::RotatableCartesianSolution(Config* config)
 {
-    float alpha_angle  = config->value(alpha_angle_checksum)->by_default(0.0f)->as_number() * DEG2RAD;
+    float alpha_angle  = config->value(alpha_angle_checksum)->as_number(0.0f) * DEG2RAD;
     sin_alpha          = sinf(alpha_angle);
     cos_alpha          = cosf(alpha_angle);
 }

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1437,61 +1437,61 @@ void ATCHandler::on_config_reload(void *argument)
 	
 	if(CARVERA == THEKERNEL->factory_set->MachineModel)
 	{
-		atc_home_info.pin.from_string( THEKERNEL->config->value(atc_checksum, endstop_pin_checksum)->by_default("1.0^" )->as_string())->as_input();
+		atc_home_info.pin.from_string( THEKERNEL->config->value(atc_checksum, endstop_pin_checksum)->as_string("1.0^" ))->as_input();
 	}
 	else
 	{
-		atc_home_info.pin.from_string( THEKERNEL->config->value(atc_checksum, endstop_pin_checksum)->by_default("1.4^" )->as_string())->as_input();
+		atc_home_info.pin.from_string( THEKERNEL->config->value(atc_checksum, endstop_pin_checksum)->as_string("1.4^" ))->as_input();
 	}
-	atc_home_info.debounce_ms    = THEKERNEL->config->value(atc_checksum, debounce_ms_checksum)->by_default(1  )->as_number();
-	atc_home_info.max_travel    = THEKERNEL->config->value(atc_checksum, max_travel_mm_checksum)->by_default(8  )->as_number();
-	atc_home_info.retract    = THEKERNEL->config->value(atc_checksum, homing_retract_mm_checksum)->by_default(3  )->as_number();
-	atc_home_info.action_dist    = THEKERNEL->config->value(atc_checksum, action_mm_checksum)->by_default(1  )->as_number();
-	atc_home_info.homing_rate    = THEKERNEL->config->value(atc_checksum, homing_rate_mm_s_checksum)->by_default(0.4f )->as_number();
-	atc_home_info.action_rate    = THEKERNEL->config->value(atc_checksum, action_rate_mm_s_checksum)->by_default(0.25f)->as_number();
+	atc_home_info.debounce_ms    = THEKERNEL->config->value(atc_checksum, debounce_ms_checksum)->as_number(1  );
+	atc_home_info.max_travel    = THEKERNEL->config->value(atc_checksum, max_travel_mm_checksum)->as_number(8  );
+	atc_home_info.retract    = THEKERNEL->config->value(atc_checksum, homing_retract_mm_checksum)->as_number(3  );
+	atc_home_info.action_dist    = THEKERNEL->config->value(atc_checksum, action_mm_checksum)->as_number(1  );
+	atc_home_info.homing_rate    = THEKERNEL->config->value(atc_checksum, homing_rate_mm_s_checksum)->as_number(0.4f );
+	atc_home_info.action_rate    = THEKERNEL->config->value(atc_checksum, action_rate_mm_s_checksum)->as_number(0.25f);
 
-	detector_info.detect_pin.from_string( THEKERNEL->config->value(atc_checksum, detector_checksum, detect_pin_checksum)->by_default("0.20^" )->as_string())->as_input();
-	detector_info.detect_rate = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_rate_mm_s_checksum)->by_default(1  )->as_number();
-	detector_info.detect_travel = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_travel_mm_checksum)->by_default(1  )->as_number();
-	this->disable_toolsensor = !THEKERNEL->config->value(atc_checksum, detector_checksum, enable_checksum)->by_default(true)->as_bool();
+	detector_info.detect_pin.from_string( THEKERNEL->config->value(atc_checksum, detector_checksum, detect_pin_checksum)->as_string("0.20^" ))->as_input();
+	detector_info.detect_rate = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_rate_mm_s_checksum)->as_number(1  );
+	detector_info.detect_travel = THEKERNEL->config->value(atc_checksum, detector_checksum, detect_travel_mm_checksum)->as_number(1  );
+	this->disable_toolsensor = !THEKERNEL->config->value(atc_checksum, detector_checksum, enable_checksum)->as_bool(true);
 
-	this->safe_z_mm = THEKERNEL->config->value(atc_checksum, safe_z_checksum)->by_default(-10)->as_number();
-	this->safe_z_empty_mm = THEKERNEL->config->value(atc_checksum, safe_z_empty_checksum)->by_default(-20)->as_number();
-	this->safe_z_offset_mm = THEKERNEL->config->value(atc_checksum, safe_z_offset_checksum)->by_default(10)->as_number();
-	this->fast_z_rate = THEKERNEL->config->value(atc_checksum, fast_z_rate_checksum)->by_default(500)->as_number();
-	this->slow_z_rate = THEKERNEL->config->value(atc_checksum, slow_z_rate_checksum)->by_default(60)->as_number();
-	this->margin_rate = THEKERNEL->config->value(atc_checksum, margin_rate_checksum)->by_default(1000)->as_number();
+	this->safe_z_mm = THEKERNEL->config->value(atc_checksum, safe_z_checksum)->as_number(-10);
+	this->safe_z_empty_mm = THEKERNEL->config->value(atc_checksum, safe_z_empty_checksum)->as_number(-20);
+	this->safe_z_offset_mm = THEKERNEL->config->value(atc_checksum, safe_z_offset_checksum)->as_number(10);
+	this->fast_z_rate = THEKERNEL->config->value(atc_checksum, fast_z_rate_checksum)->as_number(500);
+	this->slow_z_rate = THEKERNEL->config->value(atc_checksum, slow_z_rate_checksum)->as_number(60);
+	this->margin_rate = THEKERNEL->config->value(atc_checksum, margin_rate_checksum)->as_number(1000);
 
-	this->probe_fast_rate = THEKERNEL->config->value(atc_checksum, probe_checksum, fast_rate_mm_m_checksum)->by_default(300  )->as_number();
-	this->probe_slow_rate = THEKERNEL->config->value(atc_checksum, probe_checksum, slow_rate_mm_m_checksum)->by_default(60   )->as_number();
-	this->probe_retract_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, retract_mm_checksum)->by_default(2   )->as_number();
-	this->probe_height_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, probe_height_mm_checksum)->by_default(0   )->as_number();
+	this->probe_fast_rate = THEKERNEL->config->value(atc_checksum, probe_checksum, fast_rate_mm_m_checksum)->as_number(300  );
+	this->probe_slow_rate = THEKERNEL->config->value(atc_checksum, probe_checksum, slow_rate_mm_m_checksum)->as_number(60   );
+	this->probe_retract_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, retract_mm_checksum)->as_number(2   );
+	this->probe_height_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, probe_height_mm_checksum)->as_number(0   );
 	
-	this->anchor_width = THEKERNEL->config->value(coordinate_checksum, anchor_width_checksum)->by_default(15  )->as_number();
-	this->anchor1_x = THEKERNEL->config->value(coordinate_checksum, anchor1_x_checksum)->by_default(-359  )->as_number();
-	this->anchor1_y = THEKERNEL->config->value(coordinate_checksum, anchor1_y_checksum)->by_default(-234  )->as_number();
-	this->anchor2_offset_x = THEKERNEL->config->value(coordinate_checksum, anchor2_offset_x_checksum)->by_default(90  )->as_number();
-	this->anchor2_offset_y = THEKERNEL->config->value(coordinate_checksum, anchor2_offset_y_checksum)->by_default(45.65F  )->as_number();
+	this->anchor_width = THEKERNEL->config->value(coordinate_checksum, anchor_width_checksum)->as_number(15  );
+	this->anchor1_x = THEKERNEL->config->value(coordinate_checksum, anchor1_x_checksum)->as_number(-359  );
+	this->anchor1_y = THEKERNEL->config->value(coordinate_checksum, anchor1_y_checksum)->as_number(-234  );
+	this->anchor2_offset_x = THEKERNEL->config->value(coordinate_checksum, anchor2_offset_x_checksum)->as_number(90  );
+	this->anchor2_offset_y = THEKERNEL->config->value(coordinate_checksum, anchor2_offset_y_checksum)->as_number(45.65F  );
 	
 	if(CARVERA == THEKERNEL->factory_set->MachineModel)
 	{
-		this->toolrack_z = THEKERNEL->config->value(coordinate_checksum, toolrack_z_checksum)->by_default(-105  )->as_number();
-		this->toolrack_offset_x = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_x_checksum)->by_default(356  )->as_number();
-		this->toolrack_offset_y = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_y_checksum)->by_default(0  )->as_number();
+		this->toolrack_z = THEKERNEL->config->value(coordinate_checksum, toolrack_z_checksum)->as_number(-105  );
+		this->toolrack_offset_x = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_x_checksum)->as_number(356  );
+		this->toolrack_offset_y = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_y_checksum)->as_number(0  );
 		this->lowest_tool_number = 0;
 	}
 	else if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
 	{
-		this->toolrack_z = THEKERNEL->config->value(coordinate_checksum, toolrack_z_checksum)->by_default(-108  )->as_number();
-		this->toolrack_offset_x = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_x_checksum)->by_default(126  )->as_number();
-		this->toolrack_offset_y = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_y_checksum)->by_default(196  )->as_number();
+		this->toolrack_z = THEKERNEL->config->value(coordinate_checksum, toolrack_z_checksum)->as_number(-108  );
+		this->toolrack_offset_x = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_x_checksum)->as_number(126  );
+		this->toolrack_offset_y = THEKERNEL->config->value(coordinate_checksum, toolrack_offset_y_checksum)->as_number(196  );
 		this->lowest_tool_number = 1;
 	}
 
 	// Load configurable probe position (absolute MCS coordinates) before first use
-	this->probe_mcs_x = THEKERNEL->config->value(coordinate_checksum, probe_mcs_x_checksum)->by_default(NAN)->as_number();
-	this->probe_mcs_y = THEKERNEL->config->value(coordinate_checksum, probe_mcs_y_checksum)->by_default(NAN)->as_number();
-	this->probe_mcs_z = THEKERNEL->config->value(coordinate_checksum, probe_mcs_z_checksum)->by_default(NAN)->as_number();
+	this->probe_mcs_x = THEKERNEL->config->value(coordinate_checksum, probe_mcs_x_checksum)->as_number(NAN);
+	this->probe_mcs_y = THEKERNEL->config->value(coordinate_checksum, probe_mcs_y_checksum)->as_number(NAN);
+	this->probe_mcs_z = THEKERNEL->config->value(coordinate_checksum, probe_mcs_z_checksum)->as_number(NAN);
 	this->probe_position_configured = !isnan(this->probe_mcs_x) || !isnan(this->probe_mcs_y) || !isnan(this->probe_mcs_z);
 	
 	// Load custom tool slots configuration
@@ -1554,32 +1554,32 @@ void ATCHandler::on_config_reload(void *argument)
 	
 	if(CARVERA == THEKERNEL->factory_set->MachineModel)
 	{
-		this->rotation_offset_x = THEKERNEL->config->value(coordinate_checksum, rotation_offset_x_checksum)->by_default(-8  )->as_number();
-		this->rotation_offset_y = THEKERNEL->config->value(coordinate_checksum, rotation_offset_y_checksum)->by_default(37.5F  )->as_number();
-		this->rotation_offset_z = THEKERNEL->config->value(coordinate_checksum, rotation_offset_z_checksum)->by_default(22.5F  )->as_number();
+		this->rotation_offset_x = THEKERNEL->config->value(coordinate_checksum, rotation_offset_x_checksum)->as_number(-8  );
+		this->rotation_offset_y = THEKERNEL->config->value(coordinate_checksum, rotation_offset_y_checksum)->as_number(37.5F  );
+		this->rotation_offset_z = THEKERNEL->config->value(coordinate_checksum, rotation_offset_z_checksum)->as_number(22.5F  );
 	
-		this->clearance_x = THEKERNEL->config->value(coordinate_checksum, clearance_x_checksum)->by_default(-75  )->as_number();
-		this->clearance_y = THEKERNEL->config->value(coordinate_checksum, clearance_y_checksum)->by_default(-3  )->as_number();
-		this->clearance_z = THEKERNEL->config->value(coordinate_checksum, clearance_z_checksum)->by_default(-3  )->as_number();
+		this->clearance_x = THEKERNEL->config->value(coordinate_checksum, clearance_x_checksum)->as_number(-75  );
+		this->clearance_y = THEKERNEL->config->value(coordinate_checksum, clearance_y_checksum)->as_number(-3  );
+		this->clearance_z = THEKERNEL->config->value(coordinate_checksum, clearance_z_checksum)->as_number(-3  );
 	}
 	else if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
 	{
-		this->rotation_offset_x = THEKERNEL->config->value(coordinate_checksum, rotation_offset_x_checksum)->by_default(30.0F)->as_number();
-		this->rotation_offset_y = THEKERNEL->config->value(coordinate_checksum, rotation_offset_y_checksum)->by_default(82.5F  )->as_number();
-		this->rotation_offset_z = THEKERNEL->config->value(coordinate_checksum, rotation_offset_z_checksum)->by_default(23.0F  )->as_number();
+		this->rotation_offset_x = THEKERNEL->config->value(coordinate_checksum, rotation_offset_x_checksum)->as_number(30.0F);
+		this->rotation_offset_y = THEKERNEL->config->value(coordinate_checksum, rotation_offset_y_checksum)->as_number(82.5F  );
+		this->rotation_offset_z = THEKERNEL->config->value(coordinate_checksum, rotation_offset_z_checksum)->as_number(23.0F  );
 	
-		this->clearance_x = THEKERNEL->config->value(coordinate_checksum, clearance_x_checksum)->by_default(-5  )->as_number();
-		this->clearance_y = THEKERNEL->config->value(coordinate_checksum, clearance_y_checksum)->by_default(-21  )->as_number();
-		this->clearance_z = THEKERNEL->config->value(coordinate_checksum, clearance_z_checksum)->by_default(-5  )->as_number();
+		this->clearance_x = THEKERNEL->config->value(coordinate_checksum, clearance_x_checksum)->as_number(-5  );
+		this->clearance_y = THEKERNEL->config->value(coordinate_checksum, clearance_y_checksum)->as_number(-21  );
+		this->clearance_z = THEKERNEL->config->value(coordinate_checksum, clearance_z_checksum)->as_number(-5  );
 	}
-	this->rotation_width = THEKERNEL->config->value(coordinate_checksum, rotation_width_checksum)->by_default(100 )->as_number();
+	this->rotation_width = THEKERNEL->config->value(coordinate_checksum, rotation_width_checksum)->as_number(100 );
 
-	this->skip_path_origin = THEKERNEL->config->value(atc_checksum, skip_path_origin_checksum)->by_default(false)->as_bool();
-	this->three_axis_probe_tlo_correction = THEKERNEL->config->value(zprobe_checksum, three_axis_probe_tlo_correction_checksum)->by_default(0.0f)->as_number();
+	this->skip_path_origin = THEKERNEL->config->value(atc_checksum, skip_path_origin_checksum)->as_bool(false);
+	this->three_axis_probe_tlo_correction = THEKERNEL->config->value(zprobe_checksum, three_axis_probe_tlo_correction_checksum)->as_number(0.0f);
 	if(CARVERA == THEKERNEL->factory_set->MachineModel || CARVERA_AIR == THEKERNEL->factory_set->MachineModel){
-		this->ref_tool_mz = THEKERNEL->config->value(coordinate_checksum, reference_tool_mz_checksum)->by_default(-115.34f)->as_number(); // Represents the machine Z coordinate when the tool length is 0
+		this->ref_tool_mz = THEKERNEL->config->value(coordinate_checksum, reference_tool_mz_checksum)->as_number(-115.34f); // Represents the machine Z coordinate when the tool length is 0
 	}else{
-		this->ref_tool_mz = THEKERNEL->config->value(coordinate_checksum, reference_tool_mz_checksum)->by_default(-115.34f)->as_number(); // In preparation for the Z1. Update this value when the Z1 is implemented
+		this->ref_tool_mz = THEKERNEL->config->value(coordinate_checksum, reference_tool_mz_checksum)->as_number(-115.34f); // In preparation for the Z1. Update this value when the Z1 is implemented
 	}
 }
 

--- a/src/modules/tools/drillingcycles/Drillingcycles.cpp
+++ b/src/modules/tools/drillingcycles/Drillingcycles.cpp
@@ -40,7 +40,7 @@ Drillingcycles::Drillingcycles() {}
 void Drillingcycles::on_module_loaded()
 {
     // if the module is disabled -> do nothing
-    if(! THEKERNEL->config->value(drillingcycles_checksum, enable_checksum)->by_default(false)->as_bool()) {
+    if(! THEKERNEL->config->value(drillingcycles_checksum, enable_checksum)->as_bool(false)) {
         // as this module is not needed free up the resource
         delete this;
         return;
@@ -65,7 +65,7 @@ void Drillingcycles::on_module_loaded()
 void Drillingcycles::on_config_reload(void *argument)
 {
     // take the dwell units configured by user, or select S (seconds) by default
-    string dwell_units = THEKERNEL->config->value(drillingcycles_checksum, dwell_units_checksum)->by_default("S")->as_string();
+    string dwell_units = THEKERNEL->config->value(drillingcycles_checksum, dwell_units_checksum)->as_string("S");
     this->dwell_units  = (dwell_units == "P") ? DWELL_UNITS_P : DWELL_UNITS_S;
 }
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -117,7 +117,7 @@ Endstops::Endstops()
 void Endstops::on_module_loaded()
 {
     // Do not do anything if not enabled or if no pins are defined
-    if (THEKERNEL->config->value( endstops_module_enable_checksum )->by_default(true)->as_bool()) {
+    if (THEKERNEL->config->value( endstops_module_enable_checksum )->as_bool(true)) {
         if(!load_old_config()) {
             delete this;
             return;
@@ -169,23 +169,23 @@ bool Endstops::load_old_config()
 	        hinfo.pin_info = nullptr;
 	
 	        // rates in mm/sec
-	        hinfo.fast_rate = THEKERNEL->config->value(checksums[i][FAST_RATE])->by_default(100)->as_number();
-	        hinfo.slow_rate = THEKERNEL->config->value(checksums[i][SLOW_RATE])->by_default(10)->as_number();
+	        hinfo.fast_rate = THEKERNEL->config->value(checksums[i][FAST_RATE])->as_number(100);
+	        hinfo.slow_rate = THEKERNEL->config->value(checksums[i][SLOW_RATE])->as_number(10);
 	
 	        // retract in mm
-	        hinfo.retract = THEKERNEL->config->value(checksums[i][RETRACT])->by_default(5)->as_number();
+	        hinfo.retract = THEKERNEL->config->value(checksums[i][RETRACT])->as_number(5);
 	
 	        // get homing direction and convert to boolean where true is home to min, and false is home to max
-	        hinfo.home_direction = THEKERNEL->config->value(checksums[i][DIRECTION])->by_default("home_to_min")->as_string() != "home_to_max";
+	        hinfo.home_direction = THEKERNEL->config->value(checksums[i][DIRECTION])->as_string("home_to_min") != "home_to_max";
 	
 	        // homing cartesian position
-	        hinfo.homing_position = hinfo.home_direction ? THEKERNEL->config->value(checksums[i][MIN])->by_default(0)->as_number() : THEKERNEL->config->value(checksums[i][MAX])->by_default(200)->as_number();
+	        hinfo.homing_position = hinfo.home_direction ? THEKERNEL->config->value(checksums[i][MIN])->as_number(0) : THEKERNEL->config->value(checksums[i][MAX])->as_number(200);
 	
 	        // used to set maximum movement on homing, set by alpha_max_travel if defined
-	        hinfo.max_travel = THEKERNEL->config->value(checksums[i][MAX_TRAVEL])->by_default(500)->as_number();
+	        hinfo.max_travel = THEKERNEL->config->value(checksums[i][MAX_TRAVEL])->as_number(500);
 	
 	        // motor alarm info
-	        if (THEKERNEL->config->value(checksums[i][ALARM_PIN])->by_default("nc" )->as_string() != "nc") {
+	        if (THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string("nc" ) != "nc") {
 	        	motor_alarm_info_t *info = new motor_alarm_info_t;
 	        	info->pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string())->as_input();
 	            info->debounce = 0;
@@ -194,12 +194,12 @@ bool Endstops::load_old_config()
 	            motor_alarms.push_back(info);
 	        }
 	
-	        hinfo.motor_alarm_pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->by_default("nc" )->as_string())->as_input();
+	        hinfo.motor_alarm_pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string("nc" ))->as_input();
 	
 	        // pin definitions for endstop pins
 	        for (int j = MIN_PIN; j <= MAX_PIN; ++j) {
 	            endstop_info_t *info = new endstop_info_t;
-	            info->pin.from_string(THEKERNEL->config->value(checksums[i][j])->by_default("nc" )->as_string())->as_input();
+	            info->pin.from_string(THEKERNEL->config->value(checksums[i][j])->as_string("nc" ))->as_input();
 	            if (!info->pin.connected()){
 	                // no pin defined try next
 	                delete info;
@@ -218,7 +218,7 @@ bool Endstops::load_old_config()
 	            info->axis_index = i;
 	
 	            // limits enabled
-	            info->limit_enable = THEKERNEL->config->value(checksums[i][LIMIT])->by_default(false)->as_bool();
+	            info->limit_enable = THEKERNEL->config->value(checksums[i][LIMIT])->as_bool(false);
 	            limit_enabled |= info->limit_enable;
 	        }
 	
@@ -238,23 +238,23 @@ bool Endstops::load_old_config()
 	        hinfo.pin_info = nullptr;
 	
 	        // rates in mm/sec
-	        hinfo.fast_rate = THEKERNEL->config->value(checksums[i][FAST_RATE])->by_default(100)->as_number();
-	        hinfo.slow_rate = THEKERNEL->config->value(checksums[i][SLOW_RATE])->by_default(10)->as_number();
+	        hinfo.fast_rate = THEKERNEL->config->value(checksums[i][FAST_RATE])->as_number(100);
+	        hinfo.slow_rate = THEKERNEL->config->value(checksums[i][SLOW_RATE])->as_number(10);
 	
 	        // retract in mm
-	        hinfo.retract = THEKERNEL->config->value(checksums[i][RETRACT])->by_default(5)->as_number();
+	        hinfo.retract = THEKERNEL->config->value(checksums[i][RETRACT])->as_number(5);
 	
 	        // get homing direction and convert to boolean where true is home to min, and false is home to max
-	        hinfo.home_direction = THEKERNEL->config->value(checksums[i][DIRECTION])->by_default("home_to_min")->as_string() != "home_to_max";
+	        hinfo.home_direction = THEKERNEL->config->value(checksums[i][DIRECTION])->as_string("home_to_min") != "home_to_max";
 	
 	        // homing cartesian position
-	        hinfo.homing_position = hinfo.home_direction ? THEKERNEL->config->value(checksums[i][MIN])->by_default(0)->as_number() : THEKERNEL->config->value(checksums[i][MAX])->by_default(200)->as_number();
+	        hinfo.homing_position = hinfo.home_direction ? THEKERNEL->config->value(checksums[i][MIN])->as_number(0) : THEKERNEL->config->value(checksums[i][MAX])->as_number(200);
 	
 	        // used to set maximum movement on homing, set by alpha_max_travel if defined
-	        hinfo.max_travel = THEKERNEL->config->value(checksums[i][MAX_TRAVEL])->by_default(500)->as_number();
+	        hinfo.max_travel = THEKERNEL->config->value(checksums[i][MAX_TRAVEL])->as_number(500);
 	
 	        // motor alarm info
-	        if (THEKERNEL->config->value(checksums[i][ALARM_PIN])->by_default("nc" )->as_string() != "nc") {
+	        if (THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string("nc" ) != "nc") {
 	        	motor_alarm_info_t *info = new motor_alarm_info_t;
 	        	info->pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string())->as_input();
 	            info->debounce = 0;
@@ -263,12 +263,12 @@ bool Endstops::load_old_config()
 	            motor_alarms.push_back(info);
 	        }
 	
-	        hinfo.motor_alarm_pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->by_default("nc" )->as_string())->as_input();
+	        hinfo.motor_alarm_pin.from_string(THEKERNEL->config->value(checksums[i][ALARM_PIN])->as_string("nc" ))->as_input();
 	
 	        // pin definitions for endstop pins
 	        for (int j = MIN_PIN; j <= MAX_PIN; ++j) {
 	            endstop_info_t *info = new endstop_info_t;
-	            info->pin.from_string(THEKERNEL->config->value(checksums[i][j])->by_default("nc" )->as_string())->as_input();
+	            info->pin.from_string(THEKERNEL->config->value(checksums[i][j])->as_string("nc" ))->as_input();
 	            if (!info->pin.connected()){
 	                // no pin defined try next
 	                delete info;
@@ -287,7 +287,7 @@ bool Endstops::load_old_config()
 	            info->axis_index = i;
 	
 	            // limits enabled
-	            info->limit_enable = THEKERNEL->config->value(checksums[i][LIMIT])->by_default(false)->as_bool();
+	            info->limit_enable = THEKERNEL->config->value(checksums[i][LIMIT])->as_bool(false);
 	            limit_enabled |= info->limit_enable;
 	        }
 	
@@ -347,14 +347,14 @@ bool Endstops::load_config()
         if(!THEKERNEL->config->value(endstop_checksum, cs, enable_checksum )->as_bool()) continue;
 
         endstop_info_t *pin_info= new endstop_info_t;
-        pin_info->pin.from_string(THEKERNEL->config->value(endstop_checksum, cs, pin_checksum)->by_default("nc" )->as_string())->as_input();
+        pin_info->pin.from_string(THEKERNEL->config->value(endstop_checksum, cs, pin_checksum)->as_string("nc" ))->as_input();
         if(!pin_info->pin.connected()){
             // no pin defined try next
             delete pin_info;
             continue;
         }
 
-        string axis= THEKERNEL->config->value(endstop_checksum, cs, axis_checksum)->by_default("")->as_string();
+        string axis= THEKERNEL->config->value(endstop_checksum, cs, axis_checksum)->as_string("");
         if(axis.empty()){
             // axis is required
             delete pin_info;
@@ -391,14 +391,14 @@ bool Endstops::load_config()
         pin_info->axis_index= i;
 
         // are limits enabled
-        pin_info->limit_enable= THEKERNEL->config->value(endstop_checksum, cs, limit_checksum)->by_default(false)->as_bool();
+        pin_info->limit_enable= THEKERNEL->config->value(endstop_checksum, cs, limit_checksum)->as_bool(false);
         limit_enabled |= pin_info->limit_enable;
 
         // enter into endstop array
         endstops.push_back(pin_info);
 
         // if set to none it means not used for homing (maybe limit only) so do not add to the homing array
-        string direction= THEKERNEL->config->value(endstop_checksum, cs, direction_checksum)->by_default("none")->as_string();
+        string direction= THEKERNEL->config->value(endstop_checksum, cs, direction_checksum)->as_string("none");
         if(direction == "none") {
             continue;
         }
@@ -414,20 +414,20 @@ bool Endstops::load_config()
         hinfo.pin_info= pin_info;
 
         // rates in mm/sec
-        hinfo.fast_rate= THEKERNEL->config->value(endstop_checksum, cs, fast_rate_checksum)->by_default(100)->as_number();
-        hinfo.slow_rate= THEKERNEL->config->value(endstop_checksum, cs, slow_rate_checksum)->by_default(10)->as_number();
+        hinfo.fast_rate= THEKERNEL->config->value(endstop_checksum, cs, fast_rate_checksum)->as_number(100);
+        hinfo.slow_rate= THEKERNEL->config->value(endstop_checksum, cs, slow_rate_checksum)->as_number(10);
 
         // retract in mm
-        hinfo.retract= THEKERNEL->config->value(endstop_checksum, cs, retract_checksum)->by_default(5)->as_number();
+        hinfo.retract= THEKERNEL->config->value(endstop_checksum, cs, retract_checksum)->as_number(5);
 
         // homing direction and convert to boolean where true is home to min, and false is home to max
         hinfo.home_direction=  direction == "home_to_min";
 
         // homing cartesian position
-        hinfo.homing_position= THEKERNEL->config->value(endstop_checksum, cs, position_checksum)->by_default(hinfo.home_direction ? 0 : 200)->as_number();
+        hinfo.homing_position= THEKERNEL->config->value(endstop_checksum, cs, position_checksum)->as_number(hinfo.home_direction ? 0 : 200);
 
         // used to set maximum movement on homing, set by max_travel if defined
-        hinfo.max_travel= THEKERNEL->config->value(endstop_checksum, cs, max_travel_checksum)->by_default(500)->as_number();
+        hinfo.max_travel= THEKERNEL->config->value(endstop_checksum, cs, max_travel_checksum)->as_number(500);
 
         // stick into array in correct place
         temp_axis_array[hinfo.axis_index]= hinfo;
@@ -479,24 +479,24 @@ bool Endstops::load_config()
 void Endstops::get_global_configs()
 {
     // NOTE the debounce count is in milliseconds so probably does not need to beset anymore
-    this->debounce_ms= THEKERNEL->config->value(endstop_debounce_ms_checksum)->by_default(10)->as_number();
-    this->debounce_count= THEKERNEL->config->value(endstop_debounce_count_checksum)->by_default(100)->as_number();
+    this->debounce_ms= THEKERNEL->config->value(endstop_debounce_ms_checksum)->as_number(10);
+    this->debounce_count= THEKERNEL->config->value(endstop_debounce_count_checksum)->as_number(100);
 
-    this->is_corexy= THEKERNEL->config->value(corexy_homing_checksum)->by_default(false)->as_bool();
-    this->is_delta=  THEKERNEL->config->value(delta_homing_checksum)->by_default(false)->as_bool();
-    this->is_rdelta= THEKERNEL->config->value(rdelta_homing_checksum)->by_default(false)->as_bool();
-    this->is_scara=  THEKERNEL->config->value(scara_homing_checksum)->by_default(false)->as_bool();
+    this->is_corexy= THEKERNEL->config->value(corexy_homing_checksum)->as_bool(false);
+    this->is_delta=  THEKERNEL->config->value(delta_homing_checksum)->as_bool(false);
+    this->is_rdelta= THEKERNEL->config->value(rdelta_homing_checksum)->as_bool(false);
+    this->is_scara=  THEKERNEL->config->value(scara_homing_checksum)->as_bool(false);
 
-    this->home_z_first= THEKERNEL->config->value(home_z_first_checksum)->by_default(true)->as_bool();
+    this->home_z_first= THEKERNEL->config->value(home_z_first_checksum)->as_bool(true);
 
-    this->trim_mm[0] = THEKERNEL->config->value(alpha_trim_checksum)->by_default(0)->as_number();
-    this->trim_mm[1] = THEKERNEL->config->value(beta_trim_checksum)->by_default(0)->as_number();
-    this->trim_mm[2] = THEKERNEL->config->value(gamma_trim_checksum)->by_default(0)->as_number();
+    this->trim_mm[0] = THEKERNEL->config->value(alpha_trim_checksum)->as_number(0);
+    this->trim_mm[1] = THEKERNEL->config->value(beta_trim_checksum)->as_number(0);
+    this->trim_mm[2] = THEKERNEL->config->value(gamma_trim_checksum)->as_number(0);
 
-	this->cover_endstop_pin.from_string( THEKERNEL->config->value(cover_endstop_checksum)->by_default("1.9^" )->as_string())->as_input();
+	this->cover_endstop_pin.from_string( THEKERNEL->config->value(cover_endstop_checksum)->as_string("1.9^" ))->as_input();
 
     // see if an order has been specified, must be three or more characters, XYZABC or ABYXZ etc
-    string order = THEKERNEL->config->value(homing_order_checksum)->by_default("")->as_string();
+    string order = THEKERNEL->config->value(homing_order_checksum)->as_string("");
     this->homing_order = 0;
     if(order.size() >= 3 && order.size() <= homing_axis.size() && !(this->is_delta || this->is_rdelta)) {
         int shift = 0;
@@ -514,9 +514,9 @@ void Endstops::get_global_configs()
     }
 
     // set to true by default for deltas due to trim, false on cartesians
-    this->move_to_origin_after_home = THEKERNEL->config->value(move_to_origin_checksum)->by_default(is_delta)->as_bool();
+    this->move_to_origin_after_home = THEKERNEL->config->value(move_to_origin_checksum)->as_bool(is_delta);
     if(!this->move_to_origin_after_home) {
-        this->park_after_home = THEKERNEL->config->value(park_after_home_checksum)->by_default(false)->as_bool();
+        this->park_after_home = THEKERNEL->config->value(park_after_home_checksum)->as_bool(false);
     }else{
         this->park_after_home= false;
     }

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -53,7 +53,7 @@ Laser::Laser()
 
 void Laser::on_module_loaded()
 {
-    if( !THEKERNEL->config->value( laser_module_enable_checksum )->by_default(true)->as_bool() ) {
+    if( !THEKERNEL->config->value( laser_module_enable_checksum )->as_bool(true) ) {
         // as not needed free up resource
         delete this;
         return;
@@ -61,7 +61,7 @@ void Laser::on_module_loaded()
 
     // Get smoothie-style pin from config
     this->laser_pin = new Pin();
-    this->laser_pin->from_string(THEKERNEL->config->value(laser_module_pin_checksum)->by_default("2.12")->as_string())->as_output();
+    this->laser_pin->from_string(THEKERNEL->config->value(laser_module_pin_checksum)->as_string("2.12"))->as_output();
     if (!this->laser_pin->connected()) {
         delete this->laser_pin;
         this->laser_pin= nullptr;
@@ -70,7 +70,7 @@ void Laser::on_module_loaded()
 	}
 
 	Pin *dummy_pin = new Pin();
-	dummy_pin->from_string(THEKERNEL->config->value(laser_module_pwm_pin_checksum)->by_default("2.4")->as_string())->as_output();
+	dummy_pin->from_string(THEKERNEL->config->value(laser_module_pwm_pin_checksum)->as_string("2.4"))->as_output();
     pwm_pin = dummy_pin->hardware_pwm();
     if (pwm_pin == NULL) {
         THEKERNEL->streams->printf("Error: Laser cannot use P%d.%d (P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26 only). Laser module disabled.\n", dummy_pin->port_number, dummy_pin->pin);
@@ -87,7 +87,7 @@ void Laser::on_module_loaded()
 
     // TTL settings
     this->ttl_pin = new Pin();
-    ttl_pin->from_string( THEKERNEL->config->value(laser_module_ttl_pin_checksum)->by_default("nc" )->as_string())->as_output();
+    ttl_pin->from_string( THEKERNEL->config->value(laser_module_ttl_pin_checksum)->as_string("nc" ))->as_output();
     this->ttl_used = ttl_pin->connected();
     this->ttl_inverting = ttl_pin->is_inverting();
     if (ttl_used) {
@@ -98,16 +98,16 @@ void Laser::on_module_loaded()
     }
 
 
-    uint32_t period = THEKERNEL->config->value(laser_module_pwm_period_checksum)->by_default(1000)->as_number();
+    uint32_t period = THEKERNEL->config->value(laser_module_pwm_period_checksum)->as_number(1000);
     THEKERNEL->Laser_period_us = period;
     this->pwm_pin->period_us(period);
     this->pwm_pin->write(this->pwm_inverting ? 1 : 0);
-    this->laser_test_power = THEKERNEL->config->value(laser_module_test_power_checksum)->by_default(0.1f)->as_number() ;
-    this->laser_maximum_power = THEKERNEL->config->value(laser_module_maximum_power_checksum)->by_default(1.0f)->as_number() ;
-    this->laser_minimum_power = THEKERNEL->config->value(laser_module_minimum_power_checksum)->by_default(0)->as_number() ;
+    this->laser_test_power = THEKERNEL->config->value(laser_module_test_power_checksum)->as_number(0.1f) ;
+    this->laser_maximum_power = THEKERNEL->config->value(laser_module_maximum_power_checksum)->as_number(1.0f) ;
+    this->laser_minimum_power = THEKERNEL->config->value(laser_module_minimum_power_checksum)->as_number(0) ;
 
     // S value that represents maximum (default 1)
-    this->laser_maximum_s_value = THEKERNEL->config->value(laser_module_maximum_s_value_checksum)->by_default(1.0f)->as_number() ;
+    this->laser_maximum_s_value = THEKERNEL->config->value(laser_module_maximum_s_value_checksum)->as_number(1.0f) ;
 
     set_laser_power(0);
 

--- a/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
+++ b/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
@@ -17,7 +17,7 @@
 void RotaryDeltaCalibration::on_module_loaded()
 {
     // if the module is disabled -> do nothing
-    if(!THEKERNEL->config->value( rotarydelta_checksum, enable_checksum )->by_default(false)->as_bool()) {
+    if(!THEKERNEL->config->value( rotarydelta_checksum, enable_checksum )->as_bool(false)) {
         // as this module is not needed free up the resource
         delete this;
         return;

--- a/src/modules/tools/scaracal/SCARAcal.cpp
+++ b/src/modules/tools/scaracal/SCARAcal.cpp
@@ -38,7 +38,7 @@
 void SCARAcal::on_module_loaded()
 {
     // if the module is disabled -> do nothing
-    if(!THEKERNEL->config->value( scaracal_checksum, enable_checksum )->by_default(false)->as_bool()) {
+    if(!THEKERNEL->config->value( scaracal_checksum, enable_checksum )->as_bool(false)) {
         // as this module is not needed free up the resource
         delete this;
         return;
@@ -52,8 +52,8 @@ void SCARAcal::on_module_loaded()
 
 void SCARAcal::on_config_reload(void *argument)
 {
-    this->slow_rate = THEKERNEL->config->value( scaracal_checksum, slow_feedrate_checksum )->by_default(5)->as_number(); // feedrate in mm/sec
-    this->z_move = THEKERNEL->config->value( scaracal_checksum, z_move_checksum )->by_default(0)->as_number(); // Optional movement of Z relative to the home position.
+    this->slow_rate = THEKERNEL->config->value( scaracal_checksum, slow_feedrate_checksum )->as_number(5); // feedrate in mm/sec
+    this->z_move = THEKERNEL->config->value( scaracal_checksum, z_move_checksum )->as_number(0); // Optional movement of Z relative to the home position.
                                                                                                   // positive values increase distance between nozzle and bed.
                                                                                                   // negative will decrease.  Useful when level code active to prevent collision
 

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -27,13 +27,13 @@ void AnalogSpindleControl::on_module_loaded()
 
     spindle_on = false;
     target_rpm = 0;
-    min_rpm = THEKERNEL->config->value(spindle_checksum, spindle_min_rpm_checksum)->by_default(100)->as_int();
-    max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(5000)->as_int();
+    min_rpm = THEKERNEL->config->value(spindle_checksum, spindle_min_rpm_checksum)->as_int(100);
+    max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->as_int(5000);
 
     // Get the pin for hardware pwm
     {
         Pin *smoothie_pin = new Pin();
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->as_string("nc"));
         pwm_pin = smoothie_pin->as_output()->hardware_pwm();
         output_inverted = smoothie_pin->is_inverting();
         delete smoothie_pin;
@@ -47,13 +47,13 @@ void AnalogSpindleControl::on_module_loaded()
     }
     
     // set pwm frequency
-    int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->by_default(1000)->as_int();
+    int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->as_int(1000);
     pwm_pin->period_us(period);
     // invert pwm signal if necessary
     pwm_pin->write(output_inverted ? 1 : 0);
 
     // Get digital out pin for switching the VFD on and off (wired to a digital input on the VFD via an optocoupler)
-    std::string switch_on_pin = THEKERNEL->config->value(spindle_checksum, spindle_switch_on_pin_checksum)->by_default("nc")->as_string();
+    std::string switch_on_pin = THEKERNEL->config->value(spindle_checksum, spindle_switch_on_pin_checksum)->as_string("nc");
     switch_on = NULL;
     if(switch_on_pin.compare("nc") != 0) {
         switch_on = new Pin();

--- a/src/modules/tools/spindle/ModbusSpindleControl.cpp
+++ b/src/modules/tools/spindle/ModbusSpindleControl.cpp
@@ -31,15 +31,15 @@ void ModbusSpindleControl::on_module_loaded()
     // preparing PinName objects from the config string
     {
         Pin *smoothie_pin = new Pin();
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_rx_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_rx_pin_checksum)->as_string("nc"));
         smoothie_pin->as_input();
         rx_pin = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
         
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_tx_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_tx_pin_checksum)->as_string("nc"));
         smoothie_pin->as_input();
         tx_pin = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
         
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_dir_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_dir_pin_checksum)->as_string("nc"));
         smoothie_pin->as_input();
         dir_pin = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
 

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -65,26 +65,26 @@ void PWMSpindleControl::on_module_loaded()
     
     factor = 100;
 
-    pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->by_default(1.0f)->as_number();
-    target_rpm = THEKERNEL->config->value(spindle_checksum, spindle_default_rpm_checksum)->by_default( 15000.0f)->as_number();
+    pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->as_number(1.0f);
+    target_rpm = THEKERNEL->config->value(spindle_checksum, spindle_default_rpm_checksum)->as_number( 15000.0f);
     if(CARVERA == THEKERNEL->factory_set->MachineModel) {
-        max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(15000.0f)->as_number();
+        max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->as_number(15000.0f);
     } else {
-        max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(13000.0f)->as_number();
+        max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->as_number(13000.0f);
     }
-    control_P_term = THEKERNEL->config->value(spindle_checksum, spindle_control_P_checksum)->by_default(0.0001f)->as_number();
-    control_I_term = THEKERNEL->config->value(spindle_checksum, spindle_control_I_checksum)->by_default(0.0001f)->as_number();
-    control_D_term = THEKERNEL->config->value(spindle_checksum, spindle_control_D_checksum)->by_default(0.0001f)->as_number();
+    control_P_term = THEKERNEL->config->value(spindle_checksum, spindle_control_P_checksum)->as_number(0.0001f);
+    control_I_term = THEKERNEL->config->value(spindle_checksum, spindle_control_I_checksum)->as_number(0.0001f);
+    control_D_term = THEKERNEL->config->value(spindle_checksum, spindle_control_D_checksum)->as_number(0.0001f);
 
-    delay_s        = THEKERNEL->config->value(spindle_checksum, spindle_delay_s_checksum)->by_default(3)->as_number();
-    stall_s        = THEKERNEL->config->value(spindle_checksum, spindle_stall_s_checksum)->by_default(100)->as_number();
-    stall_count_rpm = THEKERNEL->config->value(spindle_checksum, spindle_stall_count_rpm_checksum)->by_default(8000)->as_number();
-    stall_alarm_rpm = THEKERNEL->config->value(spindle_checksum, spindle_stall_alarm_rpm_checksum)->by_default(5000)->as_number();
-    acc_ratio      = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->by_default(1.0f)->as_number();
-    alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->by_default("nc")->as_string())->as_input();
+    delay_s        = THEKERNEL->config->value(spindle_checksum, spindle_delay_s_checksum)->as_number(3);
+    stall_s        = THEKERNEL->config->value(spindle_checksum, spindle_stall_s_checksum)->as_number(100);
+    stall_count_rpm = THEKERNEL->config->value(spindle_checksum, spindle_stall_count_rpm_checksum)->as_number(8000);
+    stall_alarm_rpm = THEKERNEL->config->value(spindle_checksum, spindle_stall_alarm_rpm_checksum)->as_number(5000);
+    acc_ratio      = THEKERNEL->config->value(spindle_checksum, spindle_acc_ratio_checksum)->as_number(1.0f);
+    alarm_pin.from_string(THEKERNEL->config->value(spindle_checksum, spindle_alarm_pin_checksum)->as_string("nc"))->as_input();
 
     // Smoothing value is low pass filter time constant in seconds.
-    float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->by_default(0.1f)->as_number();
+    float smoothing_time = THEKERNEL->config->value(spindle_checksum, spindle_control_smoothing_checksum)->as_number(0.1f);
     if (smoothing_time * UPDATE_FREQ < 1.0f)
         smoothing_decay = 1.0f;
     else
@@ -93,7 +93,7 @@ void PWMSpindleControl::on_module_loaded()
     // Get the pin for hardware pwm
     {
         Pin *smoothie_pin = new Pin();
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_pwm_pin_checksum)->as_string("nc"));
         pwm_pin = smoothie_pin->as_output()->hardware_pwm();
         output_inverted = smoothie_pin->is_inverting();
         delete smoothie_pin;
@@ -106,13 +106,13 @@ void PWMSpindleControl::on_module_loaded()
         return;
     }
 
-    max_pwm = THEKERNEL->config->value(spindle_checksum, spindle_max_pwm_checksum)->by_default(1.0f)->as_number();
+    max_pwm = THEKERNEL->config->value(spindle_checksum, spindle_max_pwm_checksum)->as_number(1.0f);
     if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
     {
     	max_pwm = 0.9;
     }
     
-    int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->by_default(1000)->as_int();
+    int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->as_int(1000);
     THEKERNEL->Spindle_period_us = period;
     pwm_pin->period_us(period);
     pwm_pin->write(output_inverted ? 1 : 0);
@@ -120,7 +120,7 @@ void PWMSpindleControl::on_module_loaded()
     // Get the pin for interrupt
     {
         Pin *smoothie_pin = new Pin();
-        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_feedback_pin_checksum)->by_default("nc")->as_string());
+        smoothie_pin->from_string(THEKERNEL->config->value(spindle_checksum, spindle_feedback_pin_checksum)->as_string("nc"));
         smoothie_pin->as_input();
         if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
             PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);

--- a/src/modules/tools/spindle/SpindleMaker.cpp
+++ b/src/modules/tools/spindle/SpindleMaker.cpp
@@ -28,7 +28,7 @@
 void SpindleMaker::load_spindle(){
 
     // If the spindle module is disabled load no Spindle 
-    if( !THEKERNEL->config->value( spindle_checksum, enable_checksum  )->by_default(true)->as_bool() ) {
+    if( !THEKERNEL->config->value( spindle_checksum, enable_checksum  )->as_bool(true) ) {
         THEKERNEL->streams->printf("NOTE: Spindle Module is disabled\n");
         return;    
     }
@@ -36,8 +36,8 @@ void SpindleMaker::load_spindle(){
     spindle = NULL;
 
     // get the two config options that make us able to determine which spindle module we need to load
-    std::string spindle_type = THEKERNEL->config->value( spindle_checksum, spindle_type_checksum )->by_default("pwm")->as_string();
-    std::string vfd_type = THEKERNEL->config->value( spindle_checksum, spindle_vfd_type_checksum )->by_default("none")->as_string(); 
+    std::string spindle_type = THEKERNEL->config->value( spindle_checksum, spindle_type_checksum )->as_string("pwm");
+    std::string vfd_type = THEKERNEL->config->value( spindle_checksum, spindle_vfd_type_checksum )->as_string("none"); 
 
     // check config which spindle type we need
     if( spindle_type.compare("pwm") == 0 ) {
@@ -65,7 +65,7 @@ void SpindleMaker::load_spindle(){
         spindle->register_for_event(ON_GET_PUBLIC_DATA);
         spindle->register_for_event(ON_SET_PUBLIC_DATA);
         spindle->register_for_event(ON_IDLE);
-        if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
+        if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->as_bool(false)) {
             spindle->register_for_event(ON_HALT);
         }
 

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -103,20 +103,20 @@ void Switch::on_module_loaded()
 // Get config
 void Switch::on_config_reload(void *argument)
 {
-    this->subcode = THEKERNEL->config->value(switch_checksum, this->name_checksum, command_subcode_checksum )->by_default(0)->as_number();
-    std::string input_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_on_command_checksum )->by_default("")->as_string();
-    std::string input_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_off_command_checksum )->by_default("")->as_string();
-    this->output_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_on_command_checksum )->by_default("")->as_string();
-    this->output_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->by_default("")->as_string();
-    this->switch_state = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->by_default(false)->as_bool();
+    this->subcode = THEKERNEL->config->value(switch_checksum, this->name_checksum, command_subcode_checksum )->as_number(0);
+    std::string input_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_on_command_checksum )->as_string("");
+    std::string input_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_off_command_checksum )->as_string("");
+    this->output_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_on_command_checksum )->as_string("");
+    this->output_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->as_string("");
+    this->switch_state = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->as_bool(false);
 
     this->input_pin = new Pin();
-    this->input_pin->from_string( THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_checksum )->by_default("nc")->as_string())->as_input();
+    this->input_pin->from_string( THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_checksum )->as_string("nc"))->as_input();
 
     bool is_input;
 
     if(this->input_pin->connected()) {
-        std::string ipb = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_behavior_checksum )->by_default("momentary")->as_string();
+        std::string ipb = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_behavior_checksum )->as_string("momentary");
         this->input_pin_behavior = (ipb == "momentary") ? momentary_checksum : toggle_checksum;
         is_input= true;
         this->ignore_on_halt= true;
@@ -129,14 +129,14 @@ void Switch::on_config_reload(void *argument)
 
 
     if(!is_input) {
-        string type = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("digital")->as_string();
-        this->failsafe= THEKERNEL->config->value(switch_checksum, this->name_checksum, failsafe_checksum )->by_default(0)->as_number();
-        this->ignore_on_halt= THEKERNEL->config->value(switch_checksum, this->name_checksum, ignore_on_halt_checksum )->by_default(false)->as_bool();
+        string type = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->as_string("digital");
+        this->failsafe= THEKERNEL->config->value(switch_checksum, this->name_checksum, failsafe_checksum )->as_number(0);
+        this->ignore_on_halt= THEKERNEL->config->value(switch_checksum, this->name_checksum, ignore_on_halt_checksum )->as_bool(false);
 
         if(type == "pwm"){
             this->output_type= SIGMADELTA;
             this->sigmadelta_pin= new Pwm();
-            this->sigmadelta_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+            this->sigmadelta_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             if(this->sigmadelta_pin->connected()) {
                 if(failsafe == 1) {
                     set_high_on_debug(sigmadelta_pin->port_number, sigmadelta_pin->pin);
@@ -152,7 +152,7 @@ void Switch::on_config_reload(void *argument)
         }else if(type == "digital"){
             this->output_type= DIGITAL;
             this->digital_pin= new Pin();
-            this->digital_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+            this->digital_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             if(this->digital_pin->connected()) {
                 if(failsafe == 1) {
                     set_high_on_debug(digital_pin->port_number, digital_pin->pin);
@@ -168,7 +168,7 @@ void Switch::on_config_reload(void *argument)
         }else if(type == "hwpwm"){
             this->output_type= HWPWM;
             Pin *pin= new Pin();
-            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             this->pwm_pin= pin->hardware_pwm();
             if(failsafe == 1) {
                 set_high_on_debug(pin->port_number, pin->pin);
@@ -184,7 +184,7 @@ void Switch::on_config_reload(void *argument)
         }else if(type == "swpwm"){
             this->output_type= SWPWM;
             Pin *pin= new Pin();
-            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             if(pin->connected()) {
                 this->swpwm_pin= new SoftPWM(pin, !pin->is_inverting());
                 if(failsafe == 1) {
@@ -199,9 +199,9 @@ void Switch::on_config_reload(void *argument)
         } else if (type == "digitalpwm") {
             this->output_type= DIGITALPWM;
             this->digital_pin= new Pin();
-            this->digital_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+            this->digital_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             Pin *pin= new Pin();
-            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_pin_checksum )->by_default("nc")->as_string())->as_output();
+            pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_pin_checksum )->as_string("nc"))->as_output();
             this->pwm_pin = pin->hardware_pwm();
             if (this->digital_pin->connected() && this->pwm_pin != nullptr)
 			{
@@ -239,8 +239,8 @@ void Switch::on_config_reload(void *argument)
 
     if(!is_input) {
         if(this->output_type == SIGMADELTA) {
-            this->sigmadelta_pin->max_pwm(THEKERNEL->config->value(switch_checksum, this->name_checksum, max_pwm_checksum )->by_default(255)->as_number());
-            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(this->sigmadelta_pin->max_pwm())->as_number();
+            this->sigmadelta_pin->max_pwm(THEKERNEL->config->value(switch_checksum, this->name_checksum, max_pwm_checksum )->as_number(255));
+            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->as_number(this->sigmadelta_pin->max_pwm());
             if(this->switch_state) {
                 this->sigmadelta_pin->pwm(this->switch_value); // will be truncated to max_pwm
             } else {
@@ -249,12 +249,12 @@ void Switch::on_config_reload(void *argument)
 
         } else if(this->output_type == HWPWM) {
             // default is 20Hz
-            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->by_default(20)->as_number() * 1000.0F; // ms but fractions are allowed
+            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->as_number(20) * 1000.0F; // ms but fractions are allowed
             this->pwm_pin->period_us(p);
 
             // default is 0% duty cycle
-            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(0)->as_number();
-            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->by_default(50)->as_number();
+            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->as_number(0);
+            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->as_number(50);
             if(this->switch_state) {
                 this->pwm_pin->write(this->default_on_value / 100.0F);
                 this->switch_value = this->default_on_value;
@@ -264,12 +264,12 @@ void Switch::on_config_reload(void *argument)
 
         } else if(this->output_type == SWPWM) {
             // default is 50Hz
-            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->by_default(20)->as_number(); // ms fractions are not allowed
+            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->as_number(20); // ms fractions are not allowed
             this->swpwm_pin->period_ms(p);
 
             // default is 0% duty cycle
-            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(0)->as_number();
-            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->by_default(50)->as_number();
+            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->as_number(0);
+            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->as_number(50);
             if(this->switch_state) {
                 this->swpwm_pin->write(this->default_on_value / 100.0F);
                 this->switch_value = this->default_on_value;
@@ -281,15 +281,15 @@ void Switch::on_config_reload(void *argument)
             this->digital_pin->set(this->switch_state);
 
         } else if (this->output_type == DIGITALPWM) {
-            this->min_pwm = THEKERNEL->config->value(switch_checksum, this->name_checksum, min_pwm_checksum )->by_default(0)->as_number();
-            this->max_pwm = THEKERNEL->config->value(switch_checksum, this->name_checksum, max_pwm_checksum )->by_default(100)->as_number();
+            this->min_pwm = THEKERNEL->config->value(switch_checksum, this->name_checksum, min_pwm_checksum )->as_number(0);
+            this->max_pwm = THEKERNEL->config->value(switch_checksum, this->name_checksum, max_pwm_checksum )->as_number(100);
         	this->digital_pin->set(this->switch_state);
             // default is 50Hz
-            float p = THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->by_default(20)->as_number() * 1000.0F; // ms but fractions are allowed
+            float p = THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->as_number(20) * 1000.0F; // ms but fractions are allowed
             this->pwm_pin->period_us(p);
             // default is 0% duty cycle
-            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(0)->as_number();
-            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->by_default(100)->as_number();
+            this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->as_number(0);
+            this->default_on_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, default_on_value_checksum )->as_number(100);
             if(this->switch_state) {
                 this->pwm_pin->write(confine(this->default_on_value, this->min_pwm, this->max_pwm) / 100.0F);
                 this->switch_value = this->default_on_value;

--- a/src/modules/tools/temperaturecontrol/AD8495.cpp
+++ b/src/modules/tools/temperaturecontrol/AD8495.cpp
@@ -40,7 +40,7 @@ void AD8495::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 {
     // Thermistor pin for ADC readings
     this->AD8495_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, AD8495_pin_checksum)->required()->as_string());
-    this->AD8495_offset = THEKERNEL->config->value(module_checksum, name_checksum, AD8495_offset_checksum)->by_default(0)->as_number(); // Stated offset. For Adafruit board it is 250C. If pin 2(REF) of amplifier is connected to 0V then there is 0C offset.
+    this->AD8495_offset = THEKERNEL->config->value(module_checksum, name_checksum, AD8495_offset_checksum)->as_number(0); // Stated offset. For Adafruit board it is 250C. If pin 2(REF) of amplifier is connected to 0V then there is 0C offset.
 	
     THEKERNEL->adc->enable_pin(&AD8495_pin);
 }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -179,34 +179,34 @@ void TemperatureControl::load_config()
 {
 
     // General config
-    this->set_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_m_code_checksum)->by_default(104)->as_number();
-    this->set_and_wait_m_code = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_and_wait_m_code_checksum)->by_default(109)->as_number();
-    this->get_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, get_m_code_checksum)->by_default(105)->as_number();
-    this->readings_per_second = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, readings_per_second_checksum)->by_default(20)->as_number();
+    this->set_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_m_code_checksum)->as_number(104);
+    this->set_and_wait_m_code = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, set_and_wait_m_code_checksum)->as_number(109);
+    this->get_m_code          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, get_m_code_checksum)->as_number(105);
+    this->readings_per_second = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, readings_per_second_checksum)->as_number(20);
 
-    this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
+    this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->as_string(string("T"));
 
     // Runaway parameters
-    uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(20)->as_number();
+    uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->as_number(20);
     if(n > 63) n= 63;
     this->runaway_range= n;
 
     // these need to fit in 9 bits after dividing by 8 so max is 4088 secs or 68 minutes
-    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(900)->as_number();
+    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->as_number(900);
     if(n > 4088) n= 4088;
     this->runaway_heating_timeout = n/8; // we have 8 second ticks
-    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_cooling_timeout_checksum)->by_default(0)->as_number(); // disable by default
+    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_cooling_timeout_checksum)->as_number(0); // disable by default
     if(n > 4088) n= 4088;
     this->runaway_cooling_timeout = n/8;
 
-    this->runaway_error_range= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_error_range_checksum)->by_default(1.0F)->as_number();
+    this->runaway_error_range= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_error_range_checksum)->as_number(1.0F);
 
     // Max and min temperatures we are not allowed to get over (Safety)
-    this->max_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_temp_checksum)->by_default(300)->as_number();
-    this->min_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, min_temp_checksum)->by_default(0)->as_number();
+    this->max_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_temp_checksum)->as_number(300);
+    this->min_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, min_temp_checksum)->as_number(0);
 
     // Heater pin
-    this->heater_pin.from_string( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, heater_pin_checksum)->by_default("nc")->as_string());
+    this->heater_pin.from_string( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, heater_pin_checksum)->as_string("nc"));
     if(this->heater_pin.connected()){
         this->readonly= false;
         this->heater_pin.as_output();
@@ -216,7 +216,7 @@ void TemperatureControl::load_config()
     }
 
     // For backward compatibility, default to a thermistor sensor.
-    std::string sensor_type = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, sensor_checksum)->by_default("thermistor")->as_string();
+    std::string sensor_type = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, sensor_checksum)->as_string("thermistor");
 
     // Instantiate correct sensor (TBD: TempSensor factory?)
     delete sensor;
@@ -234,8 +234,8 @@ void TemperatureControl::load_config()
     }
     sensor->UpdateConfig(temperature_control_checksum, this->name_checksum);
 
-    this->preset1 = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, preset1_checksum)->by_default(0)->as_number();
-    this->preset2 = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, preset2_checksum)->by_default(0)->as_number();
+    this->preset1 = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, preset1_checksum)->as_number(0);
+    this->preset2 = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, preset2_checksum)->as_number(0);
 
 
     // sigma-delta output modulation
@@ -243,14 +243,14 @@ void TemperatureControl::load_config()
 
     if(!this->readonly) {
         // used to enable bang bang control of heater
-        this->use_bangbang = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, bang_bang_checksum)->by_default(false)->as_bool();
-        this->hysteresis = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, hysteresis_checksum)->by_default(2)->as_number();
-        this->windup = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, windup_checksum)->by_default(false)->as_bool();
-        this->heater_pin.max_pwm( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_pwm_checksum)->by_default(255)->as_number() );
+        this->use_bangbang = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, bang_bang_checksum)->as_bool(false);
+        this->hysteresis = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, hysteresis_checksum)->as_number(2);
+        this->windup = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, windup_checksum)->as_bool(false);
+        this->heater_pin.max_pwm( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_pwm_checksum)->as_number(255) );
         this->heater_pin.set(0);
         set_low_on_debug(heater_pin.port_number, heater_pin.pin);
         // activate SD-DAC timer
-        THEKERNEL->slow_ticker->attach( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, pwm_frequency_checksum)->by_default(2000)->as_number(), &heater_pin, &Pwm::on_tick);
+        THEKERNEL->slow_ticker->attach( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, pwm_frequency_checksum)->as_number(2000), &heater_pin, &Pwm::on_tick);
     }
 
 
@@ -259,13 +259,13 @@ void TemperatureControl::load_config()
     this->PIDdt = 1.0 / this->readings_per_second;
 
     // PID
-    setPIDp( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, p_factor_checksum)->by_default(10 )->as_number() );
-    setPIDi( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, i_factor_checksum)->by_default(0.3f)->as_number() );
-    setPIDd( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, d_factor_checksum)->by_default(200)->as_number() );
+    setPIDp( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, p_factor_checksum)->as_number(10 ) );
+    setPIDi( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, i_factor_checksum)->as_number(0.3f) );
+    setPIDd( THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, d_factor_checksum)->as_number(200) );
 
     if(!this->readonly) {
         // set to the same as max_pwm by default
-        this->i_max = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, i_max_checksum   )->by_default(this->heater_pin.max_pwm())->as_number();
+        this->i_max = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, i_max_checksum   )->as_number(this->heater_pin.max_pwm());
     }
 
     this->iTerm = 0.0;

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -64,12 +64,12 @@ void Thermistor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
     this->beta = 4066;
 
     // force use of beta perdefined thermistor table based on betas
-    bool use_beta_table= THEKERNEL->config->value(module_checksum, name_checksum, use_beta_table_checksum)->by_default(false)->as_bool();
+    bool use_beta_table= THEKERNEL->config->value(module_checksum, name_checksum, use_beta_table_checksum)->as_bool(false);
 
     bool found= false;
     int cnt= 0;
     // load a predefined thermistor name if found
-    string thermistor = THEKERNEL->config->value(module_checksum, name_checksum, thermistor_checksum)->by_default("")->as_string();
+    string thermistor = THEKERNEL->config->value(module_checksum, name_checksum, thermistor_checksum)->as_string("");
     if(!thermistor.empty()) {
         if(!use_beta_table) {
             for (auto& i : predefined_thermistors) {
@@ -115,12 +115,12 @@ void Thermistor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 
     // Preset values are overriden by specified values
     if(!use_steinhart_hart) {
-        this->beta = THEKERNEL->config->value(module_checksum, name_checksum, beta_checksum)->by_default(this->beta)->as_number(); // Thermistor beta rating. See http://reprap.org/bin/view/Main/MeasuringThermistorBeta
+        this->beta = THEKERNEL->config->value(module_checksum, name_checksum, beta_checksum)->as_number(this->beta); // Thermistor beta rating. See http://reprap.org/bin/view/Main/MeasuringThermistorBeta
     }
-    this->r0 = THEKERNEL->config->value(module_checksum, name_checksum, r0_checksum  )->by_default(this->r0  )->as_number(); // Stated resistance eg. 100K
-    this->t0 = THEKERNEL->config->value(module_checksum, name_checksum, t0_checksum  )->by_default(this->t0  )->as_number(); // Temperature at stated resistance, eg. 25C
-    this->r1 = THEKERNEL->config->value(module_checksum, name_checksum, r1_checksum  )->by_default(this->r1  )->as_number();
-    this->r2 = THEKERNEL->config->value(module_checksum, name_checksum, r2_checksum  )->by_default(this->r2  )->as_number();
+    this->r0 = THEKERNEL->config->value(module_checksum, name_checksum, r0_checksum  )->as_number(this->r0  ); // Stated resistance eg. 100K
+    this->t0 = THEKERNEL->config->value(module_checksum, name_checksum, t0_checksum  )->as_number(this->t0  ); // Temperature at stated resistance, eg. 25C
+    this->r1 = THEKERNEL->config->value(module_checksum, name_checksum, r1_checksum  )->as_number(this->r1  );
+    this->r2 = THEKERNEL->config->value(module_checksum, name_checksum, r2_checksum  )->as_number(this->r2  );
 
     // Thermistor pin for ADC readings
     this->thermistor_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, thermistor_pin_checksum )->required()->as_string());
@@ -128,11 +128,11 @@ void Thermistor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 
     // specify the three Steinhart-Hart coefficients
     // specified as three comma separated floats, no spaces
-    string coef= THEKERNEL->config->value(module_checksum, name_checksum, coefficients_checksum)->by_default("")->as_string();
+    string coef= THEKERNEL->config->value(module_checksum, name_checksum, coefficients_checksum)->as_string("");
 
     // speficy three temp,resistance pairs, best to use 25° 150° 240° and the coefficients will be calculated
     // specified as 25.0,100000.0,150.0,1355.0,240.0,203.0 which is temp in °C,resistance in ohms
-    string rtc= THEKERNEL->config->value(module_checksum, name_checksum, rt_curve_checksum)->by_default("")->as_string();
+    string rtc= THEKERNEL->config->value(module_checksum, name_checksum, rt_curve_checksum)->as_string("");
     if(!rtc.empty()) {
         // use the http://en.wikipedia.org/wiki/Steinhart-Hart_equation instead of beta, as it is more accurate over the entire temp range
         // we use three temps/resistor values taken from the thermistor R-C curve found in most datasheets

--- a/src/modules/tools/temperaturecontrol/max31855.cpp
+++ b/src/modules/tools/temperaturecontrol/max31855.cpp
@@ -34,12 +34,12 @@ Max31855::~Max31855()
 void Max31855::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
 {
     // Chip select
-    this->spi_cs_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, chip_select_checksum)->by_default("0.16")->as_string());
+    this->spi_cs_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, chip_select_checksum)->as_string("0.16"));
     this->spi_cs_pin.set(true);
     this->spi_cs_pin.as_output();
 
     // select which SPI channel to use
-    int spi_channel = THEKERNEL->config->value(module_checksum, name_checksum, spi_channel_checksum)->by_default(0)->as_number();
+    int spi_channel = THEKERNEL->config->value(module_checksum, name_checksum, spi_channel_checksum)->as_number(0);
     PinName miso;
     PinName mosi;
     PinName sclk;

--- a/src/modules/tools/temperatureswitch/TemperatureSwitch.cpp
+++ b/src/modules/tools/temperatureswitch/TemperatureSwitch.cpp
@@ -68,12 +68,12 @@ void TemperatureSwitch::on_module_loaded()
 TemperatureSwitch* TemperatureSwitch::load_config(uint16_t modcs)
 {
     // see if enabled
-    if (!THEKERNEL->config->value(temperatureswitch_checksum, modcs, enable_checksum)->by_default(false)->as_bool()) {
+    if (!THEKERNEL->config->value(temperatureswitch_checksum, modcs, enable_checksum)->as_bool(false)) {
         return nullptr;
     }
 
     // load settings from config file
-    string switchname = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_switch_checksum)->by_default("")->as_string();
+    string switchname = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_switch_checksum)->as_string("");
     if(switchname.empty()) {
 		// no switch specified so invalid entry
 		THEKERNEL->streams->printf("WARNING TEMPERATURESWITCH: no switch specified\n");
@@ -85,11 +85,11 @@ TemperatureSwitch* TemperatureSwitch::load_config(uint16_t modcs)
 
     ts->temperatureswitch_switch_cs= get_checksum(switchname); // checksum of the switch to use
 
-    ts->temperatureswitch_threshold_temp = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_threshold_temp_checksum)->by_default(35.0f)->as_number();
-    ts->temperatureswitch_cooldown_power_init = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_init_checksum)->by_default(50.0f)->as_number();
-    ts->temperatureswitch_cooldown_power_step = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_step_checksum)->by_default(10.0f)->as_number();
-    ts->temperatureswitch_cooldown_power_laser = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_laser_checksum)->by_default(80.0f)->as_number();
-    ts->temperatureswitch_cooldown_delay = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_delay_checksum)->by_default(180)->as_number();
+    ts->temperatureswitch_threshold_temp = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_threshold_temp_checksum)->as_number(35.0f);
+    ts->temperatureswitch_cooldown_power_init = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_init_checksum)->as_number(50.0f);
+    ts->temperatureswitch_cooldown_power_step = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_step_checksum)->as_number(10.0f);
+    ts->temperatureswitch_cooldown_power_laser = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_power_laser_checksum)->as_number(80.0f);
+    ts->temperatureswitch_cooldown_delay = THEKERNEL->config->value(temperatureswitch_checksum, modcs, temperatureswitch_cooldown_delay_checksum)->as_number(180);
 
     // set initial state
     ts->cooldown_delay_counter = -1;

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -155,24 +155,24 @@ CartGridStrategy::~CartGridStrategy()
 bool CartGridStrategy::handleConfig()
 {
 
-    uint8_t grid_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_size_checksum)->by_default(7)->as_number();
-    this->current_grid_x_size = this->configured_grid_x_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_x_size_checksum)->by_default(grid_size)->as_number();
-    this->current_grid_y_size = this->configured_grid_y_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_y_size_checksum)->by_default(grid_size)->as_number();
+    uint8_t grid_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_size_checksum)->as_number(7);
+    this->current_grid_x_size = this->configured_grid_x_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_x_size_checksum)->as_number(grid_size);
+    this->current_grid_y_size = this->configured_grid_y_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, grid_y_size_checksum)->as_number(grid_size);
 
     // we use a different file format depending on whether it is square or not
     this->new_file_format= true;
 
     this->force_debug = false;
 
-    tolerance = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, tolerance_checksum)->by_default(0.03F)->as_number();
-    save = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, save_checksum)->by_default(false)->as_bool();
-    do_home = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, do_home_checksum)->by_default(true)->as_bool();
-    only_by_two_corners = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, only_by_two_corners_checksum)->by_default(false)->as_bool();
-    human_readable = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, human_readable_checksum)->by_default(false)->as_bool();
-    do_manual_attach = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, m_attach_checksum)->by_default(false)->as_bool();
+    tolerance = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, tolerance_checksum)->as_number(0.03F);
+    save = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, save_checksum)->as_bool(false);
+    do_home = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, do_home_checksum)->as_bool(true);
+    only_by_two_corners = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, only_by_two_corners_checksum)->as_bool(false);
+    human_readable = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, human_readable_checksum)->as_bool(false);
+    do_manual_attach = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, m_attach_checksum)->as_bool(false);
 
-    this->height_limit = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, height_limit_checksum)->by_default(NAN)->as_number();
-    this->dampening_start = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, dampening_start_checksum)->by_default(NAN)->as_number();
+    this->height_limit = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, height_limit_checksum)->as_number(NAN);
+    this->dampening_start = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, dampening_start_checksum)->as_number(NAN);
 
     if(!isnan(this->height_limit) && !isnan(this->dampening_start)) {
         this->damping_interval = height_limit - dampening_start;
@@ -182,8 +182,8 @@ bool CartGridStrategy::handleConfig()
 
     this->x_start = 0.0F;
     this->y_start = 0.0F;
-    this->x_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, x_size_checksum)->by_default(0.0F)->as_number();
-    this->y_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, y_size_checksum)->by_default(0.0F)->as_number();
+    this->x_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, x_size_checksum)->as_number(0.0F);
+    this->y_size = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, y_size_checksum)->as_number(0.0F);
     if (this->x_size == 0.0F || this->y_size == 0.0F) {
         THEKERNEL->streams->printf("Error: Invalid config, x_size and y_size must be defined\n");
         return false;
@@ -191,12 +191,12 @@ bool CartGridStrategy::handleConfig()
 
     // the initial height above the bed we stop the intial move down after home to find the bed
     // this should be a height that is enough that the probe will not hit the bed and is an offset from max_z (can be set to 0 if max_z takes into account the probe offset)
-    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, initial_height_checksum)->by_default(NAN)->as_number();
+    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, initial_height_checksum)->as_number(NAN);
     if(initial_height <= 0) initial_height= NAN;
 
     // Probe offsets xxx,yyy,zzz
     {
-        std::string po = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, probe_offsets_checksum)->by_default("0,0,0")->as_string();
+        std::string po = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, probe_offsets_checksum)->as_string("0,0,0");
         std::vector<float> v = parse_number_list(po.c_str());
         if(v.size() >= 3) {
             this->probe_offsets = std::make_tuple(v[0], v[1], v[2]);
@@ -206,7 +206,7 @@ bool CartGridStrategy::handleConfig()
     //  manual attachment point xxx,yyy,zzz
     if (do_manual_attach)
     {
-        std::string ap = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, mount_position_checksum)->by_default("0,0,50")->as_string();
+        std::string ap = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, mount_position_checksum)->as_string("0,0,50");
         std::vector<float> w = parse_number_list(ap.c_str());
         if(w.size() >= 3) {
             m_attach = new float[3];
@@ -222,8 +222,8 @@ bool CartGridStrategy::handleConfig()
         m_attach= nullptr;
     }
 
-    this->before_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, before_probe_gcode_checksum)->by_default("")->as_string();
-    this->after_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, after_probe_gcode_checksum)->by_default("")->as_string();
+    this->before_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, before_probe_gcode_checksum)->as_string("");
+    this->after_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, after_probe_gcode_checksum)->as_string("");
 
     // for the gcode commands we need to replace _ for space
     std::replace(before_probe.begin(), before_probe.end(), '_', ' '); // replace _ with space
@@ -238,7 +238,7 @@ bool CartGridStrategy::handleConfig()
     }
 
     // Flex compensation configuration
-    this->flex_x_points = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, flex_x_points_checksum)->by_default(30)->as_number();
+    this->flex_x_points = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, flex_x_points_checksum)->as_number(30);
     this->flex_x_start = 0.0F;
 
     // Allocate memory for flex compensation data
@@ -250,7 +250,7 @@ bool CartGridStrategy::handleConfig()
         return false;
     }
 
-    this->flex_compensation_always_active = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, flex_compensation_always_active_checksum)->by_default(false)->as_bool();
+    this->flex_compensation_always_active = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, flex_compensation_always_active_checksum)->as_bool(false);
     reset_flex_compensation();
     reset_bed_level();
 

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -27,16 +27,16 @@
 bool DeltaCalibrationStrategy::handleConfig()
 {
     // default is probably wrong
-    float r= THEKERNEL->config->value(leveling_strategy_checksum, delta_calibration_strategy_checksum, radius_checksum)->by_default(-1)->as_number();
+    float r= THEKERNEL->config->value(leveling_strategy_checksum, delta_calibration_strategy_checksum, radius_checksum)->as_number(-1);
     if(r == -1) {
         // deprecated config syntax]
-        r =  THEKERNEL->config->value(zprobe_checksum, probe_radius_checksum)->by_default(100.0F)->as_number();
+        r =  THEKERNEL->config->value(zprobe_checksum, probe_radius_checksum)->as_number(100.0F);
     }
     this->probe_radius= r;
 
     // the initial height above the bed we stop the intial move down after home to find the bed
     // this should be a height that is enough that the probe will not hit the bed and is an offset from max_z (can be set to 0 if max_z takes into account the probe offset)
-    this->initial_height= THEKERNEL->config->value(leveling_strategy_checksum, delta_calibration_strategy_checksum, initial_height_checksum)->by_default(10)->as_number();
+    this->initial_height= THEKERNEL->config->value(leveling_strategy_checksum, delta_calibration_strategy_checksum, initial_height_checksum)->as_number(10);
     return true;
 }
 

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -108,20 +108,20 @@ DeltaGridStrategy::~DeltaGridStrategy()
 
 bool DeltaGridStrategy::handleConfig()
 {
-    grid_size = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_size_checksum)->by_default(7)->as_number();
-    tolerance = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, tolerance_checksum)->by_default(0.03F)->as_number();
-    save = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, save_checksum)->by_default(false)->as_bool();
-    do_home = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, do_home_checksum)->by_default(true)->as_bool();
-    is_square = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, is_square_checksum)->by_default(false)->as_bool();
-    grid_radius = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_radius_checksum)->by_default(50.0F)->as_number();
+    grid_size = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_size_checksum)->as_number(7);
+    tolerance = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, tolerance_checksum)->as_number(0.03F);
+    save = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, save_checksum)->as_bool(false);
+    do_home = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, do_home_checksum)->as_bool(true);
+    is_square = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, is_square_checksum)->as_bool(false);
+    grid_radius = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_radius_checksum)->as_number(50.0F);
 
     // the initial height above the bed we stop the intial move down after home to find the bed
     // this should be a height that is enough that the probe will not hit the bed and is an offset from max_z (can be set to 0 if max_z takes into account the probe offset)
-    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, initial_height_checksum)->by_default(10)->as_number();
+    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, initial_height_checksum)->as_number(10);
 
     // Probe offsets xxx,yyy,zzz
     {
-        std::string po = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, probe_offsets_checksum)->by_default("0,0,0")->as_string();
+        std::string po = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, probe_offsets_checksum)->as_string("0,0,0");
         std::vector<float> v = parse_number_list(po.c_str());
         if(v.size() >= 3) {
             this->probe_offsets = std::make_tuple(v[0], v[1], v[2]);

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -95,20 +95,20 @@ ThreePointStrategy::~ThreePointStrategy()
 bool ThreePointStrategy::handleConfig()
 {
     // format is xxx,yyy for the probe points
-    std::string p1 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_1_checksum)->by_default("")->as_string();
-    std::string p2 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_2_checksum)->by_default("")->as_string();
-    std::string p3 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_3_checksum)->by_default("")->as_string();
+    std::string p1 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_1_checksum)->as_string("");
+    std::string p2 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_2_checksum)->as_string("");
+    std::string p3 = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_point_3_checksum)->as_string("");
     if(!p1.empty()) probe_points[0] = parseXY(p1.c_str());
     if(!p2.empty()) probe_points[1] = parseXY(p2.c_str());
     if(!p3.empty()) probe_points[2] = parseXY(p3.c_str());
 
     // Probe offsets xxx,yyy,zzz
-    std::string po = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_offsets_checksum)->by_default("0,0,0")->as_string();
+    std::string po = THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, probe_offsets_checksum)->as_string("0,0,0");
     this->probe_offsets= parseXYZ(po.c_str());
 
-    this->home= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, home_checksum)->by_default(true)->as_bool();
-    this->tolerance= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, tolerance_checksum)->by_default(0.03F)->as_number();
-    this->save= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, save_plane_checksum)->by_default(false)->as_bool();
+    this->home= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, home_checksum)->as_bool(true);
+    this->tolerance= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, tolerance_checksum)->as_number(0.03F);
+    this->save= THEKERNEL->config->value(leveling_strategy_checksum, three_point_leveling_strategy_checksum, save_plane_checksum)->as_bool(false);
     return true;
 }
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -81,7 +81,7 @@ constexpr double pi = 3.141592653589793;
 void ZProbe::on_module_loaded()
 {
     // if the module is disabled -> do nothing
-    if(!THEKERNEL->config->value( zprobe_checksum, enable_checksum )->by_default(true)->as_bool()) {
+    if(!THEKERNEL->config->value( zprobe_checksum, enable_checksum )->as_bool(true)) {
         // as this module is not needed free up the resource
         delete this;
         return;
@@ -112,10 +112,10 @@ void ZProbe::on_module_loaded()
 
 void ZProbe::config_load()
 {
-    this->pin.from_string( THEKERNEL->config->value(zprobe_checksum, probe_pin_checksum)->by_default("2.6v" )->as_string())->as_input();
-    this->calibrate_pin.from_string( THEKERNEL->config->value(zprobe_checksum, calibrate_pin_checksum)->by_default("0.5^" )->as_string())->as_input();
-    this->debounce_ms    = THEKERNEL->config->value(zprobe_checksum, debounce_ms_checksum)->by_default(0  )->as_number();
-    this->probe_calibration_safety_margin = THEKERNEL->config->value(zprobe_checksum, probe_calibration_safety_margin_checksum)->by_default(0.1F)->as_number();
+    this->pin.from_string( THEKERNEL->config->value(zprobe_checksum, probe_pin_checksum)->as_string("2.6v" ))->as_input();
+    this->calibrate_pin.from_string( THEKERNEL->config->value(zprobe_checksum, calibrate_pin_checksum)->as_string("0.5^" ))->as_input();
+    this->debounce_ms    = THEKERNEL->config->value(zprobe_checksum, debounce_ms_checksum)->as_number(0  );
+    this->probe_calibration_safety_margin = THEKERNEL->config->value(zprobe_checksum, probe_calibration_safety_margin_checksum)->as_number(0.1F);
     this->halt_pending = false;
     this->probe_triggered = false;
 
@@ -162,8 +162,8 @@ void ZProbe::config_load()
     }
 
     // need to know if we need to use delta kinematics for homing
-    this->is_delta = THEKERNEL->config->value(delta_homing_checksum)->by_default(false)->as_bool();
-    this->is_rdelta = THEKERNEL->config->value(rdelta_homing_checksum)->by_default(false)->as_bool();
+    this->is_delta = THEKERNEL->config->value(delta_homing_checksum)->as_bool(false);
+    this->is_rdelta = THEKERNEL->config->value(rdelta_homing_checksum)->as_bool(false);
 
     // default for backwards compatibility add DeltaCalibrationStrategy if a delta
     // may be deprecated
@@ -176,18 +176,18 @@ void ZProbe::config_load()
     }
 #endif
 
-    this->probe_height  = THEKERNEL->config->value(zprobe_checksum, probe_height_checksum)->by_default(5)->as_number();
-    this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(5)->as_number(); // feedrate in mm/sec
-    this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->by_default(100)->as_number(); // feedrate in mm/sec
-    this->return_feedrate = THEKERNEL->config->value(zprobe_checksum, return_feedrate_checksum)->by_default(5)->as_number(); // feedrate in mm/sec
-    this->reverse_z     = THEKERNEL->config->value(zprobe_checksum, reverse_z_direction_checksum)->by_default(false)->as_bool(); // Z probe moves in reverse direction
-    this->max_z         = THEKERNEL->config->value(zprobe_checksum, max_z_checksum)->by_default(NAN)->as_number(); // maximum zprobe distance
-    THEKERNEL->probe_tip_diameter = THEKERNEL->config->value(zprobe_checksum, probe_tip_diameter_checksum)->by_default(2)->as_number(); // probe tip diameter
-    this->tool_0_3axis  = THEKERNEL->config->value(zprobe_checksum, toolZeroIs3Axis_checksum)->by_default(false)->as_bool();
+    this->probe_height  = THEKERNEL->config->value(zprobe_checksum, probe_height_checksum)->as_number(5);
+    this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->as_number(5); // feedrate in mm/sec
+    this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->as_number(100); // feedrate in mm/sec
+    this->return_feedrate = THEKERNEL->config->value(zprobe_checksum, return_feedrate_checksum)->as_number(5); // feedrate in mm/sec
+    this->reverse_z     = THEKERNEL->config->value(zprobe_checksum, reverse_z_direction_checksum)->as_bool(false); // Z probe moves in reverse direction
+    this->max_z         = THEKERNEL->config->value(zprobe_checksum, max_z_checksum)->as_number(NAN); // maximum zprobe distance
+    THEKERNEL->probe_tip_diameter = THEKERNEL->config->value(zprobe_checksum, probe_tip_diameter_checksum)->as_number(2); // probe tip diameter
+    this->tool_0_3axis  = THEKERNEL->config->value(zprobe_checksum, toolZeroIs3Axis_checksum)->as_bool(false);
     if(isnan(this->max_z)){
-        this->max_z = THEKERNEL->config->value(gamma_max_checksum)->by_default(200)->as_number(); // maximum zprobe distance
+        this->max_z = THEKERNEL->config->value(gamma_max_checksum)->as_number(200); // maximum zprobe distance
     }
-    this->dwell_before_probing = THEKERNEL->config->value(zprobe_checksum, dwell_before_probing_checksum)->by_default(0)->as_number(); // dwell time in seconds before probing
+    this->dwell_before_probing = THEKERNEL->config->value(zprobe_checksum, dwell_before_probing_checksum)->as_number(0); // dwell time in seconds before probing
 
 }
 

--- a/src/modules/utils/configurator/Configurator.cpp
+++ b/src/modules/utils/configurator/Configurator.cpp
@@ -38,7 +38,7 @@ void Configurator::config_get_command( string parameters, StreamOutput *stream )
         get_checksums(setting_checksums, setting );
         THEKERNEL->config->config_cache_load(); // need to load config cache first as it is unloaded after booting
         ConfigValue *cv = THEKERNEL->config->value(setting_checksums);
-        if(cv != NULL && cv->found) {
+        if(cv != NULL && cv->found()) {
             string value = cv->as_string();
             stream->printf( "cached: %s is set to %s\r\n", setting.c_str(), value.c_str() );
         } else {
@@ -72,6 +72,11 @@ void Configurator::config_set_command( string parameters, StreamOutput *stream )
     string value = shift_parameter(parameters);
     if(source.empty() || setting.empty() || value.empty()) {
         stream->printf( "Usage: config-set source setting value # where source is sd, setting is the key and value is the new value\r\n" );
+        return;
+    }
+
+    if(value.size() >= CONFIGVALUE_MAX_LEN) {
+        stream->printf( "error: value too long (%d chars, max %d)\r\n", (int)value.size(), CONFIGVALUE_MAX_LEN - 1 );
         return;
     }
 
@@ -123,6 +128,10 @@ void Configurator::config_load_command( string parameters, StreamOutput *stream 
     string source = shift_parameter(parameters);
     if(source == "load") {
         THEKERNEL->config->config_cache_load();
+        if(!THEKERNEL->config->is_config_cache_loaded()) {
+            stream->printf( "ERROR: config cache failed to load\r\n");
+            return;
+        }
         stream->printf( "config cache loaded\r\n");
 
     } else if(source == "unload") {
@@ -131,6 +140,10 @@ void Configurator::config_load_command( string parameters, StreamOutput *stream 
 
     } else if(source == "dump") {
         THEKERNEL->config->config_cache_load();
+        if(!THEKERNEL->config->is_config_cache_loaded()) {
+            stream->printf( "ERROR: config cache failed to load\r\n");
+            return;
+        }
         THEKERNEL->config->config_cache->dump(stream);
         THEKERNEL->config->config_cache_clear();
 

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -65,49 +65,49 @@ MainButton::MainButton()
 
 void MainButton::on_module_loaded()
 {
-    bool main_button_enable = THEKERNEL->config->value( main_button_enable_checksum )->by_default(true)->as_bool(); // @deprecated
+    bool main_button_enable = THEKERNEL->config->value( main_button_enable_checksum )->as_bool(true); // @deprecated
     if (!main_button_enable) {
         delete this;
         return;
     }
 	
-    this->main_button_LED_R.from_string( THEKERNEL->config->value( main_button_LED_R_pin_checksum )->by_default("1.10")->as_string())->as_output();
-    this->main_button_LED_G.from_string( THEKERNEL->config->value( main_button_LED_G_pin_checksum )->by_default("1.15")->as_string())->as_output();
-    this->main_button_LED_B.from_string( THEKERNEL->config->value( main_button_LED_B_pin_checksum )->by_default("1.14")->as_string())->as_output();
+    this->main_button_LED_R.from_string( THEKERNEL->config->value( main_button_LED_R_pin_checksum )->as_string("1.10"))->as_output();
+    this->main_button_LED_G.from_string( THEKERNEL->config->value( main_button_LED_G_pin_checksum )->as_string("1.15"))->as_output();
+    this->main_button_LED_B.from_string( THEKERNEL->config->value( main_button_LED_B_pin_checksum )->as_string("1.14"))->as_output();
     
     if(CARVERA == THEKERNEL->factory_set->MachineModel)
     {
-	    this->main_button.from_string( THEKERNEL->config->value( main_button_pin_checksum )->by_default("1.16^")->as_string())->as_input();
+	    this->main_button.from_string( THEKERNEL->config->value( main_button_pin_checksum )->as_string("1.16^"))->as_input();
 	}
 	else if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
     {
-    	this->main_button.from_string( THEKERNEL->config->value( main_button_pin_checksum )->by_default("2.13!^")->as_string())->as_input();
+    	this->main_button.from_string( THEKERNEL->config->value( main_button_pin_checksum )->as_string("2.13!^"))->as_input();
     }
-    this->poll_frequency = THEKERNEL->config->value( main_button_poll_frequency_checksum )->by_default(20)->as_number();
-    this->long_press_time_ms = THEKERNEL->config->value( main_long_press_time_ms_checksum )->by_default(3000)->as_number();
-    this->long_press_enable = THEKERNEL->config->value( main_button_long_press_checksum )->by_default(false)->as_string();
+    this->poll_frequency = THEKERNEL->config->value( main_button_poll_frequency_checksum )->as_number(20);
+    this->long_press_time_ms = THEKERNEL->config->value( main_long_press_time_ms_checksum )->as_number(3000);
+    this->long_press_enable = THEKERNEL->config->value( main_button_long_press_checksum )->as_string("");
 	if(CARVERA == THEKERNEL->factory_set->MachineModel)
     {
-    	this->e_stop.from_string( THEKERNEL->config->value( e_stop_pin_checksum )->by_default("0.26^")->as_string())->as_input();
+    	this->e_stop.from_string( THEKERNEL->config->value( e_stop_pin_checksum )->as_string("0.26^"))->as_input();
     }
 	else if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
     {
-    	this->e_stop.from_string( THEKERNEL->config->value( e_stop_pin_checksum )->by_default("0.20^")->as_string())->as_input();
+    	this->e_stop.from_string( THEKERNEL->config->value( e_stop_pin_checksum )->as_string("0.20^"))->as_input();
     }
-    this->PS12.from_string( THEKERNEL->config->value( ps12_pin_checksum )->by_default("0.22")->as_string())->as_output();
-    this->PS24.from_string( THEKERNEL->config->value( ps24_pin_checksum )->by_default("0.10")->as_string())->as_output();
-    this->power_fan_delay_s = THEKERNEL->config->value( power_fan_delay_s_checksum )->by_default(30)->as_int();
+    this->PS12.from_string( THEKERNEL->config->value( ps12_pin_checksum )->as_string("0.22"))->as_output();
+    this->PS24.from_string( THEKERNEL->config->value( ps24_pin_checksum )->as_string("0.10"))->as_output();
+    this->power_fan_delay_s = THEKERNEL->config->value( power_fan_delay_s_checksum )->as_int(30);
 
-    this->auto_sleep = THEKERNEL->config->value(power_checksum, auto_sleep_checksum )->by_default(true)->as_bool();
-    this->auto_sleep_min = THEKERNEL->config->value(power_checksum, auto_sleep_min_checksum )->by_default(30)->as_number();
+    this->auto_sleep = THEKERNEL->config->value(power_checksum, auto_sleep_checksum )->as_bool(true);
+    this->auto_sleep_min = THEKERNEL->config->value(power_checksum, auto_sleep_min_checksum )->as_number(30);
 
 
-    this->enable_light = THEKERNEL->config->value(get_checksum("switch"), get_checksum("light"), get_checksum("startup_state"))->by_default(false)->as_bool();
-    this->turn_off_light_min = THEKERNEL->config->value(light_checksum, turn_off_min_checksum )->by_default(10)->as_number();
+    this->enable_light = THEKERNEL->config->value(get_checksum("switch"), get_checksum("light"), get_checksum("startup_state"))->as_bool(false);
+    this->turn_off_light_min = THEKERNEL->config->value(light_checksum, turn_off_min_checksum )->as_number(10);
 
-    this->stop_on_cover_open = THEKERNEL->config->value( stop_on_cover_open_checksum )->by_default(false)->as_bool(); // @deprecated
+    this->stop_on_cover_open = THEKERNEL->config->value( stop_on_cover_open_checksum )->as_bool(false); // @deprecated
 
-    this->sd_ok = THEKERNEL->config->value( sd_ok_checksum )->by_default(false)->as_bool(); // @deprecated
+    this->sd_ok = THEKERNEL->config->value( sd_ok_checksum )->as_bool(false); // @deprecated
 
     this->register_for_event(ON_IDLE);
     this->register_for_event(ON_SECOND_TICK);

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -92,18 +92,18 @@ void Player::on_module_loaded()
     this->register_for_event(ON_GCODE_RECEIVED);
     this->register_for_event(ON_HALT);
 
-    this->on_boot_gcode = THEKERNEL->config->value(on_boot_gcode_checksum)->by_default("/sd/on_boot.gcode")->as_string();
-    this->on_boot_gcode_enable = THEKERNEL->config->value(on_boot_gcode_enable_checksum)->by_default(false)->as_bool();
+    this->on_boot_gcode = THEKERNEL->config->value(on_boot_gcode_checksum)->as_string("/sd/on_boot.gcode");
+    this->on_boot_gcode_enable = THEKERNEL->config->value(on_boot_gcode_enable_checksum)->as_bool(false);
 
-    this->home_on_boot = THEKERNEL->config->value(home_on_boot_checksum)->by_default(true)->as_bool();
+    this->home_on_boot = THEKERNEL->config->value(home_on_boot_checksum)->as_bool(true);
 
-    this->after_suspend_gcode = THEKERNEL->config->value(after_suspend_gcode_checksum)->by_default("")->as_string();
-    this->before_resume_gcode = THEKERNEL->config->value(before_resume_gcode_checksum)->by_default("")->as_string();
+    this->after_suspend_gcode = THEKERNEL->config->value(after_suspend_gcode_checksum)->as_string("");
+    this->before_resume_gcode = THEKERNEL->config->value(before_resume_gcode_checksum)->as_string("");
     std::replace( this->after_suspend_gcode.begin(), this->after_suspend_gcode.end(), '_', ' '); // replace _ with space
     std::replace( this->before_resume_gcode.begin(), this->before_resume_gcode.end(), '_', ' '); // replace _ with space
-    this->leave_heaters_on = THEKERNEL->config->value(leave_heaters_on_suspend_checksum)->by_default(false)->as_bool();
+    this->leave_heaters_on = THEKERNEL->config->value(leave_heaters_on_suspend_checksum)->as_bool(false);
 
-    this->laser_clustering = THEKERNEL->config->value(laser_module_clustering_checksum)->by_default(false)->as_bool();
+    this->laser_clustering = THEKERNEL->config->value(laser_module_clustering_checksum)->as_bool(false);
 }
 
 void Player::on_halt(void* argument)

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -63,17 +63,17 @@ WifiProvider::WifiProvider()
 
 void WifiProvider::on_module_loaded()
 {
-    if( !THEKERNEL->config->value( wifi_checksum,  wifi_enable)->by_default(true)->as_bool() ) {
+    if( !THEKERNEL->config->value( wifi_checksum,  wifi_enable)->as_bool(true) ) {
         // as not needed free up resource
         delete this;
         return;
     }
 
-	this->tcp_port = THEKERNEL->config->value(wifi_checksum, tcp_port_checksum)->by_default(2222)->as_int();
-	this->udp_send_port = THEKERNEL->config->value(wifi_checksum, udp_send_port_checksum)->by_default(3333)->as_int();
-	this->udp_recv_port = THEKERNEL->config->value(wifi_checksum, udp_recv_port_checksum)->by_default(4444)->as_int();
-	this->tcp_timeout_s = THEKERNEL->config->value(wifi_checksum, tcp_timeout_s_checksum)->by_default(10)->as_int();
-    std::string config_name = THEKERNEL->config->value(wifi_checksum, machine_name_checksum)->by_default("CARVERA")->as_string();
+	this->tcp_port = THEKERNEL->config->value(wifi_checksum, tcp_port_checksum)->as_int(2222);
+	this->udp_send_port = THEKERNEL->config->value(wifi_checksum, udp_send_port_checksum)->as_int(3333);
+	this->udp_recv_port = THEKERNEL->config->value(wifi_checksum, udp_recv_port_checksum)->as_int(4444);
+	this->tcp_timeout_s = THEKERNEL->config->value(wifi_checksum, tcp_timeout_s_checksum)->as_int(10);
+    std::string config_name = THEKERNEL->config->value(wifi_checksum, machine_name_checksum)->as_string("CARVERA");
     strncpy(this->machine_name, config_name.c_str(), sizeof(this->machine_name) - 1);
     this->machine_name[sizeof(this->machine_name) - 1] = '\0'; // Ensure null termination
 
@@ -81,12 +81,12 @@ void WifiProvider::on_module_loaded()
     this->init_wifi_module(false);
 
     // Add interrupt for WIFI data receving
-    Pin *smoothie_pin = new(AHB) Pin();
-    smoothie_pin->from_string(THEKERNEL->config->value(wifi_checksum, wifi_interrupt_pin_checksum)->by_default("2.11")->as_string());
+    Pin *smoothie_pin = new Pin();
+    smoothie_pin->from_string(THEKERNEL->config->value(wifi_checksum, wifi_interrupt_pin_checksum)->as_string("2.11"));
     smoothie_pin->as_input();
     if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
         PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
-        wifi_interrupt_pin = new(AHB) mbed::InterruptIn(pinname);
+        wifi_interrupt_pin = new mbed::InterruptIn(pinname);
         wifi_interrupt_pin->rise(this, &WifiProvider::on_pin_rise);
         NVIC_SetPriority(EINT3_IRQn, 16);
     } else {


### PR DESCRIPTION
WARNING: The config cache bypasses malloc entirely. It is placed at a fixed address in RAM just below the stack (__StackLimit), in the gap between the heap and stack that is unused during boot. A safety check in config_cache_clear() verifies the heap did not grow into the cache region; if it did, it prints a diagnostic and resets. The cache occupies 350 * 26 = 9100 bytes below __StackLimit.

WARNING: Config values limited to 19 chars (system_reset on boot, error on config-set). Config cache limited to 350 entries.

- Place config cache in fixed RAM below __StackLimit, bypassing the heap allocator entirely — zero malloc/free, zero fragmentation
- Replace std::string value with char[20], eliminating per-entry string buffer mallocs
- Replace by_default(X)->as_TYPE() with as_TYPE(X) overloads
- Remove found/default_int/default_double/default_set members
- Move ~25 non-ISR objects from new(AHB) to plain new; keep SerialConsole, SerialConsole2, SlowTicker, StepTicker, Conveyor in AHB

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.

