### PR TITLE
Report boot-time config errors to the controller

### DIFF
--- a/mbed/src/cpp/stdio.cpp
+++ b/mbed/src/cpp/stdio.cpp
@@ -76,7 +76,7 @@ static void init_serial() {
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
     serial_format(&stdio_uart, 8, ParityNone, 1);
-    serial_baud(&stdio_uart, 9600);
+    serial_baud(&stdio_uart, 115200);
 #endif
 }
 

--- a/mbed/src/vendor/NXP/capi/LPC1768/PeripheralNames.h
+++ b/mbed/src/vendor/NXP/capi/LPC1768/PeripheralNames.h
@@ -69,9 +69,9 @@ typedef enum {
      CAN_2 = (int)LPC_CAN2_BASE
 } CANName;
 
-#define STDIO_UART_TX     USBTX
-#define STDIO_UART_RX     USBRX
-#define STDIO_UART        UART_0
+#define STDIO_UART_TX     P2_8
+#define STDIO_UART_RX     P2_9
+#define STDIO_UART        UART_2
 
 #ifdef __cplusplus
 }

--- a/src/libs/ADC/adc.cpp
+++ b/src/libs/ADC/adc.cpp
@@ -4,6 +4,8 @@
  */
 #include "mbed.h"
 #include "adc.h"
+#include "libs/Kernel.h"
+#include "libs/StreamOutputPool.h"
 
 using namespace mbed;
 
@@ -40,9 +42,9 @@ ADC::ADC(int sample_rate, int cclk_div)
             LPC_SC->PCLKSEL0 |= 0x3 << 24;
             break;
         default:
-            printf("ADC Warning: ADC CCLK clock divider must be 1, 2, 4 or 8. %u supplied.\n",
+            THEKERNEL->streams->printf("ADC Warning: ADC CCLK clock divider must be 1, 2, 4 or 8. %u supplied.\n",
                 cclk_div);
-            printf("Defaulting to 1.\n");
+            THEKERNEL->streams->printf("Defaulting to 1.\n");
             LPC_SC->PCLKSEL0 |= 0x1 << 24;
             break;
     }
@@ -50,20 +52,20 @@ ADC::ADC(int sample_rate, int cclk_div)
     clock_div=pclk / adc_clk_freq;
 
     if (clock_div > 0xFF) {
-        printf("ADC Warning: Clock division is %u which is above 255 limit. Re-Setting at limit.\n", clock_div);
+        THEKERNEL->streams->printf("ADC Warning: Clock division is %u which is above 255 limit. Re-Setting at limit.\n", clock_div);
         clock_div=0xFF;
     }
     if (clock_div == 0) {
-        printf("ADC Warning: Clock division is 0. Re-Setting to 1.\n");
+        THEKERNEL->streams->printf("ADC Warning: Clock division is 0. Re-Setting to 1.\n");
         clock_div=1;
     }
 
     _adc_clk_freq=pclk / clock_div;
     if (_adc_clk_freq > MAX_ADC_CLOCK) {
-        printf("ADC Warning: Actual ADC sample rate of %u which is above %u limit\n",
+        THEKERNEL->streams->printf("ADC Warning: Actual ADC sample rate of %u which is above %u limit\n",
             _adc_clk_freq / CLKS_PER_SAMPLE, MAX_ADC_CLOCK / CLKS_PER_SAMPLE);
         while ((pclk / max_div) > MAX_ADC_CLOCK) max_div++;
-        printf("ADC Warning: Maximum recommended sample rate is %u\n", (pclk / max_div) / CLKS_PER_SAMPLE);
+        THEKERNEL->streams->printf("ADC Warning: Maximum recommended sample rate is %u\n", (pclk / max_div) / CLKS_PER_SAMPLE);
     }
 
     LPC_ADC->ADCR =

--- a/src/libs/ConfigSource.cpp
+++ b/src/libs/ConfigSource.cpp
@@ -2,6 +2,8 @@
 #include "ConfigSource.h"
 #include "ConfigValue.h"
 #include "ConfigCache.h"
+#include "libs/Kernel.h"
+#include "libs/StreamOutputPool.h"
 
 #include "stdio.h"
 
@@ -19,13 +21,15 @@ ConfigValue* ConfigSource::process_line(const string &buffer)
 
     size_t end_key = buffer.find_first_of(" \t", begin_key);
     if(end_key == string::npos) {
-        printf("ERROR: config file line %s is invalid, no key value pair found\r\n", buffer.c_str());
+        THEKERNEL->streams->printf("ERROR: config file line %s is invalid, no key value pair found\r\n", buffer.c_str());
+        THEKERNEL->set_config_load_error(true);
         return NULL;
     }
 
     size_t begin_value = buffer.find_first_not_of(" \t", end_key);
     if(begin_value == string::npos || buffer[begin_value] == '#') {
-        printf("ERROR: config file line %s has no value\r\n", buffer.c_str());
+        THEKERNEL->streams->printf("ERROR: config file line %s has no value\r\n", buffer.c_str());
+        THEKERNEL->set_config_load_error(true);
         return NULL;
     }
 

--- a/src/libs/ConfigSources/FileConfigSource.cpp
+++ b/src/libs/ConfigSources/FileConfigSource.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "libs/Kernel.h"
+#include "libs/StreamOutputPool.h"
 #include "ConfigValue.h"
 #include "FileConfigSource.h"
 #include "ConfigCache.h"
@@ -35,8 +36,10 @@ bool FileConfigSource::readLine(string& line, int lineno, FILE *fp)
             // truncate long lines
             if(lineno != 0) {
                 // report if it is not truncating a comment
-                if(strchr(buf, '#') == NULL)
-                    printf("Truncated long line %d in: %s\n", lineno, config_file.c_str());
+                if(strchr(buf, '#') == NULL) {
+                    THEKERNEL->streams->printf("Truncated long line %d in: %s\n", lineno, config_file.c_str());
+                    THEKERNEL->set_config_load_error(true);
+                }
             }
             // read until the next \n or eof
             int c;
@@ -95,7 +98,7 @@ void FileConfigSource::transfer_values_to_cache( ConfigCache *cache, const char 
                     else if(file_exists("/local" + inc_file_name)) inc_file_name = "/local" + inc_file_name;
                 }
                 if(file_exists(inc_file_name)) {
-                    printf("Including config file: %s\n", inc_file_name.c_str());
+                    THEKERNEL->streams->printf("Including config file: %s\n", inc_file_name.c_str());
 
                     // save position in current config file
                     fpos_t pos;
@@ -109,7 +112,8 @@ void FileConfigSource::transfer_values_to_cache( ConfigCache *cache, const char 
                     freopen(file_name, "r", lp);
                     fsetpos(lp, &pos);
                 }else{
-                    printf("Unable to find included config file: %s\n", inc_file_name.c_str());
+                    THEKERNEL->streams->printf("Unable to find included config file: %s\n", inc_file_name.c_str());
+                    THEKERNEL->set_config_load_error(true);
                 }
             }
 
@@ -294,7 +298,8 @@ string FileConfigSource::get_config_file()
     if( this->has_config_file() ) {
         return this->config_file;
     } else {
-        printf("ERROR: no config file found\r\n");
+        THEKERNEL->streams->printf("ERROR: no config file found\r\n");
+        THEKERNEL->set_config_load_error(true);
         return "";
     }
 }

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -94,13 +94,21 @@ Kernel::Kernel()
     disable_serial_console = false;
     keep_alive_request = false;
     flex_compensation_load_error = false;
+    config_load_error = false;
 
-    instance = this; // setup the Singleton instance of the kernel    
-    
+    instance = this; // setup the Singleton instance of the kernel
+
     // init I2C
     this->i2c = new mbed::I2C(P0_27, P0_28);
     this->i2c->frequency(200000);
-    
+
+    // Bring up streams + serial console first so factory and config parser
+    // errors are visible on the host link. Baud is hard-coded here and gets
+    // re-applied from config later in SerialConsole::on_module_loaded().
+    this->streams = new(AHB) StreamOutputPool();
+    this->serial  = new(AHB) SerialConsole(P2_8, P2_9, 115200);
+    this->streams->append_stream(this->serial);
+
     this->factory_set = new(AHB) FACTORY_SET();
     // read Factory setting data from eeprom
     this->read_Factory_data();
@@ -113,8 +121,6 @@ Kernel::Kernel()
 
     // Pre-load the config cache
     this->config->config_cache_load();
-
-    this->streams = new(AHB) StreamOutputPool();
 
     this->current_path   = "/";
 
@@ -141,9 +147,13 @@ Kernel::Kernel()
     // Check if we should break into the debugger on halt
     this->halt_on_error_debug = this->config->value( halt_on_error_debug_checksum )->by_default(false)->as_bool();
 
-    if (!this->disable_serial_console) {
-        int uart_baud = this->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(115200)->as_number();
-        this->serial = new(AHB) SerialConsole(P2_8, P2_9, uart_baud);
+    if (this->disable_serial_console) {
+        this->streams->remove_stream(this->serial);
+        delete this->serial;
+        this->serial = nullptr;
+    } else {
+        // add_module() runs SerialConsole::on_module_loaded() which re-reads
+        // uart.baud_rate from config and applies it to the hardware.
         this->add_module( this->serial );
     }
 
@@ -1059,7 +1069,7 @@ bool Kernel::Factroy_readLine(string& line, int lineno, FILE *fp)
             if(lineno != 0) {
                 // report if it is not truncating a comment
                 if(strchr(buf, '#') == NULL)
-                    printf("Truncated long line %d in: %s\n", lineno, "Factory file");
+                    THEKERNEL->streams->printf("Truncated long line %d in: %s\n", lineno, "Factory file");
             }
             // read until the next \n or eof
             int c;
@@ -1086,13 +1096,13 @@ bool Kernel::process_line(const string &buffer, uint16_t *check_sum, unsigned ch
     
     size_t end_key = buffer.find_first_of(" \t", begin_key);
     if(end_key == string::npos) {
-        printf("ERROR: factory file line %s is invalid, no key value pair found\r\n", buffer.c_str());
+        THEKERNEL->streams->printf("ERROR: factory file line %s is invalid, no key value pair found\r\n", buffer.c_str());
         return false;
     }
 
     size_t begin_value = buffer.find_first_not_of(" \t", end_key);
     if(begin_value == string::npos || buffer[begin_value] == '#') {
-        printf("ERROR: factory file line %s has no value\r\n", buffer.c_str());
+        THEKERNEL->streams->printf("ERROR: factory file line %s has no value\r\n", buffer.c_str());
         return false;
     }
     

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -195,6 +195,8 @@ class Kernel {
         bool is_flex_compensation_active() const { return flex_compensation_active; }
         void set_flex_compensation_load_error(bool f) { flex_compensation_load_error = f; }
         bool is_flex_compensation_load_error() const { return flex_compensation_load_error; }
+        void set_config_load_error(bool f) { config_load_error = f; }
+        bool is_config_load_error() const { return config_load_error; }
 
         void set_probeLaser(bool f) { probeLaserOn = f; }
         bool is_probeLaserOn() const { return probeLaserOn; }
@@ -293,6 +295,7 @@ class Kernel {
             bool halt_on_error_debug:1;
             bool flex_compensation_active:1;
             bool flex_compensation_load_error:1;
+            bool config_load_error:1;
         };
         int iic_page_write(unsigned char u8PageNum, unsigned char u8len, unsigned char *pu8Array);
 

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -29,8 +29,8 @@ using std::string;
 // Serial reading module
 // Treats every received line as a command and passes it ( via event call ) to the command dispatcher.
 // The command dispatcher will then ask other modules if they can do something with it
-SerialConsole::SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate ){
-    this->serial = new mbed::Serial( rx_pin, tx_pin );
+SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate ){
+    this->serial = new mbed::Serial( tx_pin, rx_pin );
     this->serial->baud(baud_rate);
     this->previous_char = 0;
     this->current_baud_rate = baud_rate;
@@ -39,15 +39,24 @@ SerialConsole::SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate ){
     this->last_activity_ms = 0;
 }
 
+SerialConsole::~SerialConsole(){
+    delete this->serial;
+}
+
 // Called when the module has just been loaded
 void SerialConsole::on_module_loaded() {
     // We want to be called every time a new char is received
     query_flag = false;
     halt_flag = false;
     diagnose_flag = false;
-	this->attach_irq(true);
 
     default_baud_rate = THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(current_baud_rate)->as_number();
+    if (default_baud_rate != current_baud_rate) {
+        this->serial->baud(default_baud_rate);
+        this->current_baud_rate = default_baud_rate;
+    }
+
+    this->attach_irq(true);
 
     // We only call the command dispatcher in the main loop, nowhere else
     this->register_for_event(ON_MAIN_LOOP);

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -22,7 +22,8 @@ using std::string;
 
 class SerialConsole : public Module, public StreamOutput {
     public:
-        SerialConsole( PinName rx_pin, PinName tx_pin, int baud_rate );
+        SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate );
+        ~SerialConsole();
 
         void on_module_loaded();
         void on_serial_char_received();

--- a/src/modules/communication/SerialConsole2.cpp
+++ b/src/modules/communication/SerialConsole2.cpp
@@ -42,7 +42,7 @@ SerialConsole2::SerialConsole2() {
 // Called when the module has just been loaded
 void SerialConsole2::on_module_loaded() {
 
-	this->serial = new mbed::Serial( USBTX, USBRX );
+	this->serial = new mbed::Serial( P0_2, P0_3 );
     this->serial->baud(THEKERNEL->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
 
     // We want to be called every time a new char is received

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -716,7 +716,10 @@ void Player::on_main_loop(void *argument)
         }
 
         if (this->on_boot_gcode_enable) {
-            this->play_command(this->on_boot_gcode, THEKERNEL->serial);
+            StreamOutput *stream = THEKERNEL->serial != nullptr
+                                 ? static_cast<StreamOutput *>(THEKERNEL->serial)
+                                 : &StreamOutput::NullStream;
+            this->play_command(this->on_boot_gcode, stream);
         }
 
     }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1234,6 +1234,9 @@ void SimpleShell::model_command( string parameters, StreamOutput *stream )
 			stream->printf("model = %s, %d, %d, %d\n", "C1", THEKERNEL->factory_set->MachineModel, THEKERNEL->factory_set->FuncSetting, THEKERNEL->probe_addr);
 			break;
 	}
+    if(THEKERNEL->is_config_load_error()) {
+        stream->printf("ERROR: config file had errors during boot, see SD\n");
+    }
 }
 
 // test 4th for factory


### PR DESCRIPTION
* Reorder Kernel construction so UART2 (serial-over-USB) stream is up early
* Route boot-path printf calls in ConfigSource, FileConfigSource, Kernel factory parser and ADC through THEKERNEL->streams so they reach the controller/host instead of the Zigbee controller on UART0.
* Add a sticky config_load_error 1-bit flag on Kernel, set by config parse/load failures and reported by the version command so the controller sees it on connect.
* Retarget stdio to UART2 so hard-fault output and other low-level prints reach the host.
* SerialConsole2 (Zigbee controller) uses P0_2/P0_3 directly instead of the misleading USBTX/USBRX dev board aliases.

Gotchas:
* The UART2 is configured at static 115200 baud during boot even if the user has a different rate in the config. Nothing can be done about it - the config is not read yet.
* disable_serial_console has no effect during boot for the same reason. The purpose of that flag is unclear.
* config_load_error flag is not cleared, the warning will be printed to the MDI console on every reconnect to encourage the user to fix the config.

Full disclosure: Claude Opus 4.6 was used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.
