### PR TITLE
Use real PID control for C1 Spindle

### DIFF
--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -26,6 +26,8 @@
 #include "port_api.h"
 #include "us_ticker_api.h"
 
+#include <numeric>
+
 #define spindle_checksum                    CHECKSUM("spindle")
 #define spindle_pwm_pin_checksum            CHECKSUM("pwm_pin")
 #define spindle_pwm_period_checksum         CHECKSUM("pwm_period")
@@ -66,6 +68,8 @@ void PWMSpindleControl::on_module_loaded()
     factor = 100;
 
     pulses_per_rev = THEKERNEL->config->value(spindle_checksum, spindle_pulses_per_rev_checksum)->by_default(1.0f)->as_number();
+    pulse_times = std::vector<uint32_t>(static_cast<uint32_t>(std::ceil(pulses_per_rev)), 0xFFFFFF);
+    total_pulse_time = std::accumulate(pulse_times.begin(), pulse_times.end(), 0);
     target_rpm = THEKERNEL->config->value(spindle_checksum, spindle_default_rpm_checksum)->by_default( 15000.0f)->as_number();
     if(CARVERA == THEKERNEL->factory_set->MachineModel) {
         max_rpm = THEKERNEL->config->value(spindle_checksum, spindle_max_rpm_checksum)->by_default(15000.0f)->as_number();
@@ -125,7 +129,10 @@ void PWMSpindleControl::on_module_loaded()
         if (smoothie_pin->port_number == 0 || smoothie_pin->port_number == 2) {
             PinName pinname = port_pin((PortName)smoothie_pin->port_number, smoothie_pin->pin);
             feedback_pin = new mbed::InterruptIn(pinname);
-            feedback_pin->rise(this, &PWMSpindleControl::on_pin_rise);
+            if (CARVERA == THEKERNEL->factory_set->MachineModel)
+                feedback_pin->rise(this, &PWMSpindleControl::on_pin_rise_carvera);
+            else
+                feedback_pin->rise(this, &PWMSpindleControl::on_pin_rise);
             NVIC_SetPriority(EINT3_IRQn, 16);
         } else {
             THEKERNEL->streams->printf("Error: Spindle feedback pin has to be on P0 or P2.\n");
@@ -135,7 +142,10 @@ void PWMSpindleControl::on_module_loaded()
         delete smoothie_pin;
     }
     
-    THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PWMSpindleControl::on_update_speed);
+    if (CARVERA == THEKERNEL->factory_set->MachineModel)
+        THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PWMSpindleControl::on_update_speed_carvera);
+    else
+        THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PWMSpindleControl::on_update_speed);
 }
 
 void PWMSpindleControl::on_pin_rise()
@@ -214,6 +224,69 @@ uint32_t PWMSpindleControl::on_update_speed(uint32_t dummy)
     else
         pwm_pin->write(current_pwm_value);
     
+    return 0;
+}
+
+// C1-specific interrupt handler that calculates RPM based on time between pulses instead of counting pulses per revolution, for better performance at high speed and with more pulses per rev
+void PWMSpindleControl::on_pin_rise_carvera() {
+    uint32_t timestamp = us_ticker_read();
+
+    // Calculate total_pulse_time based on last pulses_per_rev interrupts
+
+    uint32_t time_diff = timestamp - last_edge;
+
+    total_pulse_time -= pulse_times[pulse_idx];
+    total_pulse_time += time_diff;
+
+    pulse_times[pulse_idx] = time_diff;
+    last_edge = timestamp;
+
+    pulse_idx = (pulse_idx + 1) % pulse_times.size();
+
+    time_since_update = 0;
+}
+
+// C1-specific PID control
+uint32_t PWMSpindleControl::on_update_speed_carvera(uint32_t /*dummy*/) {
+    // If we don't get any interrupts for 1 second, set current RPM to 0
+    if (++time_since_update > UPDATE_FREQ) {
+    	current_rpm = 0;
+    } else {    // Calculate current RPM
+	    uint32_t t = total_pulse_time;
+	    if (t > 2000 * acc_ratio ) //RPM < 30000
+	    {	
+	        float new_rpm = 1000000 * acc_ratio * 60.0f / t;
+	        current_rpm = smoothing_decay * new_rpm + (1.0f - smoothing_decay) * current_rpm;
+	    }
+	}
+
+    if (spindle_on) {
+        float error = target_rpm * (factor / 100) - current_rpm;
+
+        if (current_pwm_value < 1.0f || error <= 0) {
+            // We are saturated at max speed, so don't increase I term to avoid windup
+            current_I_value += control_I_term * error * 1.0f / UPDATE_FREQ;
+            current_I_value = confine(current_I_value, -1.0f, 1.0f);
+        }
+
+        float new_pwm = 0.0000485 * target_rpm + 0.02; // Feed forward term, empirically derived at noload
+        new_pwm += control_P_term * error;
+        new_pwm += current_I_value;
+        new_pwm += control_D_term * (error - prev_error) * UPDATE_FREQ;
+        new_pwm = confine(new_pwm, 0.0f, max_pwm);
+
+        prev_error = error;
+        current_pwm_value = new_pwm;
+    } else {
+        current_I_value = 0;
+        current_pwm_value = 0;
+    }
+
+    if (output_inverted)
+        pwm_pin->write(1.0f - current_pwm_value);
+    else
+        pwm_pin->write(current_pwm_value);
+
     return 0;
 }
 

--- a/src/modules/tools/spindle/PWMSpindleControl.h
+++ b/src/modules/tools/spindle/PWMSpindleControl.h
@@ -11,6 +11,7 @@
 #include "SpindleControl.h"
 #include <stdint.h>
 #include "Pin.h"
+#include <vector>
 
 namespace mbed {
     class PwmOut;
@@ -30,7 +31,9 @@ class PWMSpindleControl: public SpindleControl {
     private:
         
         void on_pin_rise();
+        void on_pin_rise_carvera();
         uint32_t on_update_speed(uint32_t dummy);
+        uint32_t on_update_speed_carvera(uint32_t /*dummy*/);
         
         mbed::PwmOut *pwm_pin; // PWM output for spindle speed control
         mbed::InterruptIn *feedback_pin; // Interrupt pin for measuring speed
@@ -68,6 +71,10 @@ class PWMSpindleControl: public SpindleControl {
         uint32_t last_edge; // Timestamp of last edge
         volatile uint32_t last_time; // Time delay between last two edges
         volatile uint32_t irq_count;
+
+        std::vector<uint32_t> pulse_times;
+        uint32_t pulse_idx{0};
+        uint32_t total_pulse_time{0};
         
         uint32_t last_rev_time;
         volatile uint32_t rev_time;


### PR DESCRIPTION
Changes are implemented as extra functions in order to limit modification to base Carvera firmware.

Conditionally replaced the rpm measurement and PWM calculation for Carvera 1 machines. Stock solution has several issues when trying to get the most out of the machine:
* Only updates raw rpm when a full revolution is detected
* Calculates an overly smoothed rpm over 100ms
* PWM only updates every 200ms using the smoothed rpm
* Improper use of P, I, and D values. P is used like I, while the I and D values are not used at all

PID implementation is essentially the stock Smoothieware version, with 2 additions:
* Added I-clamping to limit overshoot when heavily ramping up speed
* Added a "real" Feed Forward component based on empirical data from my machine running with no load
 
RPM measurement is updated to maintain a rolling revolution time. The controller will always keep track of the last `pulses_per_rev` number of pulses, summed to get the last revolution time. This should be a decent balance of high reactivity while limiting the susceptibility to measurement noise. If more smoothing is needed the spindle.control_smoothing value can be tuned.

The PWM update loop is left running at 100hz. I decided not to update this to 1000hz due to relatively low pulses per revolution. At lower rpms, this would cause multiple PWM updated to trigger between any rpm measurements, and special handling would likely lead to higher compute cost. Empirically, there also did not seem to be much difference at high rpms.

I wasn't able to get a perfect tuning of the PID values, but my values should be a decent place to start for further tuning. A couple config values need to be updated to take full advantage of the new implementation:
* spindle.control_P: 0.0001
  * Pushing this higher led to a bit of rpm oscillation when unloaded. However, I haven't tested higher values with load and I think increasing this would be good to get tighter rpm control
* spindle.control_I: 0.00002
  * This kind of corresponds to the original P value from the stock implementation. My quick testing with the I value didn't get me much improvement, but it might need a much higher value
* spindle.control_D: 0
  * With the P and I at its current values, there isn't much need for D. However with higher P values D will be needed to limit overshoot and oscillation. Further testing is needed
* spindle.control_smoothing: 0.001
  * This change is critical. The default value is 0.1, or 100ms of smoothing. At 0.01 and smaller, there is no smoothing with the 100hz update loop, but setting it to 0.001 can be safe in case the update loop is updated to 1000hz later on.
* spindle.max_rpm: 16000
  * Not strictly necessary, but with better control the spindle can run a bit faster to better handle small diameter endmills without rpm drop

In order to merge this without any impact to existing users, the default PID values would likely need to be changes to something like P: 0, I: 0.00001, D:0, to match the stock behavior. Alternatively, my preference would be to determine a good set of PID values and update the defaults to that so that everyone can benefit from a stronger spindle without doing their own tuning.

Initial Testing Results:

Cut parameters:
Facing Operation in Fusion 360
3.175 single flute endmill
15000 target rpm
381mm/min feedrate
2.2mm stepover
tested 0.2mm to 1.0mm step downs.

Stock firmware reached 0.8mm step down before I was uncomfortable letting it continue. It probably could have run 1.0mm, but it would have bogged down the spindle for most of the cut if it didn't break the endmill. Based on the controller readout, it would bog down >5%, or down below 14000. It was likely even worse in reality since the controller readout is also delayed and smoothed.
With PID, even the 1.0mm step down was within 1% rpm deviation, or above 14850rpm. It would perform worse when cutting conventional due to higher cutting forces, but climb cutting performed very well. I think with better P and I values, the rpm could be tightened up even more.

Secondary Test with a 6mm endmill:

Cut parameters:
Facing Operation in Fusion 360
6mm single flute endmill
14550 target rpm
699mm/min feedrate
4.2mm stepover
tested 0.5, 0.8, 1.0mm step downs

Adaptive Clearing in Fusion 360
6mm single flue endmill
16005 target rpm
2636mm/min feedrate
0.2mm stepover
6mm stepdown

The larger tool diameter was really pushing the machine, and showed how suboptimal my PID values are. The 0.5mm facing op went pretty good, but 0.8mm and 1.0mm bogged down pretty hard, with 1.0mm bogging down >5%. I then tried a deep adaptive op, 6mm stepdown. I increased the target rpm by 10% and was able to keep the rpms above or around the 14550 intended target. The machine is definitely capable of making these heavier cuts, but the PID values need more tuning.