### PR TITLE
Increase default zprobe safety margin

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -267,7 +267,7 @@ zprobe.debounce_ms							1				# Set if noisy
 # zprobe.max_z								100				# max z
 zprobe.calibrate_pin						0.5^			# calibrate_pin
 zprobe.probe_tip_diameter					1.6				#3 axis probe tip diamter
-zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
+zprobe.calibration_safety_margin              1             # max distance to move after calibrate pin but before probe pin detected
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true

--- a/src/config2.default
+++ b/src/config2.default
@@ -290,7 +290,7 @@ zprobe.debounce_ms							1				# Set if noisy
 # zprobe.max_z								100				# max z
 zprobe.calibrate_pin						0.5^			# calibrate_pin
 zprobe.probe_tip_diameter					2.0				#3 axis probe tip diamter
-zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
+zprobe.calibration_safety_margin              1             # max distance to move after calibrate pin but before probe pin detected
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,6 @@
+[unreleased]
+- Changed: Increased zprobe.calibration_safety_margin to 1mm from 0.1 to better support probes "out of the box"
+
 [2.1.0c]
 - Fixed: Unused Variables removed
 - Fixed: Removing unused code blocks in simpleshell


### PR DESCRIPTION
Increasingly more people are needing to change the default zprobe.calibration_safety_margin.

I've just received a batch of 20 v6 probes manufactured in March 2026, and they all make use of a stiffer spring than before requiring a safety margin of 0.4-6mm. I'll of course include instructions to do this, but people DIYing would not know what to do.

Looking at the spec sheet the v6 touch probes have a 2mm of travel in them in Z before bottoming out, and my C1 tool setter has 3-4mm of travel itself. I assume the Air has something similar. Based on this I think we are safe to set the calibration_safety_margin to 1mm

@WARIO2412 do you agree?