### PR TITLE
Suspend stops spindle, and resume restarts but only if it was running…

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -326,6 +326,7 @@ e_stop_pin									0.26!^			# Emergency stop pin
 # Spindle configuration
 #spindle.enable								true			# set this to false to disable the spindle module
 #spindle.type								pwm				# sets the spindle module to PWM mode
+spindle_suspend_restore_enable              true            # On suspend: if spindle is running, stop it and remember RPM. On resume: restore only if it was running.
 spindle.pwm_pin								2.5				# Big Mosfet Q7. Pin must be hardware PWM capable.
 spindle.pwm_period							1000			# default 1000, sets the PWM frequency
 spindle.feedback_pin						2.7				# Pin must be interrupt capable. 

--- a/src/config2.default
+++ b/src/config2.default
@@ -350,6 +350,7 @@ power_fan_delay_s							30				# power fan turn on/off delay
 # Spindle configuration
 #spindle.enable								true			# set this to false to disable the spindle module
 #spindle.type								pwm				# sets the spindle module to PWM mode
+spindle_suspend_restore_enable              true            # On suspend: if spindle is running, stop it and remember RPM. On resume: restore only if it was running.
 spindle.pwm_pin								2.5				# Big Mosfet Q7. Pin must be hardware PWM capable.
 spindle.pwm_period							10000			# default 1000, sets the PWM frequency
 spindle.feedback_pin						2.7				# Pin must be interrupt capable. 

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -350,7 +350,7 @@ void MainButton::on_idle(void *argument)
     				break;
 				case SUSPEND:
     				// resume
-					THEKERNEL->set_suspending(false);    				
+					PublicData::set_value(player_checksum, resume_play_checksum, nullptr);
     				break;
     			case ALARM:
     				halt_reason = THEKERNEL->get_halt_reason();

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -1102,18 +1102,24 @@ void Player::restore_spindle_on_resume()
         return;
     }
 
+    // Spindle already on (e.g. user sent M3/M4 while paused); keep their setting.
+    if (this->last_spindle_on) {
+        this->clear_saved_spindle();
+        return;
+    }
+
+    const bool ccw = this->saved_spindle_ccw;
     char buf[32];
     if (this->saved_spindle_rpm > 0.0f) {
-        snprintf(buf, sizeof(buf), "%s S%.0f", this->saved_spindle_ccw ? "M4" : "M3", this->saved_spindle_rpm);
+        snprintf(buf, sizeof(buf), "%s S%.0f", ccw ? "M4" : "M3", this->saved_spindle_rpm);
     } else {
-        snprintf(buf, sizeof(buf), "%s", this->saved_spindle_ccw ? "M4" : "M3");
+        snprintf(buf, sizeof(buf), "%s", ccw ? "M4" : "M3");
     }
     this->clear_saved_spindle();
     this->dispatch_gcode(buf);
 
-    // Keep the tracked state consistent so a second suspend works as expected
     this->last_spindle_on = true;
-    this->last_spindle_ccw = (strstr(buf, "M4") != nullptr);
+    this->last_spindle_ccw = ccw;
 }
 
 /**

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -48,6 +48,7 @@
 #define after_suspend_gcode_checksum      CHECKSUM("after_suspend_gcode")
 #define before_resume_gcode_checksum      CHECKSUM("before_resume_gcode")
 #define leave_heaters_on_suspend_checksum CHECKSUM("leave_heaters_on_suspend")
+#define spindle_suspend_restore_enable_checksum CHECKSUM("spindle_suspend_restore_enable")
 #define laser_module_clustering_checksum 	  CHECKSUM("laser_module_clustering")
 
 extern SDFAT mounter;
@@ -80,6 +81,13 @@ Player::Player()
     this->last_played_lines = 0;
     this->last_percent_complete = 0;
     this->last_elapsed_secs = 0;
+    this->saved_spindle_on = false;
+    this->saved_spindle_rpm = 0.0f;
+    this->spindle_suspend_restore_enable = true;
+    this->last_spindle_on = false;
+    this->last_spindle_rpm = 0.0f;
+    this->last_spindle_ccw = false;
+    this->saved_spindle_ccw = false;
 }
 
 void Player::on_module_loaded()
@@ -102,6 +110,7 @@ void Player::on_module_loaded()
     std::replace( this->after_suspend_gcode.begin(), this->after_suspend_gcode.end(), '_', ' '); // replace _ with space
     std::replace( this->before_resume_gcode.begin(), this->before_resume_gcode.end(), '_', ' '); // replace _ with space
     this->leave_heaters_on = THEKERNEL->config->value(leave_heaters_on_suspend_checksum)->as_bool(false);
+    this->spindle_suspend_restore_enable = THEKERNEL->config->value(spindle_suspend_restore_enable_checksum)->as_bool(true);
 
     this->laser_clustering = THEKERNEL->config->value(laser_module_clustering_checksum)->as_bool(false);
 }
@@ -119,6 +128,7 @@ void Player::on_halt(void* argument)
 		THEKERNEL->set_waiting(false);
 		THEKERNEL->set_suspending(false);
 		THEROBOT->pop_state();
+		this->clear_saved_spindle();
 		THEKERNEL->streams->printf("Suspend cleared\n");
 	}
 }
@@ -259,6 +269,23 @@ void Player::on_gcode_received(void *argument)
     Gcode *gcode = static_cast<Gcode *>(argument);
     string args = get_arguments(gcode->get_command());
     if (gcode->has_m) {
+        // Track spindle state from the job stream so suspend/resume can work
+        if (gcode->m == 3) {
+            this->last_spindle_on = true;
+            this->last_spindle_ccw = false;
+            if (gcode->has_letter('S')) {
+                this->last_spindle_rpm = gcode->get_value('S');
+            }
+        } else if (gcode->m == 4) {
+            this->last_spindle_on = true;
+            this->last_spindle_ccw = true;
+            if (gcode->has_letter('S')) {
+                this->last_spindle_rpm = gcode->get_value('S');
+            }
+        } else if (gcode->m == 5) {
+            this->last_spindle_on = false;
+        }
+
         if (gcode->m == 1) { //optiional stop
             if (THEKERNEL->get_optional_stop_mode()){
             this->suspend_command((gcode->subcode == 1)?"h":"", gcode->stream);
@@ -421,6 +448,7 @@ void Player::on_gcode_received(void *argument)
                 // clean up
             	THEKERNEL->set_suspending(false);
                 THEROBOT->pop_state();
+                this->clear_saved_spindle();
             }
         }
     }
@@ -452,9 +480,10 @@ void Player::on_console_line_received( void *argument )
     }else if (cmd == "abort") {
         this->abort_command( possible_command, new_message.stream );
     }else if (cmd == "suspend") {
-        this->suspend_command( possible_command, new_message.stream );
+        bool pause_outside_play_mode = (possible_command.find_first_of("5") != string::npos);
+        this->suspend_command(possible_command, new_message.stream, pause_outside_play_mode);
     }else if (cmd == "resume") {
-        this->resume_command( possible_command, new_message.stream );
+        this->resume_command(possible_command, new_message.stream);
     }else if (cmd == "goto") {
     	this->goto_command( possible_command, new_message.stream );
     }else if (cmd == "buffer") {
@@ -1015,7 +1044,76 @@ void Player::on_set_public_data(void *argument)
     		string quoted_filename = "\"" + this->last_filename + "\"";
         	this->play_command(quoted_filename, &(StreamOutput::NullStream));
     	}
+    } else if (pdr->second_element_is(suspend_play_checksum)) {
+        bool pause_outside_play_mode = false;
+        if (pdr->get_data_ptr() != nullptr) {
+            pause_outside_play_mode = *static_cast<bool *>(pdr->get_data_ptr());
+        }
+        this->suspend_command("", &(StreamOutput::NullStream), pause_outside_play_mode);
+        pdr->set_taken();
+    } else if (pdr->second_element_is(resume_play_checksum)) {
+        this->resume_command("", &(StreamOutput::NullStream));
+        pdr->set_taken();
     }
+}
+
+void Player::dispatch_gcode(const char *gcode_line)
+{
+    Gcode gcode(gcode_line, &(StreamOutput::NullStream));
+    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+}
+
+void Player::clear_saved_spindle()
+{
+    this->saved_spindle_on = false;
+    this->saved_spindle_rpm = 0.0f;
+    this->saved_spindle_ccw = false;
+}
+
+void Player::save_and_stop_spindle_on_suspend()
+{
+    this->clear_saved_spindle();
+
+    if (!this->spindle_suspend_restore_enable) {
+        return;
+    }
+
+    if (THEKERNEL->get_laser_mode()) {
+        return;
+    }
+
+    if (this->last_spindle_on) {
+        this->saved_spindle_on = true;
+        this->saved_spindle_rpm = this->last_spindle_rpm;
+        this->saved_spindle_ccw = this->last_spindle_ccw;
+        this->dispatch_gcode("M5");
+    }
+}
+
+void Player::restore_spindle_on_resume()
+{
+    if (!this->spindle_suspend_restore_enable) {
+        this->clear_saved_spindle();
+        return;
+    }
+
+    if (!this->saved_spindle_on || THEKERNEL->get_laser_mode()) {
+        this->clear_saved_spindle();
+        return;
+    }
+
+    char buf[32];
+    if (this->saved_spindle_rpm > 0.0f) {
+        snprintf(buf, sizeof(buf), "%s S%.0f", this->saved_spindle_ccw ? "M4" : "M3", this->saved_spindle_rpm);
+    } else {
+        snprintf(buf, sizeof(buf), "%s", this->saved_spindle_ccw ? "M4" : "M3");
+    }
+    this->clear_saved_spindle();
+    this->dispatch_gcode(buf);
+
+    // Keep the tracked state consistent so a second suspend works as expected
+    this->last_spindle_on = true;
+    this->last_spindle_ccw = (strstr(buf, "M4") != nullptr);
 }
 
 /**
@@ -1070,6 +1168,8 @@ void Player::suspend_command(string parameters, StreamOutput *stream, bool pause
     THEROBOT->push_state();
     current_motion_mode = THEROBOT->get_current_motion_mode();
 
+    this->save_and_stop_spindle_on_suspend();
+
     // execute optional gcode if defined
     if(!after_suspend_gcode.empty()) {
         struct SerialMessage message;
@@ -1101,6 +1201,7 @@ void Player::resume_command(string parameters, StreamOutput *stream )
     if(THEKERNEL->is_halted()) {
         THEKERNEL->streams->printf("Resume aborted by kill\n");
         THEROBOT->pop_state();
+        this->clear_saved_spindle();
         THEKERNEL->set_suspending(false);
         return;
     }
@@ -1114,6 +1215,8 @@ void Player::resume_command(string parameters, StreamOutput *stream )
         message.line = 0;
         THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
     }
+
+    this->restore_spindle_on_resume();
 
     if (this->goto_line == 0) {
         // Restore position
@@ -1141,6 +1244,7 @@ void Player::resume_command(string parameters, StreamOutput *stream )
 
     if(THEKERNEL->is_halted()) {
         THEKERNEL->streams->printf("Resume aborted by kill\n");
+        this->clear_saved_spindle();
         THEKERNEL->set_suspending(false);
         return;
     }

--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -44,6 +44,10 @@ class Player : public Module {
         void abort_command( string parameters, StreamOutput* stream );
         void suspend_command( string parameters, StreamOutput* stream , bool pause_outside_play_mode = false);
         void resume_command( string parameters, StreamOutput* stream );
+        void save_and_stop_spindle_on_suspend();
+        void restore_spindle_on_resume();
+        void clear_saved_spindle();
+        void dispatch_gcode(const char *gcode_line);
         void goto_command( string parameters, StreamOutput* stream );
         void buffer_command( string parameters, StreamOutput* stream );
         void upload_command( string parameters, StreamOutput* stream );
@@ -98,7 +102,13 @@ class Player : public Module {
         unsigned long last_elapsed_secs;
         uint8_t current_motion_mode;
         float saved_position[3]; // only saves XYZ
+        float saved_spindle_rpm;
+        bool saved_spindle_ccw;
+        float last_spindle_rpm;
         float slope;
+        bool saved_spindle_on;
+        bool last_spindle_on;
+        bool last_spindle_ccw;
         std::map<uint16_t, float> saved_temperatures;
         struct {
             bool on_boot_gcode_enable:1;
@@ -109,5 +119,6 @@ class Player : public Module {
             bool override_leave_heaters_on:1;
             bool inner_playing:1;
             bool laser_clustering:1;
+            bool spindle_suspend_restore_enable:1;
         };
 };

--- a/src/modules/utils/player/PlayerPublicAccess.h
+++ b/src/modules/utils/player/PlayerPublicAccess.h
@@ -8,6 +8,8 @@
 #define get_progress_checksum     CHECKSUM("progress")
 #define inner_playing_checksum    CHECKSUM("inner_playing")
 #define restart_job_checksum    CHECKSUM("restart_job")
+#define suspend_play_checksum   CHECKSUM("suspend_play")
+#define resume_play_checksum    CHECKSUM("resume_play")
 
 struct pad_progress {
     unsigned int percent_complete;

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,5 @@
 [unreleased]
+- Enhancement: Suspend/resume saves spindle state, stops the spindle on pause, and restores speed only if it was running. This functionality is enabled by default, but can be disabled via config key spindle_suspend_restore_enable.
 - Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 
 - Enhancement: Added `debugmode slowticker` to output SlowTicker ISR duration stats once per second to console
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console


### PR DESCRIPTION
Suspend/resume saves spindle state, stops the spindle on pause, and restores speed only if it was running. 

This functionality is enabled by default, but can be disabled via config key `spindle_suspend_restore_enable`.

This works the same with all three combinations of `M600` / `suspend` / front button action.