### PR TITLE
Prevent current line reporting from going backward after a tool change

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -209,6 +209,9 @@ void Player::goto_line_number(unsigned long line_number)
         played_lines += 1;
         played_cnt += len;
     }
+
+    // Keep status report current line in sync with file position
+    this->playing_lines = this->played_lines;
 }
 
 void Player::end_of_file()
@@ -951,7 +954,8 @@ void Player::on_get_public_data(void *argument)
                 const Block *block = StepTicker::getInstance()->get_current_block();
                 // Note to avoid a race condition where the block is being cleared we check the is_ready flag which gets cleared first,
                 // as this is an interrupt if that flag is not clear then it cannot be cleared while this is running and the block will still be valid (albeit it may have finished)
-                if (block != nullptr && block->is_ready && block->is_g123) {
+                // Only advance played lines, never go backward
+                if (block != nullptr && block->is_ready && block->is_g123 && block->line > this->playing_lines) {
                 	this->playing_lines = block->line;
                 }
                 p.played_lines = this->playing_lines;
@@ -1006,6 +1010,10 @@ void Player::on_set_public_data(void *argument)
         pdr->set_taken();
     } else if (pdr->second_element_is(inner_playing_checksum)) {
     	bool b = *static_cast<bool *>(pdr->get_data_ptr());
+        // Resync when entering or leaving ATC so status report current line does not jump
+        if (b != this->inner_playing && this->playing_file) {
+            this->playing_lines = this->played_lines;
+        }
     	this->inner_playing = b;
     	if (this->playing_file) pdr->set_taken();
     } else if (pdr->second_element_is(restart_job_checksum)) {

--- a/version.txt
+++ b/version.txt
@@ -2,6 +2,7 @@
 - Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 
 - Enhancement: Added `debugmode slowticker` to output SlowTicker ISR duration stats once per second to console
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
+- Fixed: Prevent incorrect current line reporting after a tool change
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
This PR fixes a bug where the current line in status report jumped backward after a tool change.

The issue was caused by the firmware entering an "inner_playing" state when the tool change is initiated (to handle the ATC moves), which switches to another counter with the correct line number, but then reverts to the old line (lagging a bit behind) when the tool change is complete.

The fix resyncs `playing_lines` to `played_lines` when entering/leaving inner_playing and adds a check to make sure we never go backward.

I also added a missing sync when `goto_line_number` is used (for instance on `M97`)

Before (the video starts just before the end of the tool change procedure):
<img width="720" height="387" alt="line_issue_before" src="https://github.com/user-attachments/assets/e6889302-ccdf-4f49-8598-b615117103c8" />

After:
<img width="720" height="387" alt="line_issue_after" src="https://github.com/user-attachments/assets/ca2adce4-3c6b-4efd-84fd-295926ce3bad" />