### PR TITLE
debugmode and slowticker

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -18,6 +18,7 @@
 
 #include "libs/StepTicker.h"
 #include "libs/PublicData.h"
+#include "us_ticker_api.h"
 #include "modules/communication/SerialConsole.h"
 #include "modules/communication/GcodeDispatch.h"
 #include "modules/robot/Planner.h"
@@ -641,8 +642,16 @@ void Kernel::call_event(_EVENT_ENUM id_event, void * argument)
     }
 
     // send to all registered modules
-    for (auto m : hooks[id_event]) {
-        (m->*kernel_callback_functions[id_event])(argument);
+    if (id_event == ON_IDLE && debug_flags.cpu_load) {
+        uint32_t t0 = us_ticker_read();
+        for (auto m : hooks[id_event]) {
+            (m->*kernel_callback_functions[id_event])(argument);
+        }
+        slow_ticker->idle_us_accum += us_ticker_read() - t0;
+    } else {
+        for (auto m : hooks[id_event]) {
+            (m->*kernel_callback_functions[id_event])(argument);
+        }
     }
 
     if(id_event == ON_HALT) {

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -90,6 +90,7 @@ Kernel::Kernel()
     probe_addr = 0;
     checkled = false;
     spindleon = false;
+    debug_flags = {};
     cachewait = false;
     disable_serial_console = false;
     keep_alive_request = false;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -255,6 +255,10 @@ class Kernel {
         uint16_t probe_addr;
         bool checkled;
         bool spindleon;
+
+        struct {
+            bool slowticker_profiling:1;
+        } debug_flags;
         float local_vars[20];
         float probe_outputs[6];
         float probe_tip_diameter = 1.6;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -258,6 +258,7 @@ class Kernel {
 
         struct {
             bool slowticker_profiling:1;
+            bool cpu_load:1;
         } debug_flags;
         float local_vars[20];
         float probe_outputs[6];

--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -13,6 +13,8 @@
 #include "libs/Hook.h"
 #include "modules/robot/Conveyor.h"
 #include "Gcode.h"
+#include "StreamOutputPool.h"
+#include "us_ticker_api.h"
 
 #include <mri.h>
 
@@ -35,6 +37,8 @@ SlowTicker::SlowTicker(){
     max_frequency = 5;  // initial max frequency is set to 5Hz
     set_frequency(max_frequency);
     flag_1s_flag = 0;
+    tick_max_us = 0;
+    tick_last_us = 0;
 }
 
 void SlowTicker::start()
@@ -60,6 +64,7 @@ void SlowTicker::set_frequency( int frequency ){
 void SlowTicker::tick(){
 
     // Call all hooks that need to be called
+    uint32_t t0 = THEKERNEL->debug_flags.slowticker_profiling ? us_ticker_read() : 0;
     for (Hook* hook : this->hooks){
         hook->countdown -= this->interval;
         if (hook->countdown < 0)
@@ -67,6 +72,11 @@ void SlowTicker::tick(){
             hook->countdown += hook->interval;
             hook->call();
         }
+    }
+    if (THEKERNEL->debug_flags.slowticker_profiling) {
+        uint32_t elapsed = us_ticker_read() - t0;
+        tick_last_us = elapsed;
+        if (elapsed > tick_max_us) tick_max_us = elapsed;
     }
 
     // deduct tick time from second counter
@@ -117,9 +127,15 @@ void SlowTicker::on_idle(void*)
     }
 
     // if interrupt has set the 1 second flag
-    if (flag_1s())
+    if (flag_1s()) {
         // fire the on_second_tick event
         THEKERNEL->call_event(ON_SECOND_TICK);
+        if (THEKERNEL->debug_flags.slowticker_profiling) {
+            THEKERNEL->streams->printf("SlowTicker: freq=%luHz  last=%luus  max=%luus  budget=%luus\n",
+                max_frequency, tick_last_us, tick_max_us, (uint32_t)(1000000UL / max_frequency));
+            tick_max_us = 0;  // reset peak each second
+        }
+    }
 }
 
 extern "C" void TIMER2_IRQHandler (void){

--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -39,6 +39,7 @@ SlowTicker::SlowTicker(){
     flag_1s_flag = 0;
     tick_max_us = 0;
     tick_last_us = 0;
+    idle_us_accum = 0;
 }
 
 void SlowTicker::start()
@@ -134,6 +135,15 @@ void SlowTicker::on_idle(void*)
             THEKERNEL->streams->printf("SlowTicker: freq=%luHz  last=%luus  max=%luus  budget=%luus\n",
                 max_frequency, tick_last_us, tick_max_us, (uint32_t)(1000000UL / max_frequency));
             tick_max_us = 0;  // reset peak each second
+        }
+        if (THEKERNEL->debug_flags.cpu_load) {
+            // idle_us_accum is the total µs spent inside ON_IDLE this second.
+            // Everything else (ON_MAIN_LOOP + interrupts) is "busy".
+            uint32_t idle_us = idle_us_accum;
+            idle_us_accum = 0;
+            uint32_t busy_us = (idle_us < 1000000) ? (1000000 - idle_us) : 0;
+            uint32_t busy_pct = busy_us / 10000;   // integer %, 0-100
+            THEKERNEL->streams->printf("CPU: %lu%% busy\n", busy_pct);
         }
     }
 }

--- a/src/libs/SlowTicker.h
+++ b/src/libs/SlowTicker.h
@@ -60,6 +60,7 @@ protected:
 public:
     volatile uint32_t tick_max_us;
     volatile uint32_t tick_last_us;
+    uint32_t idle_us_accum;
 };
 
 

--- a/src/libs/SlowTicker.h
+++ b/src/libs/SlowTicker.h
@@ -56,6 +56,10 @@ class SlowTicker : public Module{
 protected:
     int flag_1s_count;
     volatile int flag_1s_flag;
+
+public:
+    volatile uint32_t tick_max_us;
+    volatile uint32_t tick_last_us;
 };
 
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -18,6 +18,7 @@
 #include "libs/StreamOutputPool.h"
 #include "libs/gpio.h"
 #include "Conveyor.h"
+#include "SlowTicker.h"
 #include "DirHandle.h"
 #include "mri.h"
 #include "version.h"
@@ -126,6 +127,7 @@ const SimpleShell::ptentry_t SimpleShell::commands_table[] = {
     {"enable_4th_hd", SimpleShell::enable_4th_hd},
     {"disable_4th_hd", SimpleShell::disable_4th_hd},
     {"baud",         SimpleShell::baud_command},
+    {"debugmode",    SimpleShell::debugmode_command},
 
     // unknown command
     {NULL, NULL}
@@ -1530,6 +1532,44 @@ void SimpleShell::baud_command(string parameters, StreamOutput *stream)
     }
     stream->printf("ok\n");
     static_cast<SerialConsole *>(THEKERNEL->serial)->set_baud_temporary(static_cast<int>(new_baud));
+}
+
+void SimpleShell::debugmode_command(string parameters, StreamOutput *stream)
+{
+    string arg = shift_parameter(parameters);
+
+    if (arg.empty()) {
+        stream->printf("Available debug modes (currently active marked with *):\n");
+        stream->printf("  slowticker  - print SlowTicker ISR duration stats once per second%s\n",
+            THEKERNEL->debug_flags.slowticker_profiling ? " *" : "");
+        stream->printf("  cpuload - print CPU load percentage once per second%s\n",
+            THEKERNEL->debug_flags.cpu_load ? " *" : "");
+        stream->printf("Usage: debugmode <mode>  or  debugmode off\n");
+        return;
+    }
+
+    if (arg == "off") {
+        THEKERNEL->debug_flags.slowticker_profiling = false;
+        THEKERNEL->debug_flags.cpu_load = false;
+        stream->printf("All debug modes disabled\n");
+        return;
+    }
+
+    if (arg == "slowticker") {
+        THEKERNEL->debug_flags.slowticker_profiling = true;
+        THEKERNEL->slow_ticker->tick_max_us = 0;
+        stream->printf("SlowTicker profiling enabled - stats will print once per second\n");
+        return;
+    }
+
+    if (arg == "cpuload") {
+        THEKERNEL->debug_flags.cpu_load = true;
+        THEKERNEL->slow_ticker->idle_us_accum = 0;
+        stream->printf("CPU load monitoring enabled - busy % once per second\n");
+        return;
+    }
+
+    stream->printf("Unknown debug mode: %s\nRun 'debugmode' with no arguments to list options\n", arg.c_str());
 }
 
 // go into dfu boot mode

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1565,7 +1565,7 @@ void SimpleShell::debugmode_command(string parameters, StreamOutput *stream)
     if (arg == "cpuload") {
         THEKERNEL->debug_flags.cpu_load = true;
         THEKERNEL->slow_ticker->idle_us_accum = 0;
-        stream->printf("CPU load monitoring enabled - busy % once per second\n");
+        stream->printf("CPU load monitoring enabled - busy percentage once per second\n");
         return;
     }
 

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -96,6 +96,8 @@ private:
 
     static void baud_command(string parameters, StreamOutput *stream);
 
+    static void debugmode_command(string parameters, StreamOutput *stream);
+
     typedef void (*PFUNC)(string parameters, StreamOutput *stream);
     typedef struct {
         const char *command;

--- a/version.txt
+++ b/version.txt
@@ -1,6 +1,7 @@
 [unreleased]
 - Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 
 - Enhancement: Added `debugmode slowticker` to output SlowTicker ISR duration stats once per second to console
+- Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,7 @@
+[unreleased]
+- Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 
+- Enhancement: Added `debugmode slowticker` to output SlowTicker ISR duration stats once per second to console
+
 [2.1.0c]
 - Fixed: Unused Variables removed
 - Fixed: Removing unused code blocks in simpleshell


### PR DESCRIPTION
I'm seeing an increasing need to bake in debug functionality that affects real time execution into the firmware, so I added some scaffolding for a `debugmode` where different capability could be temporarily enabled.

The first debug tool I added is functionality to output stats on the SlowTicker ISR duration to aid in investigation of the poor PID spindle response time. The theory was that the processor is already busy with everything else that it wasn't going through the hooks in SlowTicker at the defined `UPDATE_FREQ`. This debugprofiler showed a last/max time in 1 second intervals to console for the actual time spent running the SlowTicker hooks vs budgeted time.

Example outputs:

No params shows the available modes as well as which are active:
```
debugmode
Available debug modes (currently active marked with *):
slowticker  - print SlowTicker ISR duration stats once per second
Usage: debugmode <mode>  or  debugmode off
```

SlowTicker mode:
```
debugmode slowticker
SlowTicker profiling enabled - stats will print once per second
SlowTicker: freq=1000Hz  last=9us  max=90us  budget=1000us
```