### PR TITLE
Add VESC USB spindle driver

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -157,6 +157,14 @@ CPPSRCS3 := $(filter-out \
 DEFINES += -DNO_MODBUS_SPINDLE
 endif
 
+# NO_VESC_SPINDLE: exclude VESC USB spindle driver
+ifdef NO_VESC_SPINDLE
+CPPSRCS3 := $(filter-out \
+  $(SRC)/modules/tools/spindle/VESCSpindleControl.cpp \
+  ,$(CPPSRCS3))
+DEFINES += -DNO_VESC_SPINDLE
+endif
+
 # NO_PID_AUTOTUNE: exclude PID autotuner (not needed when no heaters are connected)
 ifdef NO_PID_AUTOTUNE
 CPPSRCS3 := $(filter-out \

--- a/mbed/src/vendor/NXP/cmsis/LPC1768/GCC_ARM/LPC1768.ld
+++ b/mbed/src/vendor/NXP/cmsis/LPC1768/GCC_ARM/LPC1768.ld
@@ -165,13 +165,6 @@ SECTIONS
 
         . = ALIGN(4);
 
-        PROVIDE(__ohci_registers_t_start = Image$$RW_IRAM1$$Base);
-
-        /* Reserve 0x200 bytes for USB OHCI controller registers */
-        . = . + 0x200;
-
-        PROVIDE(__ohci_registers_t_end = .);
-
         *(AHBSRAM)
         Image$$RW_IRAM1$$ZI$$Limit = .;
         PROVIDE(__AHB_dyn_start = .);

--- a/src/libs/USBDevice/MSCFileSystem.cpp
+++ b/src/libs/USBDevice/MSCFileSystem.cpp
@@ -80,7 +80,7 @@ int MSCFileSystem::initialise_msc()
     //print_clock();
     Host_Init();               /* Initialize the  host controller                                    */
 
-    rc = Host_EnumDev();       /* Enumerate the device connected                                            */
+    rc = MS_Enumerate();       /* Enumerate the device connected                                            */
     if (rc != OK)
     {
         // fprintf(stderr, "Could not enumerate device: %d\n", rc) ;
@@ -116,7 +116,7 @@ int MSCFileSystem::disk_initialize()
 
 int MSCFileSystem::disk_write(const char *buffer, uint32_t block_number, uint32_t count)
 {
-    if ( OK == MS_BulkSend(block_number, 1, (USB_INT08U *)buffer) )
+    if ( OK == MS_BulkSend(block_number, 1, reinterpret_cast<const volatile USB_INT08U *>(buffer)) )
         return 0;
     return 1;
 }

--- a/src/libs/USBDevice/USBHostCDC.cpp
+++ b/src/libs/USBDevice/USBHostCDC.cpp
@@ -1,0 +1,331 @@
+/*
+ * USB Host CDC-ACM driver.
+ * See USBHostCDC.h for API documentation.
+ */
+
+#include "USBHostCDC.h"
+
+#include "StreamOutputPool.h"
+#include "libs/Kernel.h"
+#include "libs/StreamOutput.h"
+#include "us_ticker_api.h"
+#include "usbhost_err.h"
+#include "usbhost_lpc17xx.h"
+
+// USBHostLite keeps the host controller state in file-scope globals. CDC
+// transfers must use the same descriptors that enumeration configured.
+extern volatile USB_INT32U HOST_WdhIntr;
+extern volatile USB_INT08U HOST_TDControlStatus;
+extern volatile int gUSBConnected;
+extern volatile HCED *EDCtrl;
+
+namespace {
+constexpr uint32_t CDC_PORT_RESET_TIMEOUT_MS = 500;
+constexpr uint16_t CDC_CONFIGURATION_DESCRIPTOR_MAX = 128;
+constexpr uint32_t CDC_BULK_TRANSFER_MAX = 128;
+constexpr uint32_t CDC_ABORT_SETTLE_MS = 2;
+constexpr uint32_t CDC_BAUD_RATE = 115200;
+constexpr uint8_t CDC_STOP_BITS_1 = 0;
+constexpr uint8_t CDC_PARITY_NONE = 0;
+constexpr uint8_t CDC_DATA_BITS_8 = 8;
+constexpr uint16_t CDC_CONTROL_LINE_DTR_RTS = 0x0003;
+constexpr uint8_t CDC_REQUEST_TYPE_HOST_TO_INTERFACE =
+    USB_HOST_TO_DEVICE | USB_REQUEST_TYPE_CLASS | USB_RECIPIENT_INTERFACE;
+
+}  // namespace
+
+USBHostCDC::USBHostCDC()
+    : _connected(false),
+      _state(CDC_XFER_IDLE),
+      _cdc_iface(0),
+      _data_iface(0),
+      _xfer_start(0),
+      _xfer_max_len(0),
+      _rx_actual(0) {}
+
+bool USBHostCDC::init(const uint32_t timeout_ms) {
+  Host_Init();
+
+  USB_INT32S rc = Host_WaitForDevice(timeout_ms);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: timeout waiting for device (%lu ms)\n",
+                               static_cast<unsigned long>(timeout_ms));
+    return false;
+  }
+
+  HostPortResetStatus port_reset = {};
+  rc = Host_ResetRootPort(CDC_PORT_RESET_TIMEOUT_MS, &port_reset);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: port reset timeout port=%08lx int=%08lx waited=%lu\n",
+                               static_cast<unsigned long>(port_reset.port_status),
+                               static_cast<unsigned long>(port_reset.interrupt_status),
+                               static_cast<unsigned long>(port_reset.waited_ms));
+    return false;
+  }
+
+  rc = Host_ReadDeviceDescriptor();
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: GET_DESCRIPTOR(device,8) failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+
+  rc = Host_SetDeviceAddress(USB_DEVICE_ADDRESS);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: SET_ADDRESS failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+
+  // TDBuffer is shared with the low-level host stack and is only 176 bytes.
+  // Fetch enough configuration data for a normal CDC descriptor tree without
+  // trusting a device-reported length that might not fit.
+  uint16_t cfg_len = 0;
+  rc = Host_ReadConfigurationDescriptor(CDC_CONFIGURATION_DESCRIPTOR_MAX, &cfg_len);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: GET_DESCRIPTOR(config) failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+  rc = parse_cdc_configuration(cfg_len);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: parse_cdc_configuration failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+
+  rc = USBH_SET_CONFIGURATION(USB_CONFIGURATION_VALUE);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: SET_CONFIGURATION failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+  Host_DelayMS(USB_SET_CONFIGURATION_SETTLE_MS);
+
+  rc = set_line_coding();
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: SET_LINE_CODING failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+  rc = set_control_line_state(CDC_CONTROL_LINE_DTR_RTS);
+  if (rc != OK) {
+    THEKERNEL->streams->printf("USB CDC: SET_CONTROL_LINE_STATE failed rc=%d\n", static_cast<int>(rc));
+    return false;
+  }
+
+  _connected = true;
+  return true;
+}
+
+USB_INT32S USBHostCDC::parse_cdc_configuration(const uint16_t fetched_len) {
+  volatile USB_INT08U *desc = TDBuffer;
+  const volatile USB_INT08U *end = TDBuffer + fetched_len;
+  bool data_iface_found = false;
+  bool bulk_in_found = false, bulk_out_found = false;
+
+  if (DESC_TYPE(desc) != USB_DESCRIPTOR_TYPE_CONFIGURATION) return ERR_BAD_CONFIGURATION;
+  desc += DESC_LENGTH(desc);
+
+  while (desc < end) {
+    const uint8_t len = DESC_LENGTH(desc);
+    const uint8_t type = DESC_TYPE(desc);
+
+    if (len == 0) break;
+    if (desc + len > end) break;
+
+    switch (type) {
+      case USB_DESCRIPTOR_TYPE_INTERFACE:
+        // Endpoint descriptors do not repeat their interface number, so keep
+        // accepting endpoints only while walking the CDC data interface.
+        if (desc[USB_INTERFACE_CLASS_OFFSET] == CDC_DATA_INTERFACE_CLASS) {
+          data_iface_found = true;
+          _data_iface = desc[USB_INTERFACE_NUMBER_OFFSET];
+        } else {
+          data_iface_found = false;
+          if (desc[USB_INTERFACE_CLASS_OFFSET] == CDC_COMMUNICATION_INTERFACE_CLASS) {
+            _cdc_iface = desc[USB_INTERFACE_NUMBER_OFFSET];
+          }
+        }
+        break;
+
+      case USB_DESCRIPTOR_TYPE_ENDPOINT:
+        if (data_iface_found &&
+            (desc[USB_ENDPOINT_ATTRIBUTES_OFFSET] & USB_ENDPOINT_TRANSFER_TYPE_MASK) == USB_ENDPOINT_TRANSFER_TYPE_BULK) {
+          const uint8_t endpoint_address = desc[USB_ENDPOINT_ADDRESS_OFFSET];
+          const uint16_t max_pkt = ReadLE16U(&desc[USB_ENDPOINT_MAX_PACKET_SIZE_OFFSET]);
+          if (endpoint_address & USB_ENDPOINT_DIRECTION_IN) {
+            EDBulkIn->Control =
+                OHCI_ED_BULK_ENDPOINT_CONTROL(USB_DEVICE_ADDRESS, endpoint_address, OHCI_ED_DIR_IN, max_pkt);
+            bulk_in_found = true;
+          } else {
+            EDBulkOut->Control =
+                OHCI_ED_BULK_ENDPOINT_CONTROL(USB_DEVICE_ADDRESS, endpoint_address, OHCI_ED_DIR_OUT, max_pkt);
+            bulk_out_found = true;
+          }
+        }
+        break;
+      default:;
+    }
+    desc += len;
+  }
+
+  if (bulk_in_found && bulk_out_found) return OK;
+  return ERR_NO_MS_INTERFACE;
+}
+
+USB_INT32S USBHostCDC::set_line_coding() const {
+  uint8_t lc[7];
+  lc[0] = static_cast<uint8_t>(CDC_BAUD_RATE);
+  lc[1] = static_cast<uint8_t>(CDC_BAUD_RATE >> 8);
+  lc[2] = static_cast<uint8_t>(CDC_BAUD_RATE >> 16);
+  lc[3] = static_cast<uint8_t>(CDC_BAUD_RATE >> 24);
+  lc[4] = CDC_STOP_BITS_1;
+  lc[5] = CDC_PARITY_NONE;
+  lc[6] = CDC_DATA_BITS_8;
+  return Host_CtrlSend(CDC_REQUEST_TYPE_HOST_TO_INTERFACE, CDC_SET_LINE_CODING, 0, _cdc_iface, sizeof(lc), lc);
+}
+
+USB_INT32S USBHostCDC::set_control_line_state(const uint16_t state) const {
+  // Many CDC devices wait for the usual terminal control lines before they
+  // accept traffic.
+  return Host_CtrlSend(CDC_REQUEST_TYPE_HOST_TO_INTERFACE, CDC_SET_CONTROL_LINE_STATE, state, _cdc_iface, 0, nullptr);
+}
+
+void USBHostCDC::submit_bulk_td(volatile HCED *ed, const uint32_t token, const volatile uint8_t *buffer,
+                                const uint32_t len) {
+  if (len == 0) return;
+
+  NVIC_DisableIRQ(USB_IRQn);
+  HOST_WdhIntr = 0;
+  HOST_TDControlStatus = 0;
+  NVIC_EnableIRQ(USB_IRQn);
+
+  TDHead->Control = (TD_ROUNDING | token | TD_DELAY_INT(0) | TD_CC);
+  TDTail->Control = 0;
+  TDHead->CurrBufPtr = reinterpret_cast<USB_INT32U>(buffer);
+  TDTail->CurrBufPtr = 0;
+  TDHead->Next = reinterpret_cast<USB_INT32U>(TDTail);
+  TDTail->Next = 0;
+  TDHead->BufEnd = reinterpret_cast<USB_INT32U>(buffer + (len - 1));
+  TDTail->BufEnd = 0;
+
+  ed->HeadTd = reinterpret_cast<USB_INT32U>(TDHead) | ((ed->HeadTd) & OHCI_ED_HEAD_TOGGLE_CARRY);
+  ed->TailTd = reinterpret_cast<USB_INT32U>(TDTail);
+  ed->Next = 0;
+
+  LPC_USB->HcBulkHeadED = reinterpret_cast<USB_INT32U>(ed);
+  LPC_USB->HcCommandStatus = LPC_USB->HcCommandStatus | OR_CMD_STATUS_BLF;
+  LPC_USB->HcControl = LPC_USB->HcControl | OR_CONTROL_BLE;
+}
+
+// Clearing BLE does not instantly stop the host controller. Mark both
+// endpoints as skipped, let one full-speed frame pass so DMA is quiet, then
+// rebuild the descriptor queues with interrupts masked while touching
+// ISR-shared state.
+void USBHostCDC::abort_transfer() {
+  NVIC_DisableIRQ(USB_IRQn);
+
+  EDBulkIn->Control |= OHCI_ED_SKIP;
+  EDBulkOut->Control |= OHCI_ED_SKIP;
+  LPC_USB->HcControl &= ~OR_CONTROL_BLE;
+
+  NVIC_EnableIRQ(USB_IRQn);
+
+  Host_DelayMS(CDC_ABORT_SETTLE_MS);
+
+  NVIC_DisableIRQ(USB_IRQn);
+
+  const USB_INT32U in_toggle = EDBulkIn->HeadTd & OHCI_ED_HEAD_TOGGLE_CARRY;
+  const USB_INT32U out_toggle = EDBulkOut->HeadTd & OHCI_ED_HEAD_TOGGLE_CARRY;
+
+  Host_TDInit(TDHead);
+  Host_TDInit(TDTail);
+
+  // Empty OHCI queues are represented by HeadTd and TailTd pointing at the
+  // same transfer descriptor.
+  EDBulkIn->HeadTd = reinterpret_cast<USB_INT32U>(TDTail) | in_toggle;
+  EDBulkIn->TailTd = reinterpret_cast<USB_INT32U>(TDTail);
+  EDBulkOut->HeadTd = reinterpret_cast<USB_INT32U>(TDTail) | out_toggle;
+  EDBulkOut->TailTd = reinterpret_cast<USB_INT32U>(TDTail);
+
+  HOST_WdhIntr = 0;
+  HOST_TDControlStatus = 0;
+
+  NVIC_EnableIRQ(USB_IRQn);
+
+  EDBulkIn->Control &= ~OHCI_ED_SKIP;
+  EDBulkOut->Control &= ~OHCI_ED_SKIP;
+}
+
+bool USBHostCDC::start_send(const uint8_t *data, uint32_t len) {
+  if (_state != CDC_XFER_IDLE || !_connected) return false;
+  if (len == 0) return false;
+  if (len > CDC_BULK_TRANSFER_MAX) len = CDC_BULK_TRANSFER_MAX;
+  // The OHCI engine can DMA from AHB SRAM only, so copy caller data out of
+  // normal RAM before submitting the transfer.
+  for (uint32_t i = 0; i < len; i++) TDBuffer[i] = data[i];
+
+  _state = CDC_XFER_SENDING;
+  _xfer_start = us_ticker_read();
+
+  submit_bulk_td(EDBulkOut, TD_OUT, TDBuffer, len);
+  return true;
+}
+
+bool USBHostCDC::start_recv(uint32_t max_len) {
+  if (_state != CDC_XFER_IDLE || !_connected) return false;
+  if (max_len == 0) return false;
+  if (max_len > CDC_BULK_TRANSFER_MAX) max_len = CDC_BULK_TRANSFER_MAX;
+
+  _state = CDC_XFER_RECEIVING;
+  _xfer_max_len = max_len;
+  _rx_actual = 0;
+  _xfer_start = us_ticker_read();
+
+  submit_bulk_td(EDBulkIn, TD_IN, TDBuffer, max_len);
+  return true;
+}
+
+// A disconnect while idle is only noticed when the next transfer is submitted
+// and times out. Callers that care about quick detection should keep a small
+// amount of periodic traffic flowing.
+CDCXferState USBHostCDC::poll() {
+  if (_state == CDC_XFER_SENDING || _state == CDC_XFER_RECEIVING) {
+    if (!gUSBConnected) {
+      abort_transfer();
+      _connected = false;
+      _state = CDC_XFER_ERROR;
+      return _state;
+    }
+
+    // Take a short, consistent snapshot of the completion flags that the USB
+    // interrupt handler updates.
+    NVIC_DisableIRQ(USB_IRQn);
+    const USB_INT32U wdh = HOST_WdhIntr;
+    const USB_INT08U td_sts = HOST_TDControlStatus;
+    if (wdh) HOST_WdhIntr = 0;
+    NVIC_EnableIRQ(USB_IRQn);
+
+    if (wdh) {
+      if (td_sts == 0) {
+        if (_state == CDC_XFER_RECEIVING) {
+          // OHCI leaves CurrBufPtr just past the last byte written, except
+          // that a completely full buffer is reported as zero.
+          if (TDHead->CurrBufPtr == 0) {
+            _rx_actual = _xfer_max_len;
+          } else {
+            const uint32_t raw = TDHead->CurrBufPtr - reinterpret_cast<USB_INT32U>(TDBuffer);
+            _rx_actual = (raw <= _xfer_max_len) ? raw : _xfer_max_len;
+          }
+        }
+        _state = CDC_XFER_COMPLETE;
+      } else {
+        _state = CDC_XFER_ERROR;
+      }
+    }
+
+    if (_state == CDC_XFER_SENDING || _state == CDC_XFER_RECEIVING) {
+      const uint32_t elapsed = (us_ticker_read() - _xfer_start) / 1000;
+      if (elapsed >= CDC_XFER_TIMEOUT_MS) {
+        abort_transfer();
+        _state = CDC_XFER_ERROR;
+      }
+    }
+  }
+  return _state;
+}

--- a/src/libs/USBDevice/USBHostCDC.h
+++ b/src/libs/USBDevice/USBHostCDC.h
@@ -1,0 +1,93 @@
+/*
+ * USB Host CDC-ACM driver.
+ *
+ * USBHostLite setup functions wait inside Host_ProcessTD, which is acceptable
+ * during enumeration but not while the machine is running. This class uses
+ * them for setup, then submits bulk transfers and lets callers poll for
+ * completion without blocking the main loop.
+ */
+
+#ifndef USBHOST_CDC_H
+#define USBHOST_CDC_H
+
+#include <cstdint>
+
+#include "usbhost_inc.h"
+
+constexpr uint8_t CDC_COMMUNICATION_INTERFACE_CLASS = 0x02;
+constexpr uint8_t CDC_DATA_INTERFACE_CLASS = 0x0A;
+
+constexpr uint8_t CDC_SET_LINE_CODING = 0x20;
+constexpr uint8_t CDC_SET_CONTROL_LINE_STATE = 0x22;
+
+constexpr uint32_t CDC_XFER_TIMEOUT_MS = 500;
+
+enum CDCXferState { CDC_XFER_IDLE = 0, CDC_XFER_SENDING, CDC_XFER_RECEIVING, CDC_XFER_COMPLETE, CDC_XFER_ERROR };
+
+class USBHostCDC {
+ public:
+  USBHostCDC();
+
+  /** Blocking setup path: initialise the host, enumerate the device, and
+   *  configure the CDC interface. The board-specific VBUS-enable pin must
+   *  already be asserted.
+   *  @param timeout_ms  max time to wait for device connection (0 = forever)
+   *  @return true on success */
+  bool init(uint32_t timeout_ms = 3000);
+
+  /** @return true if a CDC device was enumerated successfully */
+  bool connected() const { return _connected; }
+
+  /** Submit an asynchronous bulk-OUT transfer. Fails if a transfer is
+   *  already in flight or the device is not connected.
+   *  @return true if the transfer was submitted */
+  bool start_send(const uint8_t *data, uint32_t len);
+
+  /** Submit an asynchronous bulk-IN transfer.
+   *  @param max_len  maximum bytes to receive (capped to 128)
+   *  @return true if the transfer was submitted */
+  bool start_recv(uint32_t max_len);
+
+  /** Drive the transfer state machine; call every on_idle().
+   *  @return current transfer state */
+  CDCXferState poll();
+
+  /** Pointer to the receive buffer. After poll() returns CDC_XFER_COMPLETE
+   *  for a recv, copy the data out before starting the next transfer. */
+  volatile uint8_t *rx_buf() { return TDBuffer; }
+
+  /** Bytes received in the last completed IN transfer. */
+  uint32_t rx_len() const { return _rx_actual; }
+
+  /** Cancel the current transfer and make the bulk endpoints usable again. */
+  void abort() const {
+    if (_state == CDC_XFER_SENDING || _state == CDC_XFER_RECEIVING) abort_transfer();
+  }
+
+  /** Reset the state machine to IDLE; call after consuming a response. */
+  void finish() { _state = CDC_XFER_IDLE; }
+
+  CDCXferState state() const { return _state; }
+
+ private:
+  // Only the bytes actually fetched are safe to parse; some devices report a
+  // larger wTotalLength than this firmware's shared USB buffer can hold.
+  USB_INT32S parse_cdc_configuration(uint16_t fetched_len);
+
+  USB_INT32S set_line_coding() const;
+  USB_INT32S set_control_line_state(uint16_t state) const;
+
+  static void submit_bulk_td(volatile HCED *ed, uint32_t token, const volatile uint8_t *buffer, uint32_t len);
+  static void abort_transfer();
+
+  bool _connected;
+  CDCXferState _state;
+  uint8_t _cdc_iface;
+  uint8_t _data_iface;
+
+  uint32_t _xfer_start;
+  uint32_t _xfer_max_len;
+  uint32_t _rx_actual;
+};
+
+#endif  // USBHOST_CDC_H

--- a/src/libs/USBDevice/USBHostLite/usbhost_lpc17xx.cpp
+++ b/src/libs/USBDevice/USBHostLite/usbhost_lpc17xx.cpp
@@ -24,12 +24,15 @@
 
 #include  "usbhost_lpc17xx.h"
 
+#include "libs/compiler.h"
+#include "wait_api.h"
+
 /*
 **************************************************************************************************************
 *                                              GLOBAL VARIABLES
 **************************************************************************************************************
 */
-int gUSBConnected;
+volatile int gUSBConnected;
 
 volatile  USB_INT32U   HOST_RhscIntr = 0;         /* Root Hub Status Change interrupt                       */
 volatile  USB_INT32U   HOST_WdhIntr  = 0;         /* Semaphore to wait until the TD is submitted            */
@@ -40,14 +43,25 @@ volatile  HCED        *EDBulkOut;                 /* BulkOut endpoint descriptor
 volatile  HCTD        *TDHead;                    /* Head transfer descriptor structure                     */
 volatile  HCTD        *TDTail;                    /* Tail transfer descriptor structure                     */
 volatile  HCCA        *Hcca;                      /* Host Controller Communications Area structure          */ 
-          USB_INT16U  *TDBufNonVol;               /* Identical to TDBuffer just to reduce compiler warnings */
 volatile  USB_INT08U  *TDBuffer;                  /* Current Buffer Pointer of transfer descriptor          */
 
-// USB host structures
-// AHB SRAM block 1
-#define HOSTBASEADDR 0x2007C000
-// reserve memory for the linker
-static USB_INT08U HostBuf[0x200] __attribute__((at(HOSTBASEADDR)));
+// The USB host controller can only DMA from AHB SRAM.
+struct USBHostMemory {
+    HCCA hcca;
+    HCTD td_head;
+    HCTD td_tail;
+    HCED ed_ctrl;
+    HCED ed_bulk_in;
+    HCED ed_bulk_out;
+    USB_INT08U td_buffer[0xB0];
+};
+
+static USBHostMemory HostMem LOCATED_IN_AHBSRAM ALIGNED_TO(256);
+static_assert(sizeof(USBHostMemory) == 0x200, "USB host memory layout must stay within the OHCI AHB block");
+
+static constexpr USB_INT32U HOST_TD_TIMEOUT_MS = 500;
+static constexpr USB_INT32U HOST_PORT_RESET_SETTLE_MS = 100;
+static constexpr USB_INT32U HOST_PORT_RESET_START_MS = 50;
 /*
 **************************************************************************************************************
 *                                         DELAY IN MILLI SECONDS
@@ -86,12 +100,7 @@ void  Host_DelayMS (USB_INT32U  delay)
 
 void  Host_DelayUS (USB_INT32U  delay)
 {
-    volatile  USB_INT32U  i;
-
-
-    for (i = 0; i < (4 * delay); i++) {    /* This logic was tested. It gives app. 1 micro sec delay        */
-        ;
-    }
+    wait_us((int)delay);
 }
 
 // bits of the USB/OTG clock control register
@@ -123,8 +132,12 @@ void  Host_DelayUS (USB_INT32U  delay)
 */
 void  Host_Init (void)
 {
-    PRINT_Log("In Host_Init\n");
+    PRINT_Log("USBHostLite: Host_Init\n");
     NVIC_DisableIRQ(USB_IRQn);                           /* Disable the USB interrupt source           */
+    HOST_RhscIntr = 0;
+    HOST_WdhIntr = 0;
+    HOST_TDControlStatus = 0;
+    gUSBConnected = 0;
     
     // turn on power for USB
     LPC_SC->PCONP       |= (1UL<<31);
@@ -161,15 +174,15 @@ void  Host_Init (void)
     LPC_PINCON->PINSEL1 &= ~((3<<26) | (3<<28));  
     LPC_PINCON->PINSEL1 |=  ((1<<26)|(1<<28));     // 0x14000000
         
-    PRINT_Log("Initializing Host Stack\n");
+    PRINT_Log("USBHostLite: initializing host stack\n");
 
-    Hcca       = (volatile  HCCA       *)(HostBuf+0x000);
-    TDHead     = (volatile  HCTD       *)(HostBuf+0x100);
-    TDTail     = (volatile  HCTD       *)(HostBuf+0x110);
-    EDCtrl     = (volatile  HCED       *)(HostBuf+0x120); 
-    EDBulkIn   = (volatile  HCED       *)(HostBuf+0x130);
-    EDBulkOut  = (volatile  HCED       *)(HostBuf+0x140);
-    TDBuffer   = (volatile  USB_INT08U *)(HostBuf+0x150);
+    Hcca       = &HostMem.hcca;
+    TDHead     = &HostMem.td_head;
+    TDTail     = &HostMem.td_tail;
+    EDCtrl     = &HostMem.ed_ctrl;
+    EDBulkIn   = &HostMem.ed_bulk_in;
+    EDBulkOut  = &HostMem.ed_bulk_out;
+    TDBuffer   = HostMem.td_buffer;
     
     /* Initialize all the TDs, EDs and HCCA to 0  */
     Host_EDInit(EDCtrl);
@@ -200,10 +213,23 @@ void  Host_Init (void)
                          OR_INTR_ENABLE_WDH |
                          OR_INTR_ENABLE_RHSC;
 
-    NVIC_SetPriority(USB_IRQn, 0);       /* highest priority */
+    // Start each host session from the current line state, not from root-port
+    // change bits left over from power-up or a previous firmware image. The
+    // ISR normally clears these before enumeration; the synthetic connected
+    // path below must do the same.
+    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_CSC | OR_RH_PORT_PRSC;
+
+    // A device can already be attached when Host_Init runs, especially after a
+    // firmware reset that did not remove VBUS. Treat live connect status as a
+    // connection event so class drivers can enumerate without unplug/replug.
+    if ((LPC_USB->HcRhPortStatus1 & OR_RH_PORT_CCS) && !HOST_RhscIntr) {
+        HOST_RhscIntr = 1;
+        gUSBConnected = 1;
+    }
+
     /* Enable the USB Interrupt */
     NVIC_EnableIRQ(USB_IRQn);
-    PRINT_Log("Host Initialized\n");
+    PRINT_Log("USBHostLite: host initialized\n");
 }
 
 /*
@@ -254,7 +280,7 @@ extern "C" void USB_IRQHandler (void)
                             gUSBConnected = 1;
                         }
                         else
-                            PRINT_Log("Spurious status change (connected)?\n");
+                            PRINT_Log("USBHostLite: spurious status change (connected)?\n");
                     } else {
                         if (gUSBConnected) {
                             LPC_USB->HcInterruptEnable = 0; // why do we get multiple disc. rupts???
@@ -262,7 +288,7 @@ extern "C" void USB_IRQHandler (void)
                             gUSBConnected = 0;
                         }
                         else
-                            PRINT_Log("Spurious status change (disconnected)?\n");
+                            PRINT_Log("USBHostLite: spurious status change (disconnected)?\n");
                     }
                 }
                 LPC_USB->HcRhPortStatus1 = OR_RH_PORT_CSC;
@@ -273,7 +299,7 @@ extern "C" void USB_IRQHandler (void)
         }
         if (int_status & OR_INTR_STATUS_WDH) {                  /* Writeback Done Head interrupt        */
             HOST_WdhIntr = 1;
-            HOST_TDControlStatus = (TDHead->Control >> 28) & 0xf;
+            HOST_TDControlStatus = (TDHead->Control >> TD_CC_SHIFT) & TD_CC_MASK;
         }            
         LPC_USB->HcInterruptStatus = int_status;                         /* Clear interrupt status register      */
     }
@@ -299,7 +325,7 @@ extern "C" void USB_IRQHandler (void)
 
 USB_INT32S  Host_ProcessTD (volatile  HCED       *ed,
                             volatile  USB_INT32U  token,
-                            volatile  USB_INT08U *buffer,
+                      const volatile  USB_INT08U *buffer,
                                       USB_INT32U  buffer_len)
 {
     volatile  USB_INT32U   td_toggle;
@@ -314,6 +340,11 @@ USB_INT32S  Host_ProcessTD (volatile  HCED       *ed,
     } else {
         td_toggle = 0;
     }
+
+    HOST_WdhIntr = 0;
+    HOST_TDControlStatus = 0;
+    LPC_USB->HcInterruptStatus = OR_INTR_STATUS_WDH;
+
     TDHead->Control = (TD_ROUNDING    |
                       token           |
                       TD_DELAY_INT(0) |                           
@@ -327,7 +358,7 @@ USB_INT32S  Host_ProcessTD (volatile  HCED       *ed,
     TDHead->BufEnd       = (USB_INT32U)(buffer + (buffer_len - 1));
     TDTail->BufEnd       = 0;
 
-    ed->HeadTd  = (USB_INT32U)TDHead | ((ed->HeadTd) & 0x00000002);
+    ed->HeadTd  = (USB_INT32U)TDHead | ((ed->HeadTd) & OHCI_ED_HEAD_TOGGLE_CARRY);
     ed->TailTd  = (USB_INT32U)TDTail;
     ed->Next    = 0;
 
@@ -339,88 +370,125 @@ USB_INT32S  Host_ProcessTD (volatile  HCED       *ed,
         LPC_USB->HcBulkHeadED    = (USB_INT32U)ed;
         LPC_USB->HcCommandStatus = LPC_USB->HcCommandStatus | OR_CMD_STATUS_BLF;
         LPC_USB->HcControl       = LPC_USB->HcControl       | OR_CONTROL_BLE;
-    }    
+    }
 
-    // Host_WDHWait();
-    Host_DelayMS(100);
+    USB_INT32U waited = 0;
+    while (!HOST_WdhIntr && waited < HOST_TD_TIMEOUT_MS) {
+        Host_DelayMS(1);
+        waited++;
+    }
+
+    if (!HOST_WdhIntr) {
+        return (ERR_TD_FAIL);
+    }
+
+    HOST_WdhIntr = 0;
 
 //    if (!(TDHead->Control & 0xF0000000)) {
     if (!HOST_TDControlStatus) {
         return (OK);
-    } else {      
+    } else {
         return (ERR_TD_FAIL);
     }
 }
 
-/*
-**************************************************************************************************************
-*                                       ENUMERATE THE DEVICE
-*
-* Description: This function is used to enumerate the device connected
-*
-* Arguments  : None
-*
-* Returns    : None
-*
-**************************************************************************************************************
-*/
-
-USB_INT32S  Host_EnumDev (void)
+USB_INT32S Host_WaitForDevice(USB_INT32U timeout_ms)
 {
-    USB_INT32S  rc;
-
-    PRINT_Log("Connect a Mass Storage device\n");
-    while (!HOST_RhscIntr)
-        __WFI();
-
-    Host_DelayMS(100);                             /* USB 2.0 spec says atleast 50ms delay beore port reset */
-    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_PRS; // Initiate port reset
-    while (LPC_USB->HcRhPortStatus1 & OR_RH_PORT_PRS)
-        __WFI(); // Wait for port reset to complete...
-    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_PRSC; // ...and clear port reset signal
-    Host_DelayMS(200);                                                 /* Wait for 100 MS after port reset  */
-
-    EDCtrl->Control = 8 << 16;                                         /* Put max pkt size = 8              */
-                                                                       /* Read first 8 bytes of device desc */
-    rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_DEVICE, 0, TDBuffer, 8);
-    if (rc != OK) {
-        PRINT_Err(rc);
-        return (rc);
+    if (timeout_ms == 0) {
+        while (!HOST_RhscIntr)
+            __WFI();
+        return (OK);
     }
 
-    EDCtrl->Control = TDBuffer[7] << 16;                               /* Get max pkt size of endpoint 0    */
-    rc = HOST_SET_ADDRESS(1);                                          /* Set the device address to 1       */
-    if (rc != OK) {
-        PRINT_Err(rc);
-        return (rc);
+    USB_INT32U waited = 0;
+    while (!HOST_RhscIntr && waited < timeout_ms) {
+        Host_DelayMS(1);
+        waited++;
     }
 
+    return HOST_RhscIntr ? OK : ERR_TD_FAIL;
+}
+
+USB_INT32S Host_ResetRootPort(USB_INT32U timeout_ms, HostPortResetStatus *status)
+{
+    if ((LPC_USB->HcRhPortStatus1 & OR_RH_PORT_CCS) == 0) {
+        if (status) {
+            status->waited_ms = 0;
+            status->port_status = LPC_USB->HcRhPortStatus1;
+            status->interrupt_status = LPC_USB->HcInterruptStatus;
+        }
+        return (ERR_TD_FAIL);
+    }
+
+    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_CSC | OR_RH_PORT_PRSC;
+    Host_DelayMS(HOST_PORT_RESET_SETTLE_MS);
+    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_PRS;
+
+    Host_DelayMS(HOST_PORT_RESET_START_MS);
+    USB_INT32U waited = HOST_PORT_RESET_START_MS;
+    if (timeout_ms == 0) {
+        while (LPC_USB->HcRhPortStatus1 & OR_RH_PORT_PRS)
+            __WFI();
+    } else {
+        while ((LPC_USB->HcRhPortStatus1 & OR_RH_PORT_PRS) && waited < timeout_ms) {
+            Host_DelayMS(1);
+            waited++;
+        }
+    }
+
+    if (status) {
+        status->waited_ms = waited;
+        status->port_status = LPC_USB->HcRhPortStatus1;
+        status->interrupt_status = LPC_USB->HcInterruptStatus;
+    }
+
+    if (LPC_USB->HcRhPortStatus1 & OR_RH_PORT_PRS) {
+        return (ERR_TD_FAIL);
+    }
+
+    LPC_USB->HcRhPortStatus1 = OR_RH_PORT_CSC | OR_RH_PORT_PRSC;
+    Host_DelayMS(200);
+    return (OK);
+}
+
+USB_INT32S Host_ReadDeviceDescriptor(void)
+{
+    EDCtrl->Control = OHCI_ED_MAX_PACKET_SIZE(USB_ENDPOINT_ZERO_INITIAL_DESCRIPTOR_BYTES);
+    USB_INT32S rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_DEVICE, 0, TDBuffer,
+                                        USB_ENDPOINT_ZERO_INITIAL_DESCRIPTOR_BYTES);
+    if (rc == OK) {
+        EDCtrl->Control = OHCI_ED_MAX_PACKET_SIZE(TDBuffer[USB_DEVICE_MAX_PACKET_SIZE0_OFFSET]);
+    }
+    return (rc);
+}
+
+USB_INT32S Host_SetDeviceAddress(USB_INT08U address)
+{
+    USB_INT32S rc = HOST_SET_ADDRESS(address);
+    if (rc != OK) {
+        return (rc);
+    }
     Host_DelayMS(2);
-    EDCtrl->Control = (EDCtrl->Control) | 1;                          /* Modify control pipe with address 1 */
-                                                                      /* Get the configuration descriptor   */
-    rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_CONFIGURATION, 0, TDBuffer, 9);
+    EDCtrl->Control = EDCtrl->Control | address;
+    return (OK);
+}
+
+USB_INT32S Host_ReadConfigurationDescriptor(USB_INT16U max_len, USB_INT16U *fetched_len)
+{
+    USB_INT32S rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_CONFIGURATION, 0, TDBuffer,
+                                        USB_CONFIGURATION_DESCRIPTOR_HEADER_SIZE);
     if (rc != OK) {
-        PRINT_Err(rc);
-        return (rc);
-    }
-                                                                       /* Get the first configuration data  */
-    rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_CONFIGURATION, 0, TDBuffer, ReadLE16U(&TDBuffer[2]));
-    if (rc != OK) {
-        PRINT_Err(rc);
         return (rc);
     }
 
-    rc = MS_ParseConfiguration();                                      /* Parse the configuration           */
-    if (rc != OK) {
-        PRINT_Err(rc);
-        return (rc);
+    USB_INT16U cfg_len = ReadLE16U(&TDBuffer[USB_CONFIGURATION_TOTAL_LENGTH_OFFSET]);
+    if (max_len && cfg_len > max_len) {
+        cfg_len = max_len;
     }
-
-    rc = USBH_SET_CONFIGURATION(1);                                    /* Select device configuration 1     */
-    if (rc != OK) {
-        PRINT_Err(rc);
+    rc = HOST_GET_DESCRIPTOR(USB_DESCRIPTOR_TYPE_CONFIGURATION, 0, TDBuffer, cfg_len);
+    if (rc == OK && fetched_len) {
+        *fetched_len = cfg_len;
     }
-    Host_DelayMS(100);                                               /* Some devices may require this delay */
     return (rc);
 }
 
@@ -454,7 +522,7 @@ USB_INT32S  Host_CtrlRecv (         USB_INT08U   bm_request_type,
 
 
     Host_FillSetup(bm_request_type, b_request, w_value, w_index, w_length);
-    rc = Host_ProcessTD(EDCtrl, TD_SETUP, TDBuffer, 8);
+    rc = Host_ProcessTD(EDCtrl, TD_SETUP, TDBuffer, USB_SETUP_PACKET_SIZE);
     if (rc == OK) {
         if (w_length) {
             rc = Host_ProcessTD(EDCtrl, TD_IN, TDBuffer, w_length);
@@ -485,16 +553,22 @@ USB_INT32S  Host_CtrlSend (          USB_INT08U   bm_request_type,
                                      USB_INT16U   w_value,
                                      USB_INT16U   w_index,
                                      USB_INT16U   w_length,
-                           volatile  USB_INT08U  *buffer)
+                     const volatile  USB_INT08U  *buffer)
 {
     USB_INT32S  rc;
 
 
     Host_FillSetup(bm_request_type, b_request, w_value, w_index, w_length);
 
-    rc = Host_ProcessTD(EDCtrl, TD_SETUP, TDBuffer, 8);
+    rc = Host_ProcessTD(EDCtrl, TD_SETUP, TDBuffer, USB_SETUP_PACKET_SIZE);
     if (rc == OK) {
         if (w_length) {
+            if (buffer == NULL) {
+                return (ERR_TD_FAIL);
+            }
+            for (USB_INT16U i = 0; i < w_length; i++) {
+                TDBuffer[i] = buffer[i];
+            }
             rc = Host_ProcessTD(EDCtrl, TD_OUT, TDBuffer, w_length);
         }
         if (rc == OK) {
@@ -524,15 +598,11 @@ void  Host_FillSetup (USB_INT08U   bm_request_type,
                       USB_INT16U   w_index,
                       USB_INT16U   w_length)
 {
-    int i;
-    for (i=0;i<w_length;i++)
-        TDBuffer[i] = 0;
-    
-    TDBuffer[0] = bm_request_type;
-    TDBuffer[1] = b_request;
-    WriteLE16U(&TDBuffer[2], w_value);
-    WriteLE16U(&TDBuffer[4], w_index);
-    WriteLE16U(&TDBuffer[6], w_length);
+    TDBuffer[USB_SETUP_BM_REQUEST_TYPE_OFFSET] = bm_request_type;
+    TDBuffer[USB_SETUP_B_REQUEST_OFFSET] = b_request;
+    WriteLE16U(&TDBuffer[USB_SETUP_W_VALUE_OFFSET], w_value);
+    WriteLE16U(&TDBuffer[USB_SETUP_W_INDEX_OFFSET], w_index);
+    WriteLE16U(&TDBuffer[USB_SETUP_W_LENGTH_OFFSET], w_length);
 }
 
 
@@ -645,12 +715,10 @@ void  Host_WDHWait (void)
 
 USB_INT32U  ReadLE32U (volatile  USB_INT08U  *pmem)
 {
-    USB_INT32U val = *(USB_INT32U*)pmem;
-#ifdef __BIG_ENDIAN
-    return __REV(val);
-#else
-    return val;
-#endif    
+    return ((USB_INT32U)pmem[0]) |
+           ((USB_INT32U)pmem[1] << 8) |
+           ((USB_INT32U)pmem[2] << 16) |
+           ((USB_INT32U)pmem[3] << 24);
 }
 
 /*
@@ -671,11 +739,10 @@ USB_INT32U  ReadLE32U (volatile  USB_INT08U  *pmem)
 void  WriteLE32U (volatile  USB_INT08U  *pmem,
                             USB_INT32U   val)
 {
-#ifdef __BIG_ENDIAN
-    *(USB_INT32U*)pmem = __REV(val);
-#else
-    *(USB_INT32U*)pmem = val;
-#endif
+    pmem[0] = (USB_INT08U)val;
+    pmem[1] = (USB_INT08U)(val >> 8);
+    pmem[2] = (USB_INT08U)(val >> 16);
+    pmem[3] = (USB_INT08U)(val >> 24);
 }
 
 /*
@@ -694,12 +761,8 @@ void  WriteLE32U (volatile  USB_INT08U  *pmem,
 
 USB_INT16U  ReadLE16U (volatile  USB_INT08U  *pmem)
 {
-    USB_INT16U val = *(USB_INT16U*)pmem;
-#ifdef __BIG_ENDIAN
-    return __REV16(val);
-#else
-    return val;
-#endif    
+    return (USB_INT16U)(((USB_INT16U)pmem[0]) |
+                        ((USB_INT16U)pmem[1] << 8));
 }
 
 /*
@@ -720,11 +783,8 @@ USB_INT16U  ReadLE16U (volatile  USB_INT08U  *pmem)
 void  WriteLE16U (volatile  USB_INT08U  *pmem,
                             USB_INT16U   val)
 {
-#ifdef __BIG_ENDIAN
-    *(USB_INT16U*)pmem = (__REV16(val) & 0xFFFF);
-#else
-    *(USB_INT16U*)pmem = val;
-#endif
+    pmem[0] = (USB_INT08U)val;
+    pmem[1] = (USB_INT08U)(val >> 8);
 }
 
 /*
@@ -743,12 +803,10 @@ void  WriteLE16U (volatile  USB_INT08U  *pmem,
 
 USB_INT32U  ReadBE32U (volatile  USB_INT08U  *pmem)
 {
-    USB_INT32U val = *(USB_INT32U*)pmem;
-#ifdef __BIG_ENDIAN
-    return val;
-#else
-    return __REV(val);
-#endif
+    return ((USB_INT32U)pmem[0] << 24) |
+           ((USB_INT32U)pmem[1] << 16) |
+           ((USB_INT32U)pmem[2] << 8) |
+           ((USB_INT32U)pmem[3]);
 }
 
 /*
@@ -769,11 +827,10 @@ USB_INT32U  ReadBE32U (volatile  USB_INT08U  *pmem)
 void  WriteBE32U (volatile  USB_INT08U  *pmem,
                             USB_INT32U   val)
 {
-#ifdef __BIG_ENDIAN
-    *(USB_INT32U*)pmem = val;
-#else
-    *(USB_INT32U*)pmem = __REV(val);
-#endif
+    pmem[0] = (USB_INT08U)(val >> 24);
+    pmem[1] = (USB_INT08U)(val >> 16);
+    pmem[2] = (USB_INT08U)(val >> 8);
+    pmem[3] = (USB_INT08U)val;
 }
 
 /*
@@ -792,12 +849,8 @@ void  WriteBE32U (volatile  USB_INT08U  *pmem,
 
 USB_INT16U  ReadBE16U (volatile  USB_INT08U  *pmem)
 {
-    USB_INT16U val = *(USB_INT16U*)pmem;
-#ifdef __BIG_ENDIAN
-    return val;
-#else
-    return __REV16(val);
-#endif    
+    return (USB_INT16U)(((USB_INT16U)pmem[0] << 8) |
+                        ((USB_INT16U)pmem[1]));
 }
 
 /*
@@ -818,9 +871,6 @@ USB_INT16U  ReadBE16U (volatile  USB_INT08U  *pmem)
 void  WriteBE16U (volatile  USB_INT08U  *pmem,
                             USB_INT16U   val)
 {
-#ifdef __BIG_ENDIAN
-    *(USB_INT16U*)pmem = val;
-#else
-    *(USB_INT16U*)pmem = (__REV16(val) & 0xFFFF);
-#endif
+    pmem[0] = (USB_INT08U)(val >> 8);
+    pmem[1] = (USB_INT08U)val;
 }

--- a/src/libs/USBDevice/USBHostLite/usbhost_lpc17xx.h
+++ b/src/libs/USBDevice/USBHostLite/usbhost_lpc17xx.h
@@ -51,8 +51,52 @@
 **************************************************************************************************************
 */
 
-#define  DESC_LENGTH(x)  x[0]
-#define  DESC_TYPE(x)    x[1]
+#define  USB_DESCRIPTOR_LENGTH_OFFSET                   0
+#define  USB_DESCRIPTOR_TYPE_OFFSET                     1
+
+#define  USB_CONFIGURATION_TOTAL_LENGTH_OFFSET          2
+
+#define  USB_DEVICE_MAX_PACKET_SIZE0_OFFSET             7
+
+#define  USB_INTERFACE_NUMBER_OFFSET                    2
+#define  USB_INTERFACE_CLASS_OFFSET                     5
+
+#define  USB_ENDPOINT_ADDRESS_OFFSET                    2
+#define  USB_ENDPOINT_ATTRIBUTES_OFFSET                 3
+#define  USB_ENDPOINT_MAX_PACKET_SIZE_OFFSET            4
+#define  USB_ENDPOINT_DIRECTION_IN                      0x80
+#define  USB_ENDPOINT_NUMBER_MASK                       0x7F
+#define  USB_ENDPOINT_TRANSFER_TYPE_MASK                0x03
+#define  USB_ENDPOINT_TRANSFER_TYPE_BULK                0x02
+
+#define  USB_DEVICE_ADDRESS                             1
+#define  USB_CONFIGURATION_VALUE                        1
+#define  USB_SET_CONFIGURATION_SETTLE_MS                100
+#define  USB_ENDPOINT_ZERO_INITIAL_DESCRIPTOR_BYTES      8
+#define  USB_SETUP_PACKET_SIZE                          8
+#define  USB_CONFIGURATION_DESCRIPTOR_HEADER_SIZE        9
+#define  USB_SETUP_BM_REQUEST_TYPE_OFFSET               0
+#define  USB_SETUP_B_REQUEST_OFFSET                     1
+#define  USB_SETUP_W_VALUE_OFFSET                       2
+#define  USB_SETUP_W_INDEX_OFFSET                       4
+#define  USB_SETUP_W_LENGTH_OFFSET                      6
+
+#define  DESC_LENGTH(x)                                 (x)[USB_DESCRIPTOR_LENGTH_OFFSET]
+#define  DESC_TYPE(x)                                   (x)[USB_DESCRIPTOR_TYPE_OFFSET]
+
+#define  OHCI_ED_FUNCTION_ADDRESS(address)              ((USB_INT32U)(address))
+#define  OHCI_ED_ENDPOINT_NUMBER(endpoint_address)      (((USB_INT32U)((endpoint_address) & USB_ENDPOINT_NUMBER_MASK)) << 7)
+#define  OHCI_ED_DIRECTION(direction)                   ((USB_INT32U)(direction) << 11)
+#define  OHCI_ED_SKIP                                   (1UL << 14)
+#define  OHCI_ED_MAX_PACKET_SIZE(max_packet)            ((USB_INT32U)(max_packet) << 16)
+#define  OHCI_ED_DIR_OUT                                1
+#define  OHCI_ED_DIR_IN                                 2
+#define  OHCI_ED_HEAD_TOGGLE_CARRY                      0x00000002
+#define  OHCI_ED_BULK_ENDPOINT_CONTROL(device_address, endpoint_address, direction, max_packet) \
+         (OHCI_ED_FUNCTION_ADDRESS(device_address) |                                            \
+          OHCI_ED_ENDPOINT_NUMBER(endpoint_address) |                                           \
+          OHCI_ED_DIRECTION(direction) |                                                        \
+          OHCI_ED_MAX_PACKET_SIZE(max_packet))
 
 
 #define  HOST_GET_DESCRIPTOR(descType, descIndex, data, length)                      \
@@ -126,6 +170,8 @@
 #define  TD_TOGGLE_0        (USB_INT32U)(0x02000000)         /* Toggle 0                                    */
 #define  TD_TOGGLE_1        (USB_INT32U)(0x03000000)         /* Toggle 1                                    */
 #define  TD_CC              (USB_INT32U)(0xF0000000)         /* Completion Code                             */
+#define  TD_CC_SHIFT        28
+#define  TD_CC_MASK         0x0F
 
 /*
 **************************************************************************************************************
@@ -189,6 +235,12 @@ extern  volatile  HCTD        *TDHead;          /* Head transfer descriptor stru
 extern  volatile  HCTD        *TDTail;          /* Tail transfer descriptor structure                       */
 extern  volatile  USB_INT08U  *TDBuffer;        /* Current Buffer Pointer of transfer descriptor            */
 
+typedef struct hostPortResetStatus {
+    USB_INT32U waited_ms;
+    USB_INT32U port_status;
+    USB_INT32U interrupt_status;
+} HostPortResetStatus;
+
 /*
 **************************************************************************************************************
 *                                       FUNCTION PROTOTYPES
@@ -199,11 +251,15 @@ void        Host_Init     (void);
 
 // extern "C" void USB_IRQHandler (void) __irq;
 
-USB_INT32S  Host_EnumDev  (void);
+USB_INT32S  Host_WaitForDevice(USB_INT32U timeout_ms);
+USB_INT32S  Host_ResetRootPort(USB_INT32U timeout_ms, HostPortResetStatus *status);
+USB_INT32S  Host_ReadDeviceDescriptor(void);
+USB_INT32S  Host_SetDeviceAddress(USB_INT08U address);
+USB_INT32S  Host_ReadConfigurationDescriptor(USB_INT16U max_len, USB_INT16U *fetched_len);
 
 USB_INT32S  Host_ProcessTD(volatile  HCED       *ed,
                            volatile  USB_INT32U  token,
-                           volatile  USB_INT08U *buffer,
+                     const volatile  USB_INT08U *buffer,
                                      USB_INT32U  buffer_len);
 
 void        Host_DelayUS  (          USB_INT32U    delay);
@@ -226,7 +282,7 @@ USB_INT32S  Host_CtrlSend (          USB_INT08U   bm_request_type,
                                      USB_INT16U   w_value,
                                      USB_INT16U   w_index,
                                      USB_INT16U   w_length,
-                           volatile  USB_INT08U  *buffer);
+                     const volatile  USB_INT08U  *buffer);
 
 void        Host_FillSetup(          USB_INT08U   bm_request_type,
                                      USB_INT08U   b_request,

--- a/src/libs/USBDevice/USBHostLite/usbhost_ms.cpp
+++ b/src/libs/USBDevice/USBHostLite/usbhost_ms.cpp
@@ -70,6 +70,56 @@ USB_INT32S MS_Init (USB_INT32U *blkSize, USB_INT32U *numBlks, USB_INT08U *inquir
     rc = MS_Inquire (inquiryResult);
     return (rc);
 }
+
+USB_INT32S MS_Enumerate(void)
+{
+    USB_INT32S rc;
+
+    PRINT_Log("USBHostLite: waiting for USB device\n");
+    rc = Host_WaitForDevice(0);
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = Host_ResetRootPort(0, NULL);
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = Host_ReadDeviceDescriptor();
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = Host_SetDeviceAddress(1);
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = Host_ReadConfigurationDescriptor(0, NULL);
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = MS_ParseConfiguration();
+    if (rc != OK) {
+        PRINT_Err(rc);
+        return (rc);
+    }
+
+    rc = USBH_SET_CONFIGURATION(1);
+    if (rc != OK) {
+        PRINT_Err(rc);
+    }
+    Host_DelayMS(100);
+    return (rc);
+}
+
 /*
 **************************************************************************************************************
 *                                         PARSE THE CONFIGURATION
@@ -370,7 +420,7 @@ USB_INT32S  MS_BulkRecv (          USB_INT32U   block_number,
 
 USB_INT32S  MS_BulkSend (          USB_INT32U   block_number,
                                    USB_INT16U   num_blocks,
-                         volatile  USB_INT08U  *user_buffer)
+                   const volatile  USB_INT08U  *user_buffer)
 {
     USB_INT32S  rc;
 

--- a/src/libs/USBDevice/USBHostLite/usbhost_ms.h
+++ b/src/libs/USBDevice/USBHostLite/usbhost_ms.h
@@ -83,7 +83,8 @@ USB_INT32S  MS_BulkRecv          (          USB_INT32U    block_number,
 
 USB_INT32S  MS_BulkSend          (          USB_INT32U    block_number,
                                             USB_INT16U    num_blocks,
-                                  volatile  USB_INT08U   *user_buffer);
+                            const volatile  USB_INT08U   *user_buffer);
+USB_INT32S  MS_Enumerate         (void);
 USB_INT32S  MS_ParseConfiguration(void);
 USB_INT32S  MS_TestUnitReady     (void);
 USB_INT32S  MS_ReadCapacity (USB_INT32U *numBlks, USB_INT32U *blkSize);

--- a/src/libs/compiler.h
+++ b/src/libs/compiler.h
@@ -3,8 +3,10 @@
 
 #if defined(__GNUC__) || defined(__clang__)
 #define LOCATED_IN_AHBSRAM __attribute__((section("AHBSRAM")))
+#define ALIGNED_TO(bytes) __attribute__((aligned(bytes)))
 #else
 #define LOCATED_IN_AHBSRAM
+#define ALIGNED_TO(bytes)
 #endif
 
 #include <stdint.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,8 @@
 #define second_usb_serial_enable_checksum  CHECKSUM("second_usb_serial_enable")
 // #define disable_msd_checksum  CHECKSUM("msd_disable")
 // #define dfu_enable_checksum  CHECKSUM("dfu_enable")
+#define usb_msc_checksum       CHECKSUM("usb_msc")
+#define enable_checksum        CHECKSUM("enable")
 #define watchdog_timeout_checksum  CHECKSUM("watchdog_timeout")
 
 // USB Stuff
@@ -167,8 +169,12 @@ void init() {
     // ATC Handler
     kernel->add_module( new ATCHandler() );
 
-    // MSC File System Handler
-    kernel->add_module( new MSCFileSystem("ud") );
+    // This module owns the USB host controller while enabled.
+    if (kernel->config->value(usb_msc_checksum, enable_checksum)->as_bool(true)) {
+        kernel->add_module( new MSCFileSystem("ud") );
+    } else {
+        kernel->streams->printf("NOTE: USB mass storage host is disabled\n");
+    }
 
     // Serial Console handles IO with the wireless probe
     kernel->add_module( new(AHB) SerialConsole2() ); // must stay in AHB: UART RxIrq writes RingBuffer

--- a/src/modules/tools/spindle/SpindleMaker.cpp
+++ b/src/modules/tools/spindle/SpindleMaker.cpp
@@ -15,6 +15,9 @@
 #ifndef NO_MODBUS_SPINDLE
 #include "HuanyangSpindleControl.h"
 #endif
+#ifndef NO_VESC_SPINDLE
+#include "VESCSpindleControl.h"
+#endif
 #include "Config.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
@@ -55,6 +58,10 @@ void SpindleMaker::load_spindle(){
             delete spindle;
             THEKERNEL->streams->printf("ERROR: No valid spindle VFD type defined\n");
         }
+#endif
+#ifndef NO_VESC_SPINDLE
+    } else if ( spindle_type.compare("vesc") == 0 ) {
+        spindle = new VESCSpindleControl();
 #endif
     } else {
         delete spindle;

--- a/src/modules/tools/spindle/VESCSpindleControl.cpp
+++ b/src/modules/tools/spindle/VESCSpindleControl.cpp
@@ -1,0 +1,704 @@
+/*
+ * VESC spindle control over USB CDC (FW 6.x packet protocol).
+ *
+ * The setup guide below assumes one USB-connected Flipsky Mini FSESC6.7 Pro
+ * driving a 48 V / 500 W / 12k RPM, 4-pole BLDC spindle with hall sensors,
+ * powered from a regulated 48 V DC PSU. This motor has 4 poles (2 pole pairs).
+ * At 12000 spindle RPM the VESC sees 24000 eRPM.
+ *
+ * VESC Tool 6.x setup guide:
+ * 1. Connect the motor to the VESC and connect the VESC to the computer
+ *    over USB. Power it up from the 48 V power supply.
+ * 2. Open VESC Tool and click AutoConnect.
+ * 3. Press "Setup Motors FOC". Press "Yes" to load defaults. Select a generic
+ *    motor and press "Next". Select "Medium Inrunner". Click
+ *    "Override (Advanced)" and set "Motor Poles" to 4. Click "Next",
+ *    then press "Yes". Click "Advanced", set "Battery Current Regen" to -2 A,
+ *    "Battery Current Max" to 12 A. Click "Next". Click "Direct Drive", set
+ *    the temperature sensor type to "Disabled".
+ * 4. Make sure the motor is free to spin. Click "Run Detection", clear
+ *    "Detect all motors" checkbox and press "OK". The motor will make strange
+ *    noises, then spin, then turn slowly. This is normal. Press "OK".
+ * 5. Press "FWD" and observe the direction of rotation. If it is wrong,
+ *    enable "Inverted". Press "Finish".
+ * 6. Set the following values:
+ *
+ *        Motor Settings -> General -> Current:
+ *          Motor Current Max:         20 A
+ *          Motor Current Max Brake:   -2 A
+ *          Absolute Maximum Current:  25 A
+ *          Battery Current Max:       12 A
+ *          Battery Current Max Regen: -2 A
+ *
+ *        Motor Settings -> General -> RPM:
+ *          Max ERPM: 26000
+ *          Max ERPM Reverse: -26000
+ *
+ *        Motor Settings -> General -> Voltage:
+ *          Battery Voltage Cutoff Start: 10 V
+ *          Battery Voltage Cutoff End:   8 V
+ *
+ *        Motor Settings -> General -> Advanced:
+ *          Minimum Input Voltage: 40 V
+ *          Maximum Input Voltage: 57 V
+ *
+ *        Motor Settings -> Additional Info -> Setup:
+ *          Motor Poles: 4
+ *
+ * 7. Check that the "Motor Settings -> FOC -> General -> Sensor Mode" is
+ *    set to "Hall Sensors", and that the "Hall Table" on the "Hall Sensors"
+ *    tab has six entries.
+ *
+ * 8. Click "Write Motor Configuration" (down arrow next to "M" on the right)
+ *    to save these settings to the VESC.
+ *
+ * 9. Add the following to your config.txt (tweak as needed):
+ *
+ *   spindle.type                 vesc
+ *   usb_msc.enable               false
+ *   spindle.default_rpm          10000
+ *   spindle.min_rpm              3000
+ *   spindle.max_rpm              15000
+ *   spindle.delay_s              3
+ *   spindle.ignore_on_halt       false
+ *   spindle.stall_s              1
+ *   spindle.stall_alarm_rpm      2000
+ *   spindle.vesc_pole_pairs      2
+ *   spindle.vesc_poll_ms         200
+ *   spindle.vesc_stall_current_a 15
+ */
+
+#include "VESCSpindleControl.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include "Config.h"
+#include "ConfigValue.h"
+#include "Gcode.h"
+#include "Pin.h"
+#include "PublicDataRequest.h"
+#include "SpindlePublicAccess.h"
+#include "StreamOutputPool.h"
+#include "USBHostCDC.h"
+#include "checksumm.h"
+#include "libs/Kernel.h"
+#include "us_ticker_api.h"
+
+constexpr uint16_t spindle_checksum = CHECKSUM("spindle");
+
+namespace {
+// The VESC packet payload is byte-packed and not guaranteed to be aligned, so
+// copy through a local integer before swapping byte order.
+uint16_t be16(const uint8_t *p) {
+  uint16_t v;
+  __builtin_memcpy(&v, p, sizeof v);
+  return __builtin_bswap16(v);
+}
+uint32_t be32(const uint8_t *p) {
+  uint32_t v;
+  __builtin_memcpy(&v, p, sizeof v);
+  return __builtin_bswap32(v);
+}
+void wbe16(uint8_t *p, const uint16_t v) {
+  const uint16_t s = __builtin_bswap16(v);
+  __builtin_memcpy(p, &s, sizeof s);
+}
+void wbe32(uint8_t *p, const uint32_t v) {
+  const uint32_t s = __builtin_bswap32(v);
+  __builtin_memcpy(p, &s, sizeof s);
+}
+
+bool elapsed_us(const uint32_t start_us, const uint32_t interval_us) {
+  return static_cast<uint32_t>(us_ticker_read() - start_us) >= interval_us;
+}
+
+// The fields used by this driver are at the front of the VESC 6.x
+// COMM_GET_VALUES response. Newer firmware can append more telemetry; that is
+// fine as long as this prefix does not move.
+struct __attribute__((packed)) VescGetValuesPayload {
+  uint8_t cmd;                 // COMM_GET_VALUES
+  uint8_t temp_mos[2];         // int16, scale 10  (deg C)
+  uint8_t _temp_motor[2];      // int16, scale 10  (deg C)
+  uint8_t current_motor[4];    // int32, scale 100 (A)
+  uint8_t _current_input[4];   // int32, scale 100 (A)
+  uint8_t _id[4];              // int32, scale 100 (A)
+  uint8_t _iq[4];              // int32, scale 100 (A)
+  uint8_t _duty[2];            // int16, scale 1000
+  uint8_t rpm[4];              // int32, scale 1   (electrical RPM)
+  uint8_t v_in[2];             // int16, scale 10  (V)
+  uint8_t _ah[4];              // int32, scale 1e4
+  uint8_t _ah_charged[4];      // int32, scale 1e4
+  uint8_t _wh[4];              // int32, scale 1e4
+  uint8_t _wh_charged[4];      // int32, scale 1e4
+  uint8_t _tachometer[4];      // int32
+  uint8_t _tachometer_abs[4];  // int32
+  uint8_t fault_code;          // int8
+};
+static_assert(sizeof(VescGetValuesPayload) == 54, "VESC COMM_GET_VALUES payload layout drift");
+
+// VESC FW 6.x appends this status byte after the fixed prefix above when
+// COMM_GET_VALUES uses its default full mask. Bit 0 is the motor command
+// timeout reported by timeout_has_timeout().
+constexpr uint8_t VESC_STATUS_TIMEOUT = 0x01;
+constexpr uint8_t VESC_GET_VALUES_STATUS_OFFSET = 73;
+constexpr uint32_t VESC_HANDSHAKE_TIMEOUT_US = 2000000UL;
+constexpr uint32_t VESC_RESPONSE_TIMEOUT_US = 400000UL;
+constexpr uint32_t VESC_ALIVE_INTERVAL_MS = 200;
+constexpr uint32_t VESC_IDLE_POLL_INTERVAL_MS = 1000;
+constexpr uint32_t VESC_TIMEOUT_STATUS_GRACE_US = 100000UL;
+}  // namespace
+
+void VESCSpindleControl::raise_spindle_alarm(const char *reason) {
+  THEKERNEL->streams->printf("ERROR: %s\n", reason);
+  THEKERNEL->set_halt_reason(SPINDLE_ALARM);
+  THEKERNEL->call_event(ON_HALT, nullptr);
+}
+
+void VESCSpindleControl::handle_comm_error(const char *reason) {
+  if (!comm_error_halted || !THEKERNEL->is_halted()) {
+    comm_error_halted = true;
+    raise_spindle_alarm(reason);
+  }
+}
+
+void VESCSpindleControl::dwell_after_spindle_change() {
+  if (delay_s <= 0) return;
+
+  char buf[80];
+  size_t n = snprintf(buf, sizeof(buf), "G4P%d", delay_s);
+  if (n > sizeof(buf)) n = sizeof(buf);
+  std::string g(buf, n);
+  Gcode gcode(g, &(StreamOutput::NullStream));
+  THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+}
+
+int32_t VESCSpindleControl::commanded_rpm() const {
+  return static_cast<int32_t>(static_cast<float>(target_rpm) * factor / 100.0f);
+}
+
+void VESCSpindleControl::reset_stall_monitor() {
+  stall_timer = 0;
+  stall_speed_seen = false;
+  stall_monitor_start = us_ticker_read();
+  stall_monitor_seq = telemetry_seq;
+}
+
+bool VESCSpindleControl::vesc_timeout_status_is_stale() const {
+  if ((vesc_status & VESC_STATUS_TIMEOUT) == 0) return false;
+
+  // VESC timeout_reset() updates the command timestamp immediately, but the
+  // reported timeout flag is cleared by VESC's timeout thread on its next pass.
+  return !elapsed_us(last_timeout_reset_cmd_time, VESC_TIMEOUT_STATUS_GRACE_US);
+}
+
+void VESCSpindleControl::on_module_loaded() {
+  protocol_ok = false;
+  default_rpm = THEKERNEL->config->value(spindle_checksum, CHECKSUM("default_rpm"))->as_int(10000);
+  pole_pairs = THEKERNEL->config->value(spindle_checksum, CHECKSUM("vesc_pole_pairs"))->as_int(2);
+  max_rpm = THEKERNEL->config->value(spindle_checksum, CHECKSUM("max_rpm"))->as_int(15000);
+  min_rpm = THEKERNEL->config->value(spindle_checksum, CHECKSUM("min_rpm"))->as_int(3000);
+  delay_s = THEKERNEL->config->value(spindle_checksum, CHECKSUM("delay_s"))->as_int(3);
+  poll_interval_ms = static_cast<uint32_t>(THEKERNEL->config->value(spindle_checksum, CHECKSUM("vesc_poll_ms"))->as_int(200));
+  const float configured_stall_s = THEKERNEL->config->value(spindle_checksum, CHECKSUM("stall_s"))->as_number(1.0f);
+  stall_us = configured_stall_s > 0.0f ? static_cast<uint32_t>(configured_stall_s * 1000000.0f) : 0;
+  stall_rpm = THEKERNEL->config->value(spindle_checksum, CHECKSUM("stall_alarm_rpm"))->as_int(2000);
+  stall_current = THEKERNEL->config->value(spindle_checksum, CHECKSUM("vesc_stall_current_a"))->as_int(15) * 100;
+  ignore_on_halt = THEKERNEL->config->value(spindle_checksum, CHECKSUM("ignore_on_halt"))->as_bool(false);
+
+  spindle_on = false;
+  target_rpm = default_rpm;
+
+  // The mass-storage module and this CDC driver both assume they own the one
+  // USB host controller. Do not try to arbitrate that at runtime; make the
+  // configuration error explicit and leave the machine halted.
+  if (THEKERNEL->config->value(CHECKSUM("usb_msc"), CHECKSUM("enable"))->as_bool(true)) {
+    THEKERNEL->streams->printf("ERROR: VESC spindle requires usb_msc.enable false\n");
+    failed_init = true;
+    return;
+  }
+
+  // Power the external USB port before enumeration. On Carvera this enable pin
+  // is active-low.
+  Pin usb_en;
+  usb_en.from_string(THEKERNEL->config->value(CHECKSUM("usb_en_pin"))->as_string("1.19"));
+  usb_en.as_output();
+  usb_en.set(false);
+  init_pending = true;
+}
+
+bool VESCSpindleControl::wait_for_usb_transfer(const CDCXferState active_state) {
+  while (usb.state() == active_state) {
+    usb.poll();
+  }
+  return usb.state() == CDC_XFER_COMPLETE;
+}
+
+void VESCSpindleControl::reset_rx_packet() { rx_pkt_len = 0; }
+
+VESCRxPacketState VESCSpindleControl::append_rx_packet_bytes(const volatile uint8_t *buf, const uint32_t len) {
+  // CDC may split one VESC frame across reads, but this driver never expects
+  // unrelated bytes in the stream. Malformed framing is a communication
+  // failure, not something to resynchronise around silently.
+  for (uint32_t i = 0; i < len; i++) {
+    const uint8_t b = buf[i];
+
+    if (rx_pkt_len == 0) {
+      if (b != 0x02) return VESC_RX_INVALID;
+      rx_pkt_buf[rx_pkt_len++] = b;
+      continue;
+    }
+
+    if (rx_pkt_len >= sizeof(rx_pkt_buf)) return VESC_RX_INVALID;
+
+    rx_pkt_buf[rx_pkt_len++] = b;
+
+    if (rx_pkt_len >= 2) {
+      const uint16_t expected_len = static_cast<uint16_t>(rx_pkt_buf[1]) + 5;
+      if (rx_pkt_buf[1] < 1 || expected_len > sizeof(rx_pkt_buf)) return VESC_RX_INVALID;
+      if (rx_pkt_len > expected_len) return VESC_RX_INVALID;
+      if (rx_pkt_len == expected_len) {
+        if (rx_pkt_buf[rx_pkt_len - 1] != 0x03) return VESC_RX_INVALID;
+        return (i + 1 == len) ? VESC_RX_COMPLETE : VESC_RX_INVALID;
+      }
+    }
+  }
+
+  return VESC_RX_INCOMPLETE;
+}
+
+bool VESCSpindleControl::verify_vesc_protocol() {
+  constexpr uint8_t payload[1] = {COMM_FW_VERSION};
+  uint8_t tx[8];
+  const uint16_t tx_len = vesc_build_packet(tx, payload, 1);
+  const uint32_t start_us = us_ticker_read();
+  reset_rx_packet();
+
+  if (!usb.start_send(tx, tx_len)) return false;
+
+  if (!wait_for_usb_transfer(CDC_XFER_SENDING)) {
+    usb.finish();
+    return false;
+  }
+  usb.finish();
+
+  while (true) {
+    if (static_cast<uint32_t>(us_ticker_read() - start_us) >= VESC_HANDSHAKE_TIMEOUT_US) return false;
+    if (!usb.start_recv(128)) return false;
+    if (!wait_for_usb_transfer(CDC_XFER_RECEIVING)) {
+      usb.finish();
+      return false;
+    }
+
+    const VESCRxPacketState rx_state = append_rx_packet_bytes(usb.rx_buf(), usb.rx_len());
+    usb.finish();
+    if (rx_state == VESC_RX_COMPLETE) break;
+    if (rx_state == VESC_RX_INVALID) return false;
+  }
+
+  const uint8_t *payload_rx = nullptr;
+  uint16_t payload_len = 0;
+  if (!extract_vesc_payload(rx_pkt_buf, rx_pkt_len, &payload_rx, &payload_len)) return false;
+
+  return payload_len >= 1 && payload_rx[0] == COMM_FW_VERSION;
+}
+
+void VESCSpindleControl::turn_on() {
+  if (!protocol_ok) {
+    raise_spindle_alarm("VESC spindle init failed");
+    return;
+  }
+
+  spindle_on = true;
+  THEKERNEL->spindleon = true;
+  reset_stall_monitor();
+  speed_update_pending = true;
+  dwell_after_spindle_change();
+}
+
+void VESCSpindleControl::turn_off() {
+  spindle_on = false;
+  THEKERNEL->spindleon = false;
+  reset_stall_monitor();
+  speed_update_pending = true;
+  dwell_after_spindle_change();
+}
+
+void VESCSpindleControl::set_speed(int rpm) {
+  if (rpm > max_rpm) rpm = max_rpm;
+  if (rpm > 0 && rpm < min_rpm) rpm = min_rpm;
+  const bool changed = rpm != target_rpm;
+  target_rpm = rpm;
+  if (spindle_on && changed) reset_stall_monitor();
+  speed_update_pending = true;
+}
+
+void VESCSpindleControl::report_speed() {
+  THEKERNEL->streams->printf(
+      "VESC  State: %s  Current RPM: %5ld  Target RPM: %ld  Vin: %d V/10  Imot: %ld A/100  Tmos: %d C/10\n",
+      spindle_on ? "on" : "off", current_rpm, target_rpm, vesc_voltage, vesc_current, vesc_temp_mos);
+}
+
+void VESCSpindleControl::set_factor(const float f) {
+  const bool changed = f != factor;
+  factor = f;
+  if (spindle_on && changed) reset_stall_monitor();
+  // PWM applies M223 immediately; do the same instead of waiting for the next
+  // explicit speed command.
+  speed_update_pending = true;
+}
+
+void VESCSpindleControl::queue_set_rpm(const int32_t erpm) {
+  uint8_t payload[5];
+  payload[0] = COMM_SET_RPM;
+  wbe32(&payload[1], static_cast<uint32_t>(erpm));
+  pkt_len = vesc_build_packet(pkt_buf, payload, sizeof payload);
+  pending_cmd = COMM_SET_RPM;
+  last_alive_time = us_ticker_read();
+  comm_state = VESC_COMM_SEND_PENDING;
+}
+
+void VESCSpindleControl::queue_get_values() {
+  constexpr uint8_t payload[1] = {COMM_GET_VALUES};
+  pkt_len = vesc_build_packet(pkt_buf, payload, 1);
+  pending_cmd = COMM_GET_VALUES;
+  reset_rx_packet();
+  comm_state = VESC_COMM_SEND_PENDING;
+}
+
+void VESCSpindleControl::queue_alive() {
+  constexpr uint8_t payload[1] = {COMM_ALIVE};
+  pkt_len = vesc_build_packet(pkt_buf, payload, 1);
+  pending_cmd = COMM_ALIVE;
+  last_alive_time = us_ticker_read();
+  comm_state = VESC_COMM_SEND_PENDING;
+}
+
+bool VESCSpindleControl::parse_get_values(const uint8_t *buf, const uint16_t len) {
+  const uint8_t *payload_rx = nullptr;
+  uint16_t payload_len = 0;
+  if (!extract_vesc_payload(buf, len, &payload_rx, &payload_len)) return false;
+
+  if (payload_len < sizeof(VescGetValuesPayload)) return false;
+
+  const auto *gv = reinterpret_cast<const VescGetValuesPayload *>(payload_rx);
+  if (gv->cmd != COMM_GET_VALUES) return false;
+
+  vesc_temp_mos = static_cast<int16_t>(be16(gv->temp_mos));
+  vesc_current = static_cast<int32_t>(be32(gv->current_motor));
+  const auto erpm = static_cast<int32_t>(be32(gv->rpm));
+  current_rpm = std::abs(erpm) / pole_pairs;
+  vesc_voltage = static_cast<int16_t>(be16(gv->v_in));
+  vesc_fault_code = gv->fault_code;
+  vesc_status = payload_len > VESC_GET_VALUES_STATUS_OFFSET ? payload_rx[VESC_GET_VALUES_STATUS_OFFSET] : 0;
+  telemetry_seq++;
+  return true;
+}
+
+void VESCSpindleControl::handle_usb_disconnected() {
+  // Once USB is gone, the VESC should stop itself on command timeout. The CNC
+  // still needs an alarm so motion does not continue with an uncontrolled
+  // spindle.
+  if (comm_state != VESC_COMM_IDLE) {
+    usb.finish();
+    comm_state = VESC_COMM_IDLE;
+  }
+  if (spindle_on && (!comm_error_halted || !THEKERNEL->is_halted())) {
+    comm_error_halted = true;
+    raise_spindle_alarm("VESC USB disconnected");
+  }
+}
+
+void VESCSpindleControl::schedule_next_vesc_command(const uint32_t now_us) {
+  const bool halted = THEKERNEL->is_halted();
+  const bool background_allowed = !halted || (spindle_on && ignore_on_halt);
+  const uint32_t telemetry_interval_ms = spindle_on ? poll_interval_ms : VESC_IDLE_POLL_INTERVAL_MS;
+
+  // A requested speed change must be delivered even while halted, because it
+  // may be the RPM=0 command from turn_off(). Other traffic stops during halt
+  // unless spindle.ignore_on_halt says to keep a running spindle alive.
+  if (speed_update_pending) {
+    speed_update_pending = false;
+    int32_t erpm = commanded_rpm() * pole_pairs;
+    if (!spindle_on) erpm = 0;
+    queue_set_rpm(erpm);
+  } else if (background_allowed) {
+    if (spindle_on && (now_us - last_alive_time) / 1000 >= VESC_ALIVE_INTERVAL_MS) {
+      queue_alive();
+    } else if ((now_us - last_poll_time) / 1000 >= telemetry_interval_ms) {
+      last_poll_time = now_us;
+      queue_get_values();
+    }
+  }
+}
+
+void VESCSpindleControl::start_pending_send() {
+  // If CDC is still busy, leave the command queued and try again on the next
+  // idle tick instead of blocking here.
+  if (usb.start_send(pkt_buf, pkt_len)) {
+    comm_state = VESC_COMM_SEND_WAIT;
+  }
+}
+
+void VESCSpindleControl::handle_send_wait(const CDCXferState xfer_state) {
+  if (xfer_state == CDC_XFER_ERROR) {
+    usb.finish();
+    comm_state = VESC_COMM_IDLE;
+    handle_comm_error("VESC USB transfer error");
+    return;
+  }
+
+  if (xfer_state != CDC_XFER_COMPLETE) return;
+
+  if (pending_cmd == COMM_SET_RPM || pending_cmd == COMM_ALIVE) {
+    last_timeout_reset_cmd_time = us_ticker_read();
+  }
+  usb.finish();
+
+  // Only COMM_GET_VALUES expects a response.
+  if (pending_cmd != COMM_GET_VALUES) {
+    comm_state = VESC_COMM_IDLE;
+    return;
+  }
+
+  reset_rx_packet();
+  rx_start_time = us_ticker_read();
+  if (usb.start_recv(128)) {
+    comm_state = VESC_COMM_RECV_WAIT;
+  } else {
+    comm_state = VESC_COMM_IDLE;
+    handle_comm_error("VESC USB receive start failed");
+  }
+}
+
+void VESCSpindleControl::handle_recv_wait(const CDCXferState xfer_state) {
+  if (xfer_state == CDC_XFER_COMPLETE) {
+    const VESCRxPacketState rx_state = append_rx_packet_bytes(usb.rx_buf(), usb.rx_len());
+    usb.finish();
+    if (rx_state == VESC_RX_COMPLETE) {
+      comm_state = VESC_COMM_PROCESS;
+    } else if (rx_state == VESC_RX_INVALID) {
+      comm_state = VESC_COMM_IDLE;
+      handle_comm_error("VESC invalid telemetry");
+    } else if (!usb.start_recv(128)) {
+      comm_state = VESC_COMM_IDLE;
+      handle_comm_error("VESC USB receive start failed");
+    }
+  } else if (xfer_state == CDC_XFER_ERROR) {
+    usb.finish();
+    comm_state = VESC_COMM_IDLE;
+    handle_comm_error("VESC USB receive error");
+  } else if (static_cast<uint32_t>(us_ticker_read() - rx_start_time) >= VESC_RESPONSE_TIMEOUT_US) {
+    usb.abort();
+    usb.finish();
+    comm_state = VESC_COMM_IDLE;
+    handle_comm_error("VESC telemetry timeout");
+  }
+}
+
+void VESCSpindleControl::process_pending_response() {
+  if (pending_cmd == COMM_GET_VALUES && !parse_get_values(rx_pkt_buf, rx_pkt_len)) {
+    comm_state = VESC_COMM_IDLE;
+    handle_comm_error("VESC invalid telemetry");
+    return;
+  }
+
+  comm_state = VESC_COMM_IDLE;
+}
+
+void VESCSpindleControl::comm_poll() {
+  if (!usb.connected()) {
+    handle_usb_disconnected();
+    return;
+  }
+
+  const CDCXferState xfer_state = usb.poll();
+
+  switch (comm_state) {
+    case VESC_COMM_IDLE:
+      schedule_next_vesc_command(us_ticker_read());
+      break;
+    case VESC_COMM_SEND_PENDING:
+      start_pending_send();
+      break;
+    case VESC_COMM_SEND_WAIT:
+      handle_send_wait(xfer_state);
+      break;
+    case VESC_COMM_RECV_WAIT:
+      handle_recv_wait(xfer_state);
+      break;
+    case VESC_COMM_PROCESS:
+      process_pending_response();
+      break;
+  }
+}
+
+void VESCSpindleControl::on_idle(void *) {
+  // Init can fail before the normal status stream is ready. Raise the alarm
+  // from idle so the controller can report the halt normally.
+  if (failed_init) {
+    failed_init = false;
+    raise_spindle_alarm("VESC spindle init failed");
+    return;
+  }
+
+  if (init_pending) {
+    init_pending = false;
+
+    if (!usb.init(5000)) {
+      THEKERNEL->streams->printf("ERROR: VESC not detected on USB host\n");
+      raise_spindle_alarm("VESC spindle init failed");
+      return;
+    }
+
+    if (!verify_vesc_protocol()) {
+      THEKERNEL->streams->printf("ERROR: VESC did not respond to COMM_FW_VERSION\n");
+      raise_spindle_alarm("VESC spindle init failed");
+      return;
+    }
+
+    protocol_ok = true;
+    THEKERNEL->streams->printf("VESC spindle connected via USB\n");
+  }
+
+  // Keep the communication state machine alive during halt long enough to send
+  // any queued stop command.
+  comm_poll();
+
+  if (THEKERNEL->is_halted()) return;
+
+  if (vesc_fault_code != 0) {
+    const uint8_t fault_code = vesc_fault_code;
+    vesc_fault_code = 0;
+    THEKERNEL->streams->printf("ERROR: VESC fault code %d - halt\n", fault_code);
+    THEKERNEL->set_halt_reason(SPINDLE_ALARM);
+    THEKERNEL->call_event(ON_HALT, nullptr);
+    return;
+  }
+
+  // Without an active spindle command, VESC's command-timeout bit only means
+  // the idle keepalive window expired. Do not carry that status into the next
+  // start command.
+  if (!spindle_on) {
+    vesc_status &= ~VESC_STATUS_TIMEOUT;
+  } else if (vesc_timeout_status_is_stale()) {
+    vesc_status &= ~VESC_STATUS_TIMEOUT;
+  }
+
+  if (vesc_status & VESC_STATUS_TIMEOUT) {
+    vesc_status = 0;
+    THEKERNEL->streams->printf("ERROR: VESC motor timeout - halt\n");
+    THEKERNEL->set_halt_reason(SPINDLE_ALARM);
+    THEKERNEL->call_event(ON_HALT, nullptr);
+    return;
+  }
+
+  const uint32_t now_us = us_ticker_read();
+  const uint32_t grace_us = delay_s > 0 ? static_cast<uint32_t>(delay_s) * 1000000UL : 0;
+  const bool monitor_has_sample = telemetry_seq != stall_monitor_seq;
+  const bool monitor_armed = stall_speed_seen || (now_us - stall_monitor_start) >= grace_us;
+  const bool stall_enabled = stall_us > 0 && stall_current > 0 && stall_rpm > 0;
+  const bool stall_target = std::abs(commanded_rpm()) > stall_rpm;
+  const int32_t stopped_rpm = stall_rpm < 500 ? stall_rpm : 500;
+
+  if (monitor_has_sample && std::abs(current_rpm) >= stall_rpm) stall_speed_seen = true;
+
+  // A loaded stall has high motor current and low speed. A command timeout or
+  // controller release has the opposite shape: the spindle was running, then
+  // VESC telemetry drops to near zero while the command is still active.
+  const bool torque_stall = std::abs(vesc_current) >= stall_current && std::abs(current_rpm) < stall_rpm;
+  const bool released_after_running =
+      stall_speed_seen && std::abs(current_rpm) <= stopped_rpm && std::abs(vesc_current) < stall_current;
+  if (spindle_on && stall_enabled && stall_target && monitor_has_sample && (torque_stall || released_after_running)) {
+    if (stall_timer == 0) {
+      stall_timer = now_us;
+    } else if (monitor_armed && (now_us - stall_timer) > stall_us) {
+      THEKERNEL->streams->printf("ERROR: %s - halt\n",
+                                 torque_stall ? "Spindle stall detected" : "Spindle stopped unexpectedly");
+      THEKERNEL->set_halt_reason(SPINDLE_STALL);
+      THEKERNEL->call_event(ON_HALT, nullptr);
+    }
+  } else {
+    stall_timer = 0;
+  }
+}
+
+void VESCSpindleControl::on_get_public_data(void *argument) {
+  auto *pdr = static_cast<PublicDataRequest *>(argument);
+  if (!pdr->starts_with(pwm_spindle_control_checksum)) return;
+
+  if (pdr->second_element_is(get_spindle_status_checksum)) {
+    const auto t = static_cast<spindle_status *>(pdr->get_data_ptr());
+    t->state = this->spindle_on;
+    t->current_rpm = static_cast<float>(this->current_rpm);
+    t->target_rpm = static_cast<float>(this->target_rpm);
+    t->current_pwm_value = 0;
+    t->factor = this->factor;
+    pdr->set_taken();
+  }
+}
+
+void VESCSpindleControl::on_set_public_data(void *argument) {
+  auto *pdr = static_cast<PublicDataRequest *>(argument);
+  if (!pdr->starts_with(pwm_spindle_control_checksum)) return;
+
+  if (pdr->second_element_is(get_spindle_status_checksum)) {
+    const auto *t = static_cast<spindle_status *>(pdr->get_data_ptr());
+    this->set_factor(t->factor);
+    pdr->set_taken();
+    return;
+  }
+  if (pdr->second_element_is(turn_off_spindle_checksum)) {
+    this->turn_off();
+    pdr->set_taken();
+  }
+}
+
+// CRC-16/CCITT (poly 0x1021, init 0x0000), VESC packet protocol.
+uint16_t VESCSpindleControl::vesc_crc16(const uint8_t *buf, const uint16_t len) {
+  uint16_t crc = 0;
+  for (uint16_t i = 0; i < len; i++) {
+    crc ^= static_cast<uint16_t>(buf[i]) << 8;
+    for (uint8_t bit = 0; bit < 8; bit++) {
+      if (crc & 0x8000)
+        crc = (crc << 1) ^ 0x1021;
+      else
+        crc <<= 1;
+    }
+  }
+  return crc;
+}
+
+// VESC short packet (payload <= 256 B):  0x02  len(1)  payload  crc16(2)  0x03
+uint16_t VESCSpindleControl::vesc_build_packet(uint8_t *out, const uint8_t *payload, const uint16_t plen) {
+  uint16_t idx = 0;
+  out[idx++] = 0x02;
+  out[idx++] = static_cast<uint8_t>(plen);
+  for (uint16_t i = 0; i < plen; i++) out[idx++] = payload[i];
+  wbe16(&out[idx], vesc_crc16(payload, plen));
+  idx += 2;
+  out[idx++] = 0x03;
+  return idx;
+}
+
+bool VESCSpindleControl::extract_vesc_payload(const uint8_t *frame, const uint16_t frame_len, const uint8_t **payload,
+                                              uint16_t *payload_len) {
+  if (payload) *payload = nullptr;
+  if (payload_len) *payload_len = 0;
+
+  if (frame_len < 6 || frame[0] != 0x02) return false;
+
+  const uint8_t plen = frame[1];
+  const uint16_t expected_len = static_cast<uint16_t>(plen) + 5;
+  if (plen < 1 || frame_len != expected_len || frame[expected_len - 1] != 0x03) return false;
+
+  const uint8_t *payload_start = &frame[2];
+
+  const uint8_t crc_bytes[2] = {frame[2 + plen], frame[2 + plen + 1]};
+  if (be16(crc_bytes) != vesc_crc16(payload_start, plen)) return false;
+
+  if (payload) *payload = payload_start;
+  if (payload_len) *payload_len = plen;
+  return true;
+}

--- a/src/modules/tools/spindle/VESCSpindleControl.h
+++ b/src/modules/tools/spindle/VESCSpindleControl.h
@@ -1,0 +1,136 @@
+/*
+ * VESC spindle control over USB CDC.
+ *
+ * Targets VESC FW 6.x packet protocol. All runtime USB transfers are
+ * non-blocking so stepper timing is never affected.
+ */
+
+#ifndef VESC_SPINDLE_CONTROL_H
+#define VESC_SPINDLE_CONTROL_H
+
+#include <cstdint>
+
+#include "SpindleControl.h"
+#include "USBHostCDC.h"
+
+// COMM_PACKET_ID values we use (VESC FW 6.x).
+enum VESCCommPacketId {
+  COMM_FW_VERSION = 0,
+  COMM_GET_VALUES = 4,
+  COMM_SET_RPM = 8,
+  COMM_ALIVE = 30
+};
+
+enum VESCCommState {
+  VESC_COMM_IDLE = 0,
+  VESC_COMM_SEND_PENDING,
+  VESC_COMM_SEND_WAIT,
+  VESC_COMM_RECV_WAIT,
+  VESC_COMM_PROCESS
+};
+
+enum VESCRxPacketState { VESC_RX_INCOMPLETE = 0, VESC_RX_COMPLETE, VESC_RX_INVALID };
+
+class VESCSpindleControl : public SpindleControl {
+ public:
+  VESCSpindleControl() = default;
+
+  void on_module_loaded() override;
+  void on_idle(void *argument) override;
+  void on_get_public_data(void *argument) override;
+  void on_set_public_data(void *argument) override;
+
+ private:
+  void turn_on() override;
+  void turn_off() override;
+  void set_speed(int rpm) override;
+  void report_speed() override;
+  void set_p_term(float) override {}
+  void set_i_term(float) override {}
+  void set_d_term(float) override {}
+  void report_settings() override {}
+  void set_factor(float f) override;
+
+  static uint16_t vesc_crc16(const uint8_t *buf, uint16_t len);
+  static uint16_t vesc_build_packet(uint8_t *out, const uint8_t *payload, uint16_t plen);
+  static bool extract_vesc_payload(const uint8_t *frame, uint16_t frame_len, const uint8_t **payload,
+                                   uint16_t *payload_len);
+  void reset_rx_packet();
+  VESCRxPacketState append_rx_packet_bytes(const volatile uint8_t *buf, uint32_t len);
+  void queue_set_rpm(int32_t erpm);
+  void queue_get_values();
+  void queue_alive();
+  bool parse_get_values(const uint8_t *buf, uint16_t len);
+
+  void comm_poll();
+  void handle_usb_disconnected();
+  void schedule_next_vesc_command(uint32_t now_us);
+  void start_pending_send();
+  void handle_send_wait(CDCXferState xfer_state);
+  void handle_recv_wait(CDCXferState xfer_state);
+  void process_pending_response();
+
+  // CDC enumeration only proves that the USB serial endpoint is present. This
+  // handshake proves the VESC packet protocol is answering before any spindle
+  // command is accepted.
+  bool verify_vesc_protocol();
+  bool wait_for_usb_transfer(CDCXferState active_state);
+  void handle_comm_error(const char *reason);
+  void dwell_after_spindle_change();
+  int32_t commanded_rpm() const;
+  void reset_stall_monitor();
+  bool vesc_timeout_status_is_stale() const;
+
+  static void raise_spindle_alarm(const char *reason);
+
+  USBHostCDC usb{};
+
+  int32_t pole_pairs = 2;
+  int32_t default_rpm = 10000;
+  int32_t max_rpm = 15000;
+  int32_t min_rpm = 3000;
+  int delay_s = 3;
+  uint32_t poll_interval_ms = 200;
+  int32_t stall_rpm = 2000;
+  uint32_t stall_us = 1000000;
+  int32_t stall_current = 1500;  // same A * 100 units as VESC telemetry
+  bool ignore_on_halt = false;
+
+  // vesc_* fields hold the raw fixed-point values from the wire.
+  int32_t current_rpm = 0;  // mechanical RPM
+  int32_t target_rpm = 0;
+  float factor = 100.0f;      // M223 override, percent
+  int16_t vesc_voltage = 0;   // V * 10
+  int32_t vesc_current = 0;   // A * 100
+  int16_t vesc_temp_mos = 0;  // deg C * 10
+  uint8_t vesc_fault_code = 0;
+  uint8_t vesc_status = 0;
+
+  uint32_t stall_timer = 0;
+  uint32_t stall_monitor_start = 0;
+  uint32_t stall_monitor_seq = 0;
+  bool stall_speed_seen = false;
+
+  VESCCommState comm_state = VESC_COMM_IDLE;
+  uint8_t pkt_buf[64]{};
+  uint16_t pkt_len = 0;
+  uint8_t rx_pkt_buf[128]{};
+  uint16_t rx_pkt_len = 0;
+  uint32_t rx_start_time = 0;
+  uint32_t last_poll_time = 0;
+  uint32_t last_alive_time = 0;
+  uint32_t last_timeout_reset_cmd_time = 0;
+  uint8_t pending_cmd = 0;
+  bool speed_update_pending = false;
+  uint32_t telemetry_seq = 0;
+
+  // Init can fail before the normal status path is ready, so the alarm is
+  // deferred to on_idle. Communication alarms are latched only until the
+  // operator clears the halt and tries to start the spindle again.
+  bool failed_init = false;
+  bool init_pending = false;
+  bool comm_error_halted = false;
+  bool protocol_ok = false;
+};
+
+#endif  // VESC_SPINDLE_CONTROL_H


### PR DESCRIPTION
Add a USB CDC host path and VESC spindle mode for VESC FW 6.x. Enable it with spindle.type vesc and usb_msc.enable false so the VESC owns the LPC1768 USB host port.

The driver honors shared spindle config for default/min/max RPM, delay_s, ignore_on_halt, and stall thresholds, with VESC-specific options for pole pairs, telemetry polling, and stall current.

It verifies the protocol at boot, sends RPM setpoints, polls telemetry, publishes spindle status, and raises spindle alarms for VESC faults, stalls, disconnects, or runtime USB transfer failures.

Place OHCI DMA data in AHB SRAM and keep the driver build-time optional with NO_VESC_SPINDLE=1.

Full disclosure: LLMs were used in making this changeset. I, @f355, have read every single line of the diff and sign off under this PR as if it was made by me without LLM assistance.