### PR TITLE
Add real PID spindle control option

### DIFF
--- a/src/modules/tools/spindle/PIDPWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PIDPWMSpindleControl.cpp
@@ -1,0 +1,107 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/Module.h"
+#include "libs/Kernel.h"
+#include "PIDPWMSpindleControl.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+#include "SlowTicker.h"
+#include "Conveyor.h"
+#include "system_LPC17xx.h"
+#include "PublicDataRequest.h"
+#include "SpindlePublicAccess.h"
+#include "utils.h"
+
+#define spindle_checksum                    CHECKSUM("spindle")
+#define spindle_ff_slope_checksum          CHECKSUM("ff_slope")
+#define spindle_ff_offset_checksum          CHECKSUM("ff_offset")
+
+#define UPDATE_FREQ 100
+
+#include "libs/Pin.h"
+#include "Gcode.h"
+#include "InterruptIn.h"
+#include "PwmOut.h"
+#include "port_api.h"
+#include "us_ticker_api.h"
+
+#include <numeric>
+
+PIDPWMSpindleControl::PIDPWMSpindleControl()
+{
+}
+
+void PIDPWMSpindleControl::on_module_loaded()
+{
+    PWMSpindleControl::on_module_loaded();
+    
+    ff_slope = THEKERNEL->config->value(spindle_checksum, spindle_ff_slope_checksum)->by_default(0.0000485f)->as_number();
+    ff_offset = THEKERNEL->config->value(spindle_checksum, spindle_ff_offset_checksum)->by_default(0.02f)->as_number();
+    
+    pulse_times = std::vector<uint32_t>(static_cast<uint32_t>(std::ceil(pulses_per_rev)), 0xFFFFFF);
+    total_pulse_time = std::accumulate(pulse_times.begin(), pulse_times.end(), 0);
+    
+    // Re-attach interrupt and ticker to the PID overrides.
+    if (feedback_pin != NULL) {
+        feedback_pin->rise(this, &PIDPWMSpindleControl::on_pin_rise);
+    }
+    THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PIDPWMSpindleControl::on_update_speed);
+}
+
+void PIDPWMSpindleControl::on_pin_rise() {
+    uint32_t timestamp = us_ticker_read();
+    uint32_t time_diff = timestamp - last_edge;
+    total_pulse_time -= pulse_times[pulse_idx];
+    total_pulse_time += time_diff;
+    pulse_times[pulse_idx] = time_diff;
+    last_edge = timestamp;
+    pulse_idx = (pulse_idx + 1) % pulse_times.size();
+    time_since_update = 0;
+}
+
+uint32_t PIDPWMSpindleControl::on_update_speed(uint32_t /*dummy*/) {
+    if (++time_since_update > UPDATE_FREQ) {
+    	current_rpm = 0;
+    } else {
+	    uint32_t t = total_pulse_time;
+	    if (t > 2000 * acc_ratio ) {	
+	        float new_rpm = 1000000 * acc_ratio * 60.0f / t;
+	        current_rpm = smoothing_decay * new_rpm + (1.0f - smoothing_decay) * current_rpm;
+	    }
+	}
+
+    if (spindle_on) {
+        float error = target_rpm * (factor / 100) - current_rpm;
+
+        if (current_pwm_value < 1.0f || error <= 0) {
+            current_I_value += control_I_term * error * 1.0f / UPDATE_FREQ;
+            current_I_value = confine(current_I_value, -1.0f, 1.0f);
+        }
+
+        float new_pwm = ff_slope * target_rpm + ff_offset; 
+        new_pwm += control_P_term * error;
+        new_pwm += current_I_value;
+        new_pwm += control_D_term * (error - prev_error) * UPDATE_FREQ;
+        new_pwm = confine(new_pwm, 0.0f, max_pwm);
+
+        prev_error = error;
+        current_pwm_value = new_pwm;
+    } else {
+        current_I_value = 0;
+        current_pwm_value = 0;
+    }
+
+    if (output_inverted)
+        pwm_pin->write(1.0f - current_pwm_value);
+    else
+        pwm_pin->write(current_pwm_value);
+
+    return 0;
+}

--- a/src/modules/tools/spindle/PIDPWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PIDPWMSpindleControl.cpp
@@ -42,8 +42,8 @@ void PIDPWMSpindleControl::on_module_loaded()
 {
     PWMSpindleControl::on_module_loaded();
     
-    ff_slope = THEKERNEL->config->value(spindle_checksum, spindle_ff_slope_checksum)->by_default(0.0000485f)->as_number();
-    ff_offset = THEKERNEL->config->value(spindle_checksum, spindle_ff_offset_checksum)->by_default(0.02f)->as_number();
+    ff_slope = THEKERNEL->config->value(spindle_checksum, spindle_ff_slope_checksum)->as_number(0.0000485f);
+    ff_offset = THEKERNEL->config->value(spindle_checksum, spindle_ff_offset_checksum)->as_number(0.02f);
     
     pulse_times = std::vector<uint32_t>(static_cast<uint32_t>(std::ceil(pulses_per_rev)), 0xFFFFFF);
     total_pulse_time = std::accumulate(pulse_times.begin(), pulse_times.end(), 0);

--- a/src/modules/tools/spindle/PIDPWMSpindleControl.h
+++ b/src/modules/tools/spindle/PIDPWMSpindleControl.h
@@ -1,0 +1,39 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PID_PWM_SPINDLE_MODULE_H
+#define PID_PWM_SPINDLE_MODULE_H
+
+#include "PWMSpindleControl.h"
+#include <stdint.h>
+#include "Pin.h"
+#include <vector>
+
+namespace mbed {
+    class PwmOut;
+    class InterruptIn;
+}
+
+class PIDPWMSpindleControl: public PWMSpindleControl {
+    public:
+        PIDPWMSpindleControl();
+        virtual ~PIDPWMSpindleControl() {};
+        void on_module_loaded();
+
+    private:
+        void on_pin_rise();
+        uint32_t on_update_speed(uint32_t dummy);
+        
+        float ff_slope;
+        float ff_offset;
+
+        std::vector<uint32_t> pulse_times;
+        uint32_t pulse_idx{0};
+        uint32_t total_pulse_time{0};
+};
+
+#endif

--- a/src/modules/tools/spindle/PWMSpindleControl.h
+++ b/src/modules/tools/spindle/PWMSpindleControl.h
@@ -27,7 +27,7 @@ class PWMSpindleControl: public SpindleControl {
         void on_set_public_data(void *argument);
         void on_idle(void* argument);
 
-    private:
+    protected:
         
         void on_pin_rise();
         uint32_t on_update_speed(uint32_t dummy);

--- a/src/modules/tools/spindle/SpindleMaker.cpp
+++ b/src/modules/tools/spindle/SpindleMaker.cpp
@@ -10,6 +10,7 @@
 #include "libs/Kernel.h"
 #include "SpindleControl.h"
 #include "PWMSpindleControl.h"
+#include "PIDPWMSpindleControl.h"
 #include "AnalogSpindleControl.h"
 #ifndef NO_MODBUS_SPINDLE
 #include "HuanyangSpindleControl.h"
@@ -42,6 +43,8 @@ void SpindleMaker::load_spindle(){
     // check config which spindle type we need
     if( spindle_type.compare("pwm") == 0 ) {
         spindle = new PWMSpindleControl();
+    } else if ( spindle_type.compare("pid_pwm") == 0 ) {
+        spindle = new PIDPWMSpindleControl();
     } else if ( spindle_type.compare("analog") == 0 ) {
         spindle = new AnalogSpindleControl();
 #ifndef NO_MODBUS_SPINDLE


### PR DESCRIPTION
See original PR at #309, updated so that the new implementation is isolated and requires the user explicitly enable it. This avoids unintended behavior change.

Changes are implemented as extra functions in order to limit modification to base Carvera firmware.

Conditionally replaced the rpm measurement and PWM calculation for Carvera 1 machines. Stock solution has several issues when trying to get the most out of the machine:

    Only updates raw rpm when a full revolution is detected
    Calculates an overly smoothed rpm over 100ms
    PWM only updates every 200ms using the smoothed rpm
    Improper use of P, I, and D values. P is used like I, while the I and D values are not used at all

PID implementation is essentially the stock Smoothieware version, with 2 additions:

    Added I-clamping to limit overshoot when heavily ramping up speed
    Added a "real" Feed Forward component based on empirical data from my machine running with no load

RPM measurement is updated to maintain a rolling revolution time. The controller will always keep track of the last pulses_per_rev number of pulses, summed to get the last revolution time. This should be a decent balance of high reactivity while limiting the susceptibility to measurement noise. If more smoothing is needed the spindle.control_smoothing value can be tuned.

The PWM update loop is left running at 100hz. I decided not to update this to 1000hz due to relatively low pulses per revolution. At lower rpms, this would cause multiple PWM updated to trigger between any rpm measurements, and special handling would likely lead to higher compute cost. Empirically, there also did not seem to be much difference at high rpms.

- spindle.type: pid_pwm
  - Needed to enable the new implementation

- spindle.control_P: 0.0002
  - Pushing this higher led to a bit of rpm oscillation when unloaded. However, I haven't tested higher values with load and I think increasing this would be good to get tighter rpm control

- spindle.control_I: 0.0002
  - This kind of corresponds to the original P value from the stock implementation. My quick testing with the I value didn't get me much improvement, but it might need a much higher value

- spindle.control_D: 0
  - With the P and I at its current values, there isn't much need for D. However with higher P values D will be needed to limit overshoot and oscillation. Further testing is needed

- spindle.control_smoothing: 0.001
  - This change is critical. The default value is 0.1, or 100ms of smoothing. At 0.01 and smaller, there is no smoothing with the 100hz update loop, but setting it to 0.001 can be safe in case the update loop is updated to 1000hz later on.

- spindle.max_rpm: 16000
  - Not strictly necessary, but with better control the spindle can run a bit faster to better handle small diameter endmills without rpm drop

To get better performance, the peak current and acc/dec knobs on the spindle controller have to be modified, but then the pid parameters can be adjusted to P: 0.0001, I: 0.001, D: 0.00001.