### PR TITLE
updating halt messages to all use the same format

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -761,7 +761,7 @@ void Kernel::write_eeprom_data()
 		}
 	}
 	if (result != 0) {
-		this->streams->printf("ALARM: EEPROM data write error:%d\n",pagenum);
+		this->streams->printf("ERROR: EEPROM data write error:%d\n",pagenum);
 	} else {
 //		this->streams->printf("EEPROM data write finished.\n");
 	}
@@ -799,7 +799,7 @@ void Kernel::erase_eeprom_data()
 		}
 	}
 	if (result != 0) {
-		this->streams->printf("ALARM: EEPROM data erase error.\n");
+		this->streams->printf("ERROR: EEPROM data erase error.\n");
 	} else {
 		this->streams->printf("EEPROM data erase finished.\n");
 	}
@@ -943,7 +943,7 @@ void Kernel::write_Factory_data()
 		}
 	}
 	if (result != 0) {
-		this->streams->printf("ALARM: FACTORY setting data write error:%d\n",pagenum);
+		this->streams->printf("ERROR: FACTORY setting data write error:%d\n",pagenum);
 	} 
 }
 
@@ -979,7 +979,7 @@ void Kernel::erase_Factory_data()
 		}
 	}
 	if (result != 0) {
-		this->streams->printf("ALARM: FACTORY setting data erase error.\n");
+		this->streams->printf("ERROR: FACTORY setting data erase error.\n");
 	}
 }
 

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -276,7 +276,7 @@ try_again:
 							// disables heaters and motors, ignores further incoming Gcode and clears block queue
 							THEKERNEL->set_halt_reason(MANUAL);
 							
-							THEKERNEL->streams->printf("ALARM: ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
+							THEKERNEL->streams->printf("ERROR: ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
 							THEKERNEL->call_event(ON_HALT, nullptr);
 							delete gcode;
 							return;
@@ -435,7 +435,7 @@ try_again:
 					}
 
 					// we cannot continue safely after an error so we enter HALT state
-					new_message.stream->printf("ALARM: error in gcode. See MDI for more details\n");
+					new_message.stream->printf("ERROR: error in gcode. See MDI for more details\n");
 					THEKERNEL->call_event(ON_HALT, nullptr);
 
 				}else if(!sent_ok) {

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -275,8 +275,9 @@ try_again:
 							// this is also handled out-of-band (it is now with ^X in the serial driver)
 							// disables heaters and motors, ignores further incoming Gcode and clears block queue
 							THEKERNEL->set_halt_reason(MANUAL);
+							
+							THEKERNEL->streams->printf("ALARM: ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
 							THEKERNEL->call_event(ON_HALT, nullptr);
-							THEKERNEL->streams->printf("ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
 							delete gcode;
 							return;
 
@@ -434,7 +435,7 @@ try_again:
 					}
 
 					// we cannot continue safely after an error so we enter HALT state
-					new_message.stream->printf("Entering Alarm/Halt state\n");
+					new_message.stream->printf("ALARM: error in gcode. See MDI for more details\n");
 					THEKERNEL->call_event(ON_HALT, nullptr);
 
 				}else if(!sent_ok) {

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -186,9 +186,9 @@ void SerialConsole::on_idle(void * argument)
         THEKERNEL->set_halt_reason(MANUAL);
         
         if(THEKERNEL->is_grbl_mode()) {
-            puts("ALARM: Abort during cycle\r\n", 0);
+            puts("ERROR: Abort during cycle\r\n", 0);
         } else {
-            puts("ALARM: Abort during cycle\r\nM999 or $X to exit HALT state\r\n", 0);
+            puts("ERROR: Abort during cycle\r\nM999 or $X to exit HALT state\r\n", 0);
         }
         THEKERNEL->call_event(ON_HALT, nullptr);
     }

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -184,12 +184,13 @@ void SerialConsole::on_idle(void * argument)
     if (halt_flag) {
         halt_flag= false;
         THEKERNEL->set_halt_reason(MANUAL);
-        THEKERNEL->call_event(ON_HALT, nullptr);
+        
         if(THEKERNEL->is_grbl_mode()) {
             puts("ALARM: Abort during cycle\r\n", 0);
         } else {
-            puts("HALTED, M999 or $X to exit HALT state\r\n", 0);
+            puts("ALARM: Abort during cycle\r\nM999 or $X to exit HALT state\r\n", 0);
         }
+        THEKERNEL->call_event(ON_HALT, nullptr);
     }
 }
 

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -185,7 +185,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 return THEKERNEL->local_vars[var_num -101];
             }
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
+            THEKERNEL->streams->printf("ERROR: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
             
             return NAN;
@@ -200,7 +200,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 return THEKERNEL->probe_outputs[var_num - 151];
             }
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
+            THEKERNEL->streams->printf("ERROR: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
             return NAN;
 
@@ -212,7 +212,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
             }
             
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
+            THEKERNEL->streams->printf("ERROR: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
             return NAN;
         }else //system variables
@@ -300,7 +300,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
 
                 default:
                     THEKERNEL->set_halt_reason(MANUAL);
-                    THEKERNEL->streams->printf("ALARM: Variable %d not found \n", var_num);
+                    THEKERNEL->streams->printf("ERROR: Variable %d not found \n", var_num);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     
                     return NAN;
@@ -314,7 +314,7 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
 float Gcode::parse_expression(const char*& expr) const {
     if (*expr == ']') {
         THEKERNEL->set_halt_reason(MANUAL);
-        THEKERNEL->streams->printf("ALARM: Mismatched closing bracket ']' without opening '['\n");
+        THEKERNEL->streams->printf("ERROR: Mismatched closing bracket ']' without opening '['\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         return NAN;
     }
@@ -417,7 +417,7 @@ float Gcode::parse_term(const char*& expr) const {
                     result /= next_factor;
                 } else {
                     THEKERNEL->set_halt_reason(MANUAL);
-                    THEKERNEL->streams->printf("ALARM: Division by zero\n");
+                    THEKERNEL->streams->printf("ERROR: Division by zero\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     
                     return NAN;
@@ -431,7 +431,7 @@ float Gcode::parse_term(const char*& expr) const {
                 result = fmod(result, next_factor);
             } else {
                 THEKERNEL->set_halt_reason(MANUAL);
-                THEKERNEL->streams->printf("ALARM: Modulo by zero\n");
+                THEKERNEL->streams->printf("ERROR: Modulo by zero\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 
                 return NAN;
@@ -508,13 +508,13 @@ float Gcode::parse_factor(const char*& expr) const {
                 }
             } else {
                 THEKERNEL->set_halt_reason(MANUAL);
-                THEKERNEL->streams->printf("ALARM: Mismatched brackets in function argument\n");
+                THEKERNEL->streams->printf("ERROR: Mismatched brackets in function argument\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 return NAN;
             }
         } else {
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Expected '[' after function name\n");
+            THEKERNEL->streams->printf("ERROR: Expected '[' after function name\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             return NAN;
         }
@@ -525,7 +525,7 @@ float Gcode::parse_factor(const char*& expr) const {
             expr++; // Skip ']'
         } else {
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Mismatched brackets in expression\n");
+            THEKERNEL->streams->printf("ERROR: Mismatched brackets in expression\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             return NAN;
         }
@@ -548,7 +548,7 @@ float Gcode::parse_factor(const char*& expr) const {
 
         if (end == original_expr) {
             THEKERNEL->set_halt_reason(MANUAL);
-            THEKERNEL->streams->printf("ALARM: Invalid number in expression, %c\n", *expr);
+            THEKERNEL->streams->printf("ERROR: Invalid number in expression, %c\n", *expr);
             THEKERNEL->call_event(ON_HALT, nullptr);
             return NAN;
         }
@@ -571,9 +571,8 @@ float Gcode::evaluate_expression(const char* expr, char** endptr) const {
     // Check for unexpected closing bracket at the beginning
     if (*expr == ']') {
         THEKERNEL->set_halt_reason(MANUAL);
-        THEKERNEL->streams->printf("ALARM: Mismatched closing bracket ']' without opening '['\n");
+        THEKERNEL->streams->printf("ERROR: Mismatched closing bracket ']' without opening '['\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        
         return NAN;
     }
 
@@ -582,8 +581,8 @@ float Gcode::evaluate_expression(const char* expr, char** endptr) const {
     // Ensure any remaining unmatched brackets are caught
     if (*expr == ']') {
         THEKERNEL->set_halt_reason(MANUAL);
+        THEKERNEL->streams->printf("ERROR: Mismatched closing bracket at end of expression\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("Mismatched closing bracket at end of expression\n");
         return NAN;
     }
 

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -185,8 +185,9 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 return THEKERNEL->local_vars[var_num -101];
             }
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Variable %d not set \n", var_num);
+            
             return NAN;
         
         } else if(var_num == 150)
@@ -199,8 +200,8 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
                 return THEKERNEL->probe_outputs[var_num - 151];
             }
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Variable %d not set \n", var_num);
             return NAN;
 
         } else if(var_num >= 501 && var_num <= 520)
@@ -211,8 +212,8 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
             }
             
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Variable %d not set \n", var_num);
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Variable %d not set \n", var_num);
             return NAN;
         }else //system variables
         {
@@ -299,8 +300,9 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
 
                 default:
                     THEKERNEL->set_halt_reason(MANUAL);
+                    THEKERNEL->streams->printf("ALARM: Variable %d not found \n", var_num);
                     THEKERNEL->call_event(ON_HALT, nullptr);
-                    THEKERNEL->streams->printf("Variable %d not found \n", var_num);
+                    
                     return NAN;
                     break;
             }
@@ -312,8 +314,8 @@ float Gcode::get_variable_value(const char* expr, char** endptr) const{
 float Gcode::parse_expression(const char*& expr) const {
     if (*expr == ']') {
         THEKERNEL->set_halt_reason(MANUAL);
+        THEKERNEL->streams->printf("ALARM: Mismatched closing bracket ']' without opening '['\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("Mismatched closing bracket ']' without opening '['\n");
         return NAN;
     }
 
@@ -415,8 +417,9 @@ float Gcode::parse_term(const char*& expr) const {
                     result /= next_factor;
                 } else {
                     THEKERNEL->set_halt_reason(MANUAL);
+                    THEKERNEL->streams->printf("ALARM: Division by zero\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
-                    THEKERNEL->streams->printf("Division by zero\n");
+                    
                     return NAN;
                 }
             }
@@ -428,8 +431,9 @@ float Gcode::parse_term(const char*& expr) const {
                 result = fmod(result, next_factor);
             } else {
                 THEKERNEL->set_halt_reason(MANUAL);
+                THEKERNEL->streams->printf("ALARM: Modulo by zero\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
-                THEKERNEL->streams->printf("Modulo by zero\n");
+                
                 return NAN;
             }
         }
@@ -504,14 +508,14 @@ float Gcode::parse_factor(const char*& expr) const {
                 }
             } else {
                 THEKERNEL->set_halt_reason(MANUAL);
+                THEKERNEL->streams->printf("ALARM: Mismatched brackets in function argument\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
-                THEKERNEL->streams->printf("Mismatched brackets in function argument\n");
                 return NAN;
             }
         } else {
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Expected '[' after function name\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Expected '[' after function name\n");
             return NAN;
         }
     } else if (*expr == '[') {
@@ -521,8 +525,8 @@ float Gcode::parse_factor(const char*& expr) const {
             expr++; // Skip ']'
         } else {
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Mismatched brackets in expression\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Mismatched brackets in expression\n");
             return NAN;
         }
     } else if (*expr == '#') {
@@ -544,8 +548,8 @@ float Gcode::parse_factor(const char*& expr) const {
 
         if (end == original_expr) {
             THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ALARM: Invalid number in expression, %c\n", *expr);
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Invalid number in expression, %c\n", *expr);
             return NAN;
         }
         expr = end;
@@ -567,8 +571,9 @@ float Gcode::evaluate_expression(const char* expr, char** endptr) const {
     // Check for unexpected closing bracket at the beginning
     if (*expr == ']') {
         THEKERNEL->set_halt_reason(MANUAL);
+        THEKERNEL->streams->printf("ALARM: Mismatched closing bracket ']' without opening '['\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("Mismatched closing bracket ']' without opening '['\n");
+        
         return NAN;
     }
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1433,7 +1433,7 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
         if (f_value <= 0.0F) {
             gcode->is_error = true;
             gcode->txt_after_ok = (f_value == 0 ? "Undefined feed rate\n" : "feed rate < 0\n");
-            THEKERNEL->streams->printf(f_value == 0 ? "Alarm:Undefined feed rate\n" : "Alarm:feed rate < 0\n");
+            THEKERNEL->streams->printf(f_value == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
             return;
         }
         if( motion_mode == SEEK )
@@ -1442,8 +1442,8 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
             this->feed_rate = f_value;
     } else if (motion_mode != SEEK && this->inverse_time_mode) {
         THEKERNEL->set_halt_reason(MANUAL);
+        THEKERNEL->streams->printf("ALARM: Inverse-time feed mode requires F parameter on every G01/G02/G03 line.\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("Inverse-time feed mode requires F parameter on every G01/G02/G03 line.\n");
         return;
     }
 
@@ -1708,13 +1708,7 @@ bool Robot::append_milestone(const float target[], float feed_rate, unsigned int
                 ( (!isnan(soft_endstop_max[i]) && transformed_target[i] > soft_endstop_max[i]) && deltas[i] > 0 )
             ) {
                 if(soft_endstop_halt && !THECONVEYOR->is_continuous_mode()) {
-                    if(THEKERNEL->is_grbl_mode()) {
-                        THEKERNEL->streams->printf("error:");
-                    }else{
-                        THEKERNEL->streams->printf("Error: ");
-                    }
-
-                    THEKERNEL->streams->printf("Soft Endstop %c was exceeded - reset or $X or M999 required\n", i+'X');
+                    THEKERNEL->streams->printf("ALARM: Soft Endstop %c was exceeded - reset or $X or M999 required\n", i+'X');
                     THEKERNEL->set_halt_reason(SOFT_LIMIT);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     return false;
@@ -1725,11 +1719,6 @@ bool Robot::append_milestone(const float target[], float feed_rate, unsigned int
 
                 } else if (!THECONVEYOR->is_continuous_mode()) {
                     // ignore it
-                    if(THEKERNEL->is_grbl_mode()) {
-                        THEKERNEL->streams->printf("error:");
-                    }else{
-                        THEKERNEL->streams->printf("Error: ");
-                    }
                     THEKERNEL->streams->printf("Soft Endstop %c was exceeded - entire move ignored\n", i+'X');
                     return false;
                 }
@@ -1981,7 +1970,7 @@ bool Robot::append_line(Gcode *gcode, const float target[], float feed_rate, flo
     if(feed_rate <= 0.0F) {
         gcode->is_error= true;
         gcode->txt_after_ok= (feed_rate == 0 ? "Undefined feed rate\n" : "feed rate < 0\n");
-        THEKERNEL->streams->printf(feed_rate == 0 ? "Alarm:Undefined feed rate\n" : "Alarm:feed rate < 0\n");
+        THEKERNEL->streams->printf(feed_rate == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
         return false;
     }
 
@@ -2084,7 +2073,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float rotated_
     if(this->feed_rate <= 0.0F) {
         gcode->is_error= true;
         gcode->txt_after_ok= (this->feed_rate == 0 ? "Undefined feed rate" : "feed rate < 0");
-        THEKERNEL->streams->printf(this->feed_rate == 0 ? "Alarm:Undefined feed rate\n" : "Alarm:feed rate < 0\n");
+        THEKERNEL->streams->printf(this->feed_rate == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
         return false;
     }
     float offset_rotated[3]{0, 0, 0};
@@ -2361,7 +2350,7 @@ bool Robot::is_homed_all_axes()
     }
     for (int i = X_AXIS; i <= Z_AXIS; ++i) {
         if (!this->is_homed(i)){
-            THEKERNEL->streams->printf("Machine has not been homed\nUse M888 To disable homed check temporarily\n");
+            THEKERNEL->streams->printf("ALARM: Machine has not been homed. Use M888 to disable homed check\n");
             THEKERNEL->set_halt_reason(HOME_FAIL);
             THEKERNEL->call_event(ON_HALT, nullptr);
             return false;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -654,7 +654,7 @@ void Robot::on_gcode_received(void *argument)
                         // notify atc module to change ref tool mcs if Z wcs offset is chaned
                         if (gcode->has_letter('Z') && gcode->get_int('L') == 20) {
                             if (tool_not_calibrated && (THEKERNEL->eeprom_data->TOOL == 0 || THEKERNEL->eeprom_data->TOOL >= 999990)){
-                                THEKERNEL->streams->printf("ALARM: Probe not calibrated. Please calibrate probe before probing.\n");
+                                THEKERNEL->streams->printf("ERROR: Probe not calibrated. Please calibrate probe before probing.\n");
                                 THEKERNEL->call_event(ON_HALT, nullptr);
                                 THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
                                 return;
@@ -742,7 +742,7 @@ void Robot::on_gcode_received(void *argument)
             // Inch mode is broken see https://github.com/Carvera-Community/Carvera_Community_Firmware/issues/209
             // case 20: this->inch_mode = true;   break;
             case 20: {
-                THEKERNEL->streams->printf("ALARM: Imperial Units are unsupported\n");
+                THEKERNEL->streams->printf("ERROR: Imperial Units are unsupported\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(MANUAL);
                 return;
@@ -1433,7 +1433,7 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
         if (f_value <= 0.0F) {
             gcode->is_error = true;
             gcode->txt_after_ok = (f_value == 0 ? "Undefined feed rate\n" : "feed rate < 0\n");
-            THEKERNEL->streams->printf(f_value == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
+            THEKERNEL->streams->printf(f_value == 0 ? "ERROR: Undefined feed rate\n" : "ERROR: feed rate < 0\n");
             return;
         }
         if( motion_mode == SEEK )
@@ -1442,7 +1442,7 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
             this->feed_rate = f_value;
     } else if (motion_mode != SEEK && this->inverse_time_mode) {
         THEKERNEL->set_halt_reason(MANUAL);
-        THEKERNEL->streams->printf("ALARM: Inverse-time feed mode requires F parameter on every G01/G02/G03 line.\n");
+        THEKERNEL->streams->printf("ERROR: Inverse-time feed mode requires F parameter on every G01/G02/G03 line.\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         return;
     }
@@ -1708,7 +1708,7 @@ bool Robot::append_milestone(const float target[], float feed_rate, unsigned int
                 ( (!isnan(soft_endstop_max[i]) && transformed_target[i] > soft_endstop_max[i]) && deltas[i] > 0 )
             ) {
                 if(soft_endstop_halt && !THECONVEYOR->is_continuous_mode()) {
-                    THEKERNEL->streams->printf("ALARM: Soft Endstop %c was exceeded - reset or $X or M999 required\n", i+'X');
+                    THEKERNEL->streams->printf("ERROR: Soft Endstop %c was exceeded - reset or $X or M999 required\n", i+'X');
                     THEKERNEL->set_halt_reason(SOFT_LIMIT);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     return false;
@@ -1970,7 +1970,7 @@ bool Robot::append_line(Gcode *gcode, const float target[], float feed_rate, flo
     if(feed_rate <= 0.0F) {
         gcode->is_error= true;
         gcode->txt_after_ok= (feed_rate == 0 ? "Undefined feed rate\n" : "feed rate < 0\n");
-        THEKERNEL->streams->printf(feed_rate == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
+        THEKERNEL->streams->printf(feed_rate == 0 ? "ERROR: Undefined feed rate\n" : "ERROR: feed rate < 0\n");
         return false;
     }
 
@@ -2073,7 +2073,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float rotated_
     if(this->feed_rate <= 0.0F) {
         gcode->is_error= true;
         gcode->txt_after_ok= (this->feed_rate == 0 ? "Undefined feed rate" : "feed rate < 0");
-        THEKERNEL->streams->printf(this->feed_rate == 0 ? "ALARM: Undefined feed rate\n" : "ALARM: feed rate < 0\n");
+        THEKERNEL->streams->printf(this->feed_rate == 0 ? "ERROR: Undefined feed rate\n" : "ERROR: feed rate < 0\n");
         return false;
     }
     float offset_rotated[3]{0, 0, 0};
@@ -2350,7 +2350,7 @@ bool Robot::is_homed_all_axes()
     }
     for (int i = X_AXIS; i <= Z_AXIS; ++i) {
         if (!this->is_homed(i)){
-            THEKERNEL->streams->printf("ALARM: Machine has not been homed. Use M888 to disable homed check\n");
+            THEKERNEL->streams->printf("ERROR: Machine has not been homed. Use M888 to disable homed check\n");
             THEKERNEL->set_halt_reason(HOME_FAIL);
             THEKERNEL->call_event(ON_HALT, nullptr);
             return false;

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -2000,8 +2000,8 @@ void ATCHandler::home_clamp()
 
     if (!atc_home_info.triggered) {
         THEKERNEL->set_halt_reason(ATC_HOME_FAIL);
+		THEKERNEL->streams->printf("ALARM: Homing atc failed - check the atc max travel settings\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->streams->printf("ERROR: Homing atc failed - check the atc max travel settings\n");
         return;
     } else {
     	THEROBOT->reset_position_from_current_actuator_position();
@@ -2114,12 +2114,12 @@ void ATCHandler::set_tool_offset(uint8_t repeat_count)
 		} else{
 			THEKERNEL->eeprom_data->REFMZ = -10;
 			THEKERNEL->write_eeprom_data();
-			THEKERNEL->call_event(ON_HALT, nullptr);
 			tool_offset = cur_tool_mz - ref_tool_mz;
 			const float offset[3] = {0.0, 0.0, tool_offset};
 			THEROBOT->saveToolOffset(offset, cur_tool_mz);
 			THEKERNEL->set_halt_reason(MANUAL);
-			THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+			THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+			THEKERNEL->call_event(ON_HALT, nullptr);
 			return;
 		}
     }
@@ -2143,12 +2143,13 @@ void ATCHandler::set_tlo_by_offset(float z_axis_offset){
 	}else{
 		THEKERNEL->eeprom_data->REFMZ = -10;
 		THEKERNEL->write_eeprom_data();
-		THEKERNEL->call_event(ON_HALT, nullptr);
+		
 		tool_offset = cur_tool_mz - ref_tool_mz;
 		const float offset[3] = {0.0, 0.0, tool_offset};
 		THEROBOT->saveToolOffset(offset, cur_tool_mz);
 		THEKERNEL->set_halt_reason(MANUAL);
-		THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+		THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+		THEKERNEL->call_event(ON_HALT, nullptr);
 		return;
 	}
 
@@ -2183,12 +2184,12 @@ void ATCHandler::on_gcode_received(void *argument)
     	    		
 					if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
 					{
-	    	    		THEKERNEL->streams->printf("Error: can not do ATC while spindle is running.\n");
+	    	    		THEKERNEL->streams->printf("ALARM: can not do ATC while spindle is running.\n");
 				        THEKERNEL->set_halt_reason(ATC_HOME_FAIL);
 				    }
 				    else	//Manual Tool Change
 				    {
-				    	THEKERNEL->streams->printf("Error: can not change tool while spindle is running.\n");
+				    	THEKERNEL->streams->printf("ALARM: can not change tool while spindle is running.\n");
 			        	THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 				    }
 			        THEKERNEL->call_event(ON_HALT, nullptr);
@@ -2235,13 +2236,13 @@ void ATCHandler::on_gcode_received(void *argument)
             if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
 			{
 	            if (new_tool > this->max_manual_tool_number){
-					THEKERNEL->call_event(ON_HALT, nullptr);
 					THEKERNEL->set_halt_reason(ATC_TOOL_INVALID);
 					gcode->stream->printf("ALARM: Invalid tool: T%d\r\n", new_tool);
-				} else if (new_tool >= 0 && !this->is_custom_tool_defined(new_tool) && new_tool <= this->tool_number && CARVERA == THEKERNEL->factory_set->MachineModel) {
 					THEKERNEL->call_event(ON_HALT, nullptr);
+				} else if (new_tool >= 0 && !this->is_custom_tool_defined(new_tool) && new_tool <= this->tool_number && CARVERA == THEKERNEL->factory_set->MachineModel) {
 					THEKERNEL->set_halt_reason(ATC_TOOL_INVALID);
 					gcode->stream->printf("ALARM: Tool T%d not defined in tool slots\r\n", new_tool);
+					THEKERNEL->call_event(ON_HALT, nullptr);
 				} else if (new_tool != active_tool) {
 					if (new_tool > -1 && THEKERNEL->get_laser_mode() && CARVERA == THEKERNEL->factory_set->MachineModel) {
 						THEKERNEL->streams->printf("ALARM: Can not do ATC in laser mode!\n");
@@ -2513,9 +2514,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (gcode->has_letter('H')) {
 					tolerance = gcode->get_value('H');
 					if (tolerance < 0.02) {
-						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
-						THEKERNEL->call_event(ON_HALT, nullptr);
+						THEKERNEL->streams->printf("ALARM: Tool Break Check - tolerance set too small\n");
 						THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
+						THEKERNEL->call_event(ON_HALT, nullptr);
 						return;
 					}
 				}
@@ -2557,9 +2558,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (gcode->has_letter('H')) {
 		    		tolerance = gcode->get_value('H');
 					if (tolerance < 0.02) {
-						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->streams->printf("ALARM: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 						THEKERNEL->call_event(ON_HALT, nullptr);
-        				THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 						return;
 					}
 
@@ -2576,9 +2577,9 @@ void ATCHandler::on_gcode_received(void *argument)
 				THEKERNEL->streams->printf("Old: %.3f , new: %.3f\n",tlo,new_tlo);
 				//test for breakage
 				if (fabs(tlo - new_tlo) > tolerance) {
-					THEKERNEL->streams->printf("ERROR: Tool Break Check - check tool for breakage\n");
-					THEKERNEL->call_event(ON_HALT, nullptr);
+					THEKERNEL->streams->printf("ALARM: Tool Break Check - check tool for breakage\n");
 					THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
+					THEKERNEL->call_event(ON_HALT, nullptr);
 					return;
 				}
 
@@ -2630,22 +2631,22 @@ void ATCHandler::on_gcode_received(void *argument)
 					// check true
 					if (!laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
-				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ALARM: Unexpected tool absence detected, please check tool rack!\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				} else if ((gcode->subcode == 2) && !this->disable_toolsensor) {
 					// check false
 					if (laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);
-				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Unexpected tool presence detected, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ALARM: Unexpected tool presence detected, please check tool rack!\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				} else if (gcode->subcode == 3) {
 					// check if the probe was triggered
 					if (!probe_detect()) {
 				        THEKERNEL->set_halt_reason(PROBE_INVALID);
-				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Wireless probe dead or not set, please charge or set first!\n");
+				        THEKERNEL->streams->printf("ALARM: Wireless probe dead or not set, please charge or set first!\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				}
 			}
@@ -2656,8 +2657,8 @@ void ATCHandler::on_gcode_received(void *argument)
 					// check if the probe was triggered
 					if (!probe_detect()) {
 				        THEKERNEL->set_halt_reason(PROBE_INVALID);
+						THEKERNEL->streams->printf("ALARM: Probe dead or not set, please charge or set first!\n");
 				        THEKERNEL->call_event(ON_HALT, nullptr);
-				        THEKERNEL->streams->printf("ERROR: Probe dead or not set, please charge or set first!\n");
 				}
 			}
 			}
@@ -2684,8 +2685,8 @@ void ATCHandler::on_gcode_received(void *argument)
 
 				} else {
 					THEKERNEL->set_halt_reason(ATC_NO_TOOL);
+					THEKERNEL->streams->printf("ALARM: No tool was set!\n");
 					THEKERNEL->call_event(ON_HALT, nullptr);
-					THEKERNEL->streams->printf("ERROR: No tool was set!\n");
 
 				}
 			} else if (gcode->subcode == 3) { //set current tool offset
@@ -2701,12 +2702,12 @@ void ATCHandler::on_gcode_received(void *argument)
 					}else{
 						THEKERNEL->eeprom_data->REFMZ = -10;
 						THEKERNEL->write_eeprom_data();
-						THEKERNEL->call_event(ON_HALT, nullptr);
 						tool_offset = cur_tool_mz - ref_tool_mz;
 						const float offset[3] = {0.0, 0.0, tool_offset};
 						THEROBOT->saveToolOffset(offset, cur_tool_mz);
 						THEKERNEL->set_halt_reason(MANUAL);
-						THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+						THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+						THEKERNEL->call_event(ON_HALT, nullptr);
 						return;
 					}
 				}

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -818,14 +818,14 @@ void ATCHandler::calibrate_a_axis_cor(Gcode *gcode) //M469.6
 	}
 
 	if (!((this->active_tool == 0) || (this->active_tool >= 999990))) {
-		THEKERNEL->streams->printf("ALARM: Attempted to probe with an improper tool. A 3-axis probe must be installed (tool 0 or tool >= 999990).\n");
+		THEKERNEL->streams->printf("ERROR: Attempted to probe with an improper tool. A 3-axis probe must be installed (tool 0 or tool >= 999990).\n");
 		THEKERNEL->call_event(ON_HALT, nullptr);
 		THEKERNEL->set_halt_reason(PROBE_FAIL);
 		return;
 	}
 
 	if (THEROBOT->get_tool_not_calibrated()) {
-		THEKERNEL->streams->printf("ALARM: Probe not calibrated. Please calibrate the probe TLO before running M469.6.\n");
+		THEKERNEL->streams->printf("ERROR: Probe not calibrated. Please calibrate the probe TLO before running M469.6.\n");
 		THEKERNEL->call_event(ON_HALT, nullptr);
 		THEKERNEL->set_halt_reason(PROBE_FAIL);
 		return;
@@ -2000,7 +2000,7 @@ void ATCHandler::home_clamp()
 
     if (!atc_home_info.triggered) {
         THEKERNEL->set_halt_reason(ATC_HOME_FAIL);
-		THEKERNEL->streams->printf("ALARM: Homing atc failed - check the atc max travel settings\n");
+		THEKERNEL->streams->printf("ERROR: Homing atc failed - check the atc max travel settings\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         return;
     } else {
@@ -2118,7 +2118,7 @@ void ATCHandler::set_tool_offset(uint8_t repeat_count)
 			const float offset[3] = {0.0, 0.0, tool_offset};
 			THEROBOT->saveToolOffset(offset, cur_tool_mz);
 			THEKERNEL->set_halt_reason(MANUAL);
-			THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+			THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
 			THEKERNEL->call_event(ON_HALT, nullptr);
 			return;
 		}
@@ -2148,7 +2148,7 @@ void ATCHandler::set_tlo_by_offset(float z_axis_offset){
 		const float offset[3] = {0.0, 0.0, tool_offset};
 		THEROBOT->saveToolOffset(offset, cur_tool_mz);
 		THEKERNEL->set_halt_reason(MANUAL);
-		THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+		THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
 		THEKERNEL->call_event(ON_HALT, nullptr);
 		return;
 	}
@@ -2184,12 +2184,12 @@ void ATCHandler::on_gcode_received(void *argument)
     	    		
 					if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
 					{
-	    	    		THEKERNEL->streams->printf("ALARM: can not do ATC while spindle is running.\n");
+	    	    		THEKERNEL->streams->printf("ERROR: can not do ATC while spindle is running.\n");
 				        THEKERNEL->set_halt_reason(ATC_HOME_FAIL);
 				    }
 				    else	//Manual Tool Change
 				    {
-				    	THEKERNEL->streams->printf("ALARM: can not change tool while spindle is running.\n");
+				    	THEKERNEL->streams->printf("ERROR: can not change tool while spindle is running.\n");
 			        	THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 				    }
 			        THEKERNEL->call_event(ON_HALT, nullptr);
@@ -2237,15 +2237,15 @@ void ATCHandler::on_gcode_received(void *argument)
 			{
 	            if (new_tool > this->max_manual_tool_number){
 					THEKERNEL->set_halt_reason(ATC_TOOL_INVALID);
-					gcode->stream->printf("ALARM: Invalid tool: T%d\r\n", new_tool);
+					gcode->stream->printf("ERROR: Invalid tool: T%d\r\n", new_tool);
 					THEKERNEL->call_event(ON_HALT, nullptr);
 				} else if (new_tool >= 0 && !this->is_custom_tool_defined(new_tool) && new_tool <= this->tool_number && CARVERA == THEKERNEL->factory_set->MachineModel) {
 					THEKERNEL->set_halt_reason(ATC_TOOL_INVALID);
-					gcode->stream->printf("ALARM: Tool T%d not defined in tool slots\r\n", new_tool);
+					gcode->stream->printf("ERROR: Tool T%d not defined in tool slots\r\n", new_tool);
 					THEKERNEL->call_event(ON_HALT, nullptr);
 				} else if (new_tool != active_tool) {
 					if (new_tool > -1 && THEKERNEL->get_laser_mode() && CARVERA == THEKERNEL->factory_set->MachineModel) {
-						THEKERNEL->streams->printf("ALARM: Can not do ATC in laser mode!\n");
+						THEKERNEL->streams->printf("ERROR: Can not do ATC in laser mode!\n");
 						return;
 					}
 					
@@ -2514,7 +2514,7 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (gcode->has_letter('H')) {
 					tolerance = gcode->get_value('H');
 					if (tolerance < 0.02) {
-						THEKERNEL->streams->printf("ALARM: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
 						THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 						THEKERNEL->call_event(ON_HALT, nullptr);
 						return;
@@ -2558,7 +2558,7 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (gcode->has_letter('H')) {
 		    		tolerance = gcode->get_value('H');
 					if (tolerance < 0.02) {
-						THEKERNEL->streams->printf("ALARM: Tool Break Check - tolerance set too small\n");
+						THEKERNEL->streams->printf("ERROR: Tool Break Check - tolerance set too small\n");
 						THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 						THEKERNEL->call_event(ON_HALT, nullptr);
 						return;
@@ -2577,7 +2577,7 @@ void ATCHandler::on_gcode_received(void *argument)
 				THEKERNEL->streams->printf("Old: %.3f , new: %.3f\n",tlo,new_tlo);
 				//test for breakage
 				if (fabs(tlo - new_tlo) > tolerance) {
-					THEKERNEL->streams->printf("ALARM: Tool Break Check - check tool for breakage\n");
+					THEKERNEL->streams->printf("ERROR: Tool Break Check - check tool for breakage\n");
 					THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 					THEKERNEL->call_event(ON_HALT, nullptr);
 					return;
@@ -2631,21 +2631,21 @@ void ATCHandler::on_gcode_received(void *argument)
 					// check true
 					if (!laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
-				        THEKERNEL->streams->printf("ALARM: Unexpected tool absence detected, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
 						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				} else if ((gcode->subcode == 2) && !this->disable_toolsensor) {
 					// check false
 					if (laser_detect()) {
 				        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);
-				        THEKERNEL->streams->printf("ALARM: Unexpected tool presence detected, please check tool rack!\n");
+				        THEKERNEL->streams->printf("ERROR: Unexpected tool presence detected, please check tool rack!\n");
 						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				} else if (gcode->subcode == 3) {
 					// check if the probe was triggered
 					if (!probe_detect()) {
 				        THEKERNEL->set_halt_reason(PROBE_INVALID);
-				        THEKERNEL->streams->printf("ALARM: Wireless probe dead or not set, please charge or set first!\n");
+				        THEKERNEL->streams->printf("ERROR: Wireless probe dead or not set, please charge or set first!\n");
 						THEKERNEL->call_event(ON_HALT, nullptr);
 					}
 				}
@@ -2657,7 +2657,7 @@ void ATCHandler::on_gcode_received(void *argument)
 					// check if the probe was triggered
 					if (!probe_detect()) {
 				        THEKERNEL->set_halt_reason(PROBE_INVALID);
-						THEKERNEL->streams->printf("ALARM: Probe dead or not set, please charge or set first!\n");
+						THEKERNEL->streams->printf("ERROR: Probe dead or not set, please charge or set first!\n");
 				        THEKERNEL->call_event(ON_HALT, nullptr);
 				}
 			}
@@ -2685,7 +2685,7 @@ void ATCHandler::on_gcode_received(void *argument)
 
 				} else {
 					THEKERNEL->set_halt_reason(ATC_NO_TOOL);
-					THEKERNEL->streams->printf("ALARM: No tool was set!\n");
+					THEKERNEL->streams->printf("ERROR: No tool was set!\n");
 					THEKERNEL->call_event(ON_HALT, nullptr);
 
 				}
@@ -2706,7 +2706,7 @@ void ATCHandler::on_gcode_received(void *argument)
 						const float offset[3] = {0.0, 0.0, tool_offset};
 						THEROBOT->saveToolOffset(offset, cur_tool_mz);
 						THEKERNEL->set_halt_reason(MANUAL);
-						THEKERNEL->streams->printf("ALARM: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
+						THEKERNEL->streams->printf("ERROR: warning, unexpected reference tool length found, reset machine then recalibrate tool\n");
 						THEKERNEL->call_event(ON_HALT, nullptr);
 						return;
 					}
@@ -2801,11 +2801,11 @@ void ATCHandler::on_gcode_received(void *argument)
 				// Do Margin, ZProbe, Auto Leveling based on parameters, change probe tool if needed
 				if (gcode->has_letter('X') && gcode->has_letter('Y')) {
 	        		if (THEKERNEL->get_laser_mode()) {
-	        			THEKERNEL->streams->printf("ALARM: Can not do Automatic work in laser mode!\n");
+	        			THEKERNEL->streams->printf("ERROR: Can not do Automatic work in laser mode!\n");
 	        			return;
 	        		}
 					if ((this->active_tool == 0 || this->active_tool >= 999990) && THEROBOT->get_tool_not_calibrated()){
-						THEKERNEL->streams->printf("ALARM: Probe not calibrated. Please calibrate probe before probing.\n");
+						THEKERNEL->streams->printf("ERROR: Probe not calibrated. Please calibrate probe before probing.\n");
 						THEKERNEL->call_event(ON_HALT, nullptr);
 						THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
 						return;
@@ -2948,7 +2948,7 @@ void ATCHandler::on_gcode_received(void *argument)
 		    			}
 		    		}
 				} else {
-					gcode->stream->printf("ALARM: Miss Automation Parameter: X/Y\r\n");
+					gcode->stream->printf("ERROR: Miss Automation Parameter: X/Y\r\n");
 				}
 			}
 		} else if (gcode->m == 496) {

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -567,7 +567,7 @@ void Endstops::on_idle(void *argument)
 			if(!THEKERNEL->is_grbl_mode()) {
 				THEKERNEL->streams->printf("%c motor alarm triggered - reset required\n", i->axis);
 			}else{
-				THEKERNEL->streams->printf("ALARM: %c motor alarm triggered -  reset required\n", i->axis);
+				THEKERNEL->streams->printf("ERROR: %c motor alarm triggered -  reset required\n", i->axis);
 			}
 			i->debounce= 0;
 			// disables heaters and motors, ignores incoming Gcode and flushes block queue
@@ -595,7 +595,7 @@ void Endstops::on_idle(void *argument)
 	                if(!THEKERNEL->is_grbl_mode()) {
 	                    THEKERNEL->streams->printf("Limit switch %c%c was hit - reset or M999 required\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
 	                }else{
-	                    THEKERNEL->streams->printf("ALARM: Hard limit %c%c\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
+	                    THEKERNEL->streams->printf("ERROR: Hard limit %c%c\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
 	                }
 	                this->status = LIMIT_TRIGGERED;
 	                i->debounce = 0;
@@ -615,7 +615,7 @@ void Endstops::on_idle(void *argument)
 	                if(!THEKERNEL->is_grbl_mode()) {
 	                    THEKERNEL->streams->printf("Limit switch %c%c was hit - reset or M999 required\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
 	                }else{
-	                    THEKERNEL->streams->printf("ALARM: Hard limit %c%c\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
+	                    THEKERNEL->streams->printf("ERROR: Hard limit %c%c\n", STEPPER[i->axis_index]->which_direction() ? '-' : '+', i->axis);
 	                }
 	                this->status = LIMIT_TRIGGERED;
 	                i->debounce = 0;
@@ -1151,7 +1151,7 @@ void Endstops::process_home_command(Gcode* gcode)
         if(!THEKERNEL->is_grbl_mode()) {
             THEKERNEL->streams->printf("ERROR: Homing cycle failed - check the max_travel settings\n");
         }else{
-            THEKERNEL->streams->printf("ALARM: Homing fail\n");
+            THEKERNEL->streams->printf("ERROR: Homing fail\n");
         }
         // clear all the homed flags
         for (auto &p : homing_axis) p.homed= false;

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -176,7 +176,7 @@ void AnalogSpindleControl::on_idle(void *argument)
     (void)argument;
     if(THEKERNEL->is_halted()) return;
     if (this->get_alarm()) {
-        THEKERNEL->streams->printf("ALARM: Spindle alarm triggered -  power off/on required\n");
+        THEKERNEL->streams->printf("ERROR: Spindle alarm triggered -  power off/on required\n");
         THEKERNEL->set_halt_reason(SPINDLE_ALARM);
         THEKERNEL->call_event(ON_HALT, nullptr);
     }

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -351,7 +351,7 @@ void PWMSpindleControl::on_idle(void *argument)
 	if(THEKERNEL->is_halted()) return;
 	// check spindle alarm
     if (this->get_alarm()) {
-		THEKERNEL->streams->printf("ALARM: Spindle alarm triggered -  power off/on required\n");
+		THEKERNEL->streams->printf("ERROR: Spindle alarm triggered -  power off/on required\n");
 		THEKERNEL->set_halt_reason(SPINDLE_ALARM);
 		THEKERNEL->call_event(ON_HALT, nullptr);
 		return;
@@ -359,7 +359,7 @@ void PWMSpindleControl::on_idle(void *argument)
     // check spindle stall
     /*
     if (this->get_stall()) {
-		THEKERNEL->streams->printf("ALARM: Spindle stall triggered -  reset required\n");
+		THEKERNEL->streams->printf("ERROR: Spindle stall triggered -  reset required\n");
 		THEKERNEL->set_halt_reason(SPINDLE_STALL);
 		THEKERNEL->call_event(ON_HALT, nullptr);
     }*/

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -55,7 +55,7 @@ void SpindleControl::on_gcode_received(void *argument)
             	if (!tool_ok) {
         			THEKERNEL->set_halt_reason(MANUAL);
         			THEKERNEL->call_event(ON_HALT, nullptr);
-        			THEKERNEL->streams->printf("ERROR: No tool or probe tool!\n");
+        			THEKERNEL->streams->printf("ALARM: Spindle cannot run without a valid tool\n");
         			return;
             	}
 

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -55,7 +55,7 @@ void SpindleControl::on_gcode_received(void *argument)
             	if (!tool_ok) {
         			THEKERNEL->set_halt_reason(MANUAL);
         			THEKERNEL->call_event(ON_HALT, nullptr);
-        			THEKERNEL->streams->printf("ALARM: Spindle cannot run without a valid tool\n");
+        			THEKERNEL->streams->printf("ERROR: Spindle cannot run without a valid tool\n");
         			return;
             	}
 

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -131,13 +131,13 @@ void TemperatureControl::on_main_loop(void *argument)
         if (isinf(this->get_temperature())){ //undefined
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Spindle temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Spindle temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Power cabinet temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Power cabinet temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -145,13 +145,13 @@ void TemperatureControl::on_main_loop(void *argument)
         else if (this->get_temperature() < this->min_temp){ //cold
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Spindle too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Spindle too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Power cabinet too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Power cabinet too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -159,13 +159,13 @@ void TemperatureControl::on_main_loop(void *argument)
         else { // hot
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Spindle overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Spindle overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ERROR: Power cabinet overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ALARM: Power cabinet overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -393,7 +393,7 @@ void TemperatureControl::on_gcode_received(void *argument)
                     // wait for temp to be reached, no more gcodes will be fetched until this is complete
                     if( gcode->m == this->set_and_wait_m_code) {
                         if(isinf(get_temperature()) && isinf(sensor->get_temperature())) {
-                            THEKERNEL->streams->printf("Temperature reading is unreliable on %s HALT asserted - reset or M999 required\n", designator.c_str());
+                            THEKERNEL->streams->printf("ALARM: Temperature reading is unreliable on %s HALT asserted - reset or M999 required\n", designator.c_str());
                             THEKERNEL->call_event(ON_HALT, nullptr);
                             return;
                         }
@@ -589,13 +589,13 @@ void TemperatureControl::on_second_tick(void *argument)
 		if (isinf(temperature) || temperature < min_temp || temperature > max_temp) {
 			if(this->name_checksum == spindle_temperature_checksum )
 	        {
-		        THEKERNEL->streams->printf("ERROR: Spindle overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
+		        THEKERNEL->streams->printf("ALARM: Spindle overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
 		        THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
 		        THEKERNEL->call_event(ON_HALT, nullptr);
 		    }
 		    else if(this->name_checksum == power_temperature_checksum )
         	{
-		        THEKERNEL->streams->printf("ERROR: Power cabinet overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
+		        THEKERNEL->streams->printf("ALARM: Power cabinet overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
 		        THEKERNEL->set_halt_reason(POWER_OVERHEATED);
 		        THEKERNEL->call_event(ON_HALT, nullptr);
 		    }
@@ -640,7 +640,7 @@ void TemperatureControl::on_second_tick(void *argument)
 	                    uint16_t t= (runaway_state == HEATING_UP) ? this->runaway_heating_timeout : this->runaway_cooling_timeout;
 	                    // we are still heating up see if we have hit the max time allowed
 	                    if(t > 0 && ++this->runaway_timer > t){
-	                        THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
+	                        THEKERNEL->streams->printf("ALARM: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
 	                        THEKERNEL->call_event(ON_HALT, nullptr);
 	                        this->runaway_state = NOT_HEATING;
 	                        this->runaway_timer = 0;
@@ -656,7 +656,7 @@ void TemperatureControl::on_second_tick(void *argument)
 	                    // If the temperature is outside the acceptable range for 8 seconds, this allows for some noise spikes without halting
 	                    if(fabsf(delta) > this->runaway_range){
 	                        if(this->runaway_timer++ >= 1) { // this being 8 seconds
-	                            THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+	                            THEKERNEL->streams->printf("ALARM: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
 	                            THEKERNEL->call_event(ON_HALT, nullptr);
 	                            this->runaway_state = NOT_HEATING;
 	                            this->runaway_timer= 0;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -131,13 +131,13 @@ void TemperatureControl::on_main_loop(void *argument)
         if (isinf(this->get_temperature())){ //undefined
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Spindle temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Spindle temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Power cabinet temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Power cabinet temperature undefined, check wiring, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -145,13 +145,13 @@ void TemperatureControl::on_main_loop(void *argument)
         else if (this->get_temperature() < this->min_temp){ //cold
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Spindle too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Spindle too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Power cabinet too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Power cabinet too cold, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -159,13 +159,13 @@ void TemperatureControl::on_main_loop(void *argument)
         else { // hot
             if(this->name_checksum == spindle_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Spindle overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Spindle overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
             else if(this->name_checksum == power_temperature_checksum )
             {
-                THEKERNEL->streams->printf("ALARM: Power cabinet overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
+                THEKERNEL->streams->printf("ERROR: Power cabinet overheated, max - %f°C, current - %f°C !\n", max_temp, get_temperature());
                 THEKERNEL->set_halt_reason(POWER_OVERHEATED);
                 THEKERNEL->call_event(ON_HALT, nullptr);
             }
@@ -393,7 +393,7 @@ void TemperatureControl::on_gcode_received(void *argument)
                     // wait for temp to be reached, no more gcodes will be fetched until this is complete
                     if( gcode->m == this->set_and_wait_m_code) {
                         if(isinf(get_temperature()) && isinf(sensor->get_temperature())) {
-                            THEKERNEL->streams->printf("ALARM: Temperature reading is unreliable on %s HALT asserted - reset or M999 required\n", designator.c_str());
+                            THEKERNEL->streams->printf("ERROR: Temperature reading is unreliable on %s HALT asserted - reset or M999 required\n", designator.c_str());
                             THEKERNEL->call_event(ON_HALT, nullptr);
                             return;
                         }
@@ -589,13 +589,13 @@ void TemperatureControl::on_second_tick(void *argument)
 		if (isinf(temperature) || temperature < min_temp || temperature > max_temp) {
 			if(this->name_checksum == spindle_temperature_checksum )
 	        {
-		        THEKERNEL->streams->printf("ALARM: Spindle overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
+		        THEKERNEL->streams->printf("ERROR: Spindle overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
 		        THEKERNEL->set_halt_reason(SPINDLE_OVERHEATED);
 		        THEKERNEL->call_event(ON_HALT, nullptr);
 		    }
 		    else if(this->name_checksum == power_temperature_checksum )
         	{
-		        THEKERNEL->streams->printf("ALARM: Power cabinet overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
+		        THEKERNEL->streams->printf("ERROR: Power cabinet overheated, max - %1.1f, current - %1.1f\n", max_temp, temperature);
 		        THEKERNEL->set_halt_reason(POWER_OVERHEATED);
 		        THEKERNEL->call_event(ON_HALT, nullptr);
 		    }
@@ -640,7 +640,7 @@ void TemperatureControl::on_second_tick(void *argument)
 	                    uint16_t t= (runaway_state == HEATING_UP) ? this->runaway_heating_timeout : this->runaway_cooling_timeout;
 	                    // we are still heating up see if we have hit the max time allowed
 	                    if(t > 0 && ++this->runaway_timer > t){
-	                        THEKERNEL->streams->printf("ALARM: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
+	                        THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
 	                        THEKERNEL->call_event(ON_HALT, nullptr);
 	                        this->runaway_state = NOT_HEATING;
 	                        this->runaway_timer = 0;
@@ -656,7 +656,7 @@ void TemperatureControl::on_second_tick(void *argument)
 	                    // If the temperature is outside the acceptable range for 8 seconds, this allows for some noise spikes without halting
 	                    if(fabsf(delta) > this->runaway_range){
 	                        if(this->runaway_timer++ >= 1) { // this being 8 seconds
-	                            THEKERNEL->streams->printf("ALARM: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+	                            THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
 	                            THEKERNEL->call_event(ON_HALT, nullptr);
 	                            this->runaway_state = NOT_HEATING;
 	                            this->runaway_timer= 0;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -627,14 +627,14 @@ void ZProbe::on_gcode_received(void *argument)
                     parse_parameters(gcode);
                 } else if (gcode->subcode == 2){//calibrate using boss
                     if (!gcode->has_letter('X') && !gcode->has_letter('Y')){ //error if there is a problem
-                        gcode->stream->printf("ALARM: Probe fail: No Gague Length\n");
+                        gcode->stream->printf("ERROR: Probe fail: No Gague Length\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
                     }
                 
                     if (gcode->has_letter('X') && gcode->has_letter('Y')){
-                        gcode->stream->printf("ALARM: Probe fail: Multiple Axes Given When 1 Expected\n");
+                        gcode->stream->printf("ERROR: Probe fail: Multiple Axes Given When 1 Expected\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -644,7 +644,7 @@ void ZProbe::on_gcode_received(void *argument)
                     }
                 }else {
                     if (!gcode->has_letter('X') && !gcode->has_letter('Y') ) { //error if there is a problem
-                        gcode->stream->printf("ALARM: Probe fail: No Radius Given\n");
+                        gcode->stream->printf("ERROR: Probe fail: No Radius Given\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -657,7 +657,7 @@ void ZProbe::on_gcode_received(void *argument)
                 break;
             case 461:
                 if (!gcode->has_letter('X') && !gcode->has_letter('Y')){ //error if there is a problem
-                    gcode->stream->printf("ALARM: Probe fail: No Axis Set\n");
+                    gcode->stream->printf("ERROR: Probe fail: No Axis Set\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(PROBE_FAIL);
                     return;
@@ -668,7 +668,7 @@ void ZProbe::on_gcode_received(void *argument)
                 break;
             case 462:
                 if (!gcode->has_letter('X') && !gcode->has_letter('Y')){ //error if there is a problem
-                    gcode->stream->printf("ALARM: Probe fail: No Axis Set\n");
+                    gcode->stream->printf("ERROR: Probe fail: No Axis Set\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(PROBE_FAIL);
                     return;
@@ -679,7 +679,7 @@ void ZProbe::on_gcode_received(void *argument)
                 break;
             case 463:
                 if (!gcode->has_letter('X') || !gcode->has_letter('Y')){
-                    gcode->stream->printf("ALARM: Probe fail: Both X and Y axis need to be set for Corner Probing\n");
+                    gcode->stream->printf("ERROR: Probe fail: Both X and Y axis need to be set for Corner Probing\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(PROBE_FAIL);
                     return;
@@ -690,7 +690,7 @@ void ZProbe::on_gcode_received(void *argument)
                 break;
             case 464:
                 if (!gcode->has_letter('X') || !gcode->has_letter('Y')){
-                    gcode->stream->printf("ALARM: Probe fail: Both X and Y axis need to be set for Corner Probing\n");
+                    gcode->stream->printf("ERROR: Probe fail: Both X and Y axis need to be set for Corner Probing\n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(PROBE_FAIL);
                     return;
@@ -703,7 +703,7 @@ void ZProbe::on_gcode_received(void *argument)
                 parse_parameters(gcode, true);
                 if (gcode->subcode == 1){
                     if (!gcode->has_letter('Y') || !gcode->has_letter('H')){
-                        gcode->stream->printf("ALARM: Probe fail: No distance or height set\n");
+                        gcode->stream->printf("ERROR: Probe fail: No distance or height set\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -711,7 +711,7 @@ void ZProbe::on_gcode_received(void *argument)
                     probing_cycle = PROBE_A_AXIS;
                 }else if (gcode->subcode == 2){
                     if (!gcode->has_letter('X') || !gcode->has_letter('Y') || !gcode->has_letter('R')){
-                        gcode->stream->printf("ALARM: Probe fail: No offset, distance or height set\n");
+                        gcode->stream->printf("ERROR: Probe fail: No offset, distance or height set\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -719,13 +719,13 @@ void ZProbe::on_gcode_received(void *argument)
                     probing_cycle = PROBE_A_AXIS_WITH_OFFSET;
                 }else{
                     if (!gcode->has_letter('X') && !gcode->has_letter('Y')){
-                            gcode->stream->printf("ALARM: Probe fail: No axis set\n");
+                            gcode->stream->printf("ERROR: Probe fail: No axis set\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
                     }
                     if (gcode->has_letter('X') && gcode->has_letter('Y')){
-                        gcode->stream->printf("ALARM: Probe fail: Axis probing only supports 1 axis input\n");
+                        gcode->stream->printf("ERROR: Probe fail: Axis probing only supports 1 axis input\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -736,7 +736,7 @@ void ZProbe::on_gcode_received(void *argument)
             case 466:
                 if (gcode->subcode == 1){
                     if (!gcode->has_letter('X') || !gcode->has_letter('Y') || !gcode->has_letter('H')){
-                        gcode->stream->printf("ALARM: Probe fail: Both X and Y axis and height need to be set for Square Probing\n");
+                        gcode->stream->printf("ERROR: Probe fail: Both X and Y axis and height need to be set for Square Probing\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -746,7 +746,7 @@ void ZProbe::on_gcode_received(void *argument)
                     }
                 }else{
                     if (!gcode->has_letter('X') && !gcode->has_letter('Y') && !gcode->has_letter('Z')){
-                        gcode->stream->printf("ALARM: Probe fail: No Axis Set\n");
+                        gcode->stream->printf("ERROR: Probe fail: No Axis Set\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         THEKERNEL->set_halt_reason(PROBE_FAIL);
                         return;
@@ -826,7 +826,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
     THEKERNEL->conveyor->wait_for_idle();
 
     if(this->pin.get() != invert_probe) {
-        gcode->stream->printf("ALARM: ZProbe triggered before move, aborting command.\n");
+        gcode->stream->printf("ERROR: ZProbe triggered before move, aborting command.\n");
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
@@ -845,7 +845,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
     float delta[3]= {x, y, z};
     THEKERNEL->set_zprobing(true);
     if(!THEROBOT->delta_move(delta, rate, 3)) {
-    	gcode->stream->printf("ALARM: Probing move too small,  %1.3f, %1.3f, %1.3f\n", x, y, z);
+    	gcode->stream->printf("ERROR: Probing move too small,  %1.3f, %1.3f, %1.3f\n", x, y, z);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         probing = false;
@@ -877,7 +877,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
 
     if(probeok == 0 && (gcode->subcode == 2 || gcode->subcode == 4)) {
         // issue error if probe was not triggered and subcode is 2 or 4
-        gcode->stream->printf("ALARM: Probe failed to trigger\n");
+        gcode->stream->printf("ERROR: Probe failed to trigger\n");
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         return false; //probe was not activated but failed due to subcodes
@@ -963,7 +963,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     float delta[3]= {0, 0, z};
     THEKERNEL->set_zprobing(true);
     if(!THEROBOT->delta_move(delta, rate, 3)) {
-        gcode->stream->printf("ALARM: Probing move too small,  %1.3f\n", z);
+        gcode->stream->printf("ERROR: Probing move too small,  %1.3f\n", z);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         calibrating = false;
@@ -998,7 +998,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
         gcode->stream->printf("Error detected at position: %.3f\n", calibrate_current_z);
         gcode->stream->printf("Safety Margin Value: %.3f\n",  probe_calibration_safety_margin);
         gcode->stream->printf("debounce: %d, cali_debounce: %d, debounce_ms: %d\n", debounce, cali_debounce, debounce_ms);
-        gcode->stream->printf("ALARM: Probe failed to trigger within safety margin (%.2fmm). See MDI\n", this->probe_calibration_safety_margin);
+        gcode->stream->printf("ERROR: Probe failed to trigger within safety margin (%.2fmm). See MDI\n", this->probe_calibration_safety_margin);
         THEKERNEL->call_event(ON_HALT, nullptr);
         return;
     }
@@ -1023,7 +1023,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
 
     if (calibrateok == 0) {
         // issue error if probe was not triggered and subcode is 2 or 4
-        gcode->stream->printf("ALARM: Calibrate fail!\n");
+        gcode->stream->printf("ERROR: Calibrate fail!\n");
         THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
     }
@@ -1255,7 +1255,7 @@ int ZProbe::xy_probe_move_alarm_when_hit(int direction, int probe_g38_subcode, f
     std::sprintf(this->buff, "G38.%i X%.3f Y%.3f F%.3f", 3+probe_g38_subcode,THEROBOT->from_millimeters(direction * x), THEROBOT->from_millimeters(direction * y), feed_rate);
     this->gcodeBuffer = new Gcode(this->buff, &StreamOutput::NullStream);
     if (probe_XYZ(this->gcodeBuffer)){
-        THEKERNEL->streams->printf("ALARM: Probe hit wall when moving to outer position\n");
+        THEKERNEL->streams->printf("ERROR: Probe hit wall when moving to outer position\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         delete gcodeBuffer;
@@ -1288,13 +1288,13 @@ bool ZProbe::parse_parameters(Gcode *gcode, bool override_probe_check){
     init_parameters_and_out_coords();
 
     if (!((override_probe_check && THEKERNEL->eeprom_data->TOOL == 0) || (this->tool_0_3axis && THEKERNEL->eeprom_data->TOOL == 0) || THEKERNEL->eeprom_data->TOOL >= 999990)){
-        THEKERNEL->streams->printf("ALARM: Attempted to 3 axis probe with an improper tool number. Tool number needs to be >= 999990\n or you need to set tool 0 as a 3 axis probe with: \n config-set sd zprobe.tool_zero_is_3axis true \n");
+        THEKERNEL->streams->printf("ERROR: Attempted to 3 axis probe with an improper tool number. Tool number needs to be >= 999990\n or you need to set tool 0 as a 3 axis probe with: \n config-set sd zprobe.tool_zero_is_3axis true \n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return false;
     }else if(THEROBOT->get_tool_not_calibrated() && gcode->has_letter('S') && (gcode->has_letter('H') || gcode->has_letter('Z'))){
         if(gcode->get_value('S') == 2){
-            THEKERNEL->streams->printf("ALARM: Probe not calibrated. Please calibrate probe before probing.\n");
+            THEKERNEL->streams->printf("ERROR: Probe not calibrated. Please calibrate probe before probing.\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEKERNEL->set_halt_reason(PROBE_FAIL);
             return false;
@@ -1395,7 +1395,7 @@ void ZProbe::probe_bore(bool calibration) //M461
     }
 
     if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;
@@ -1524,7 +1524,7 @@ void ZProbe::probe_boss(bool calibration) //M462
     int repeat_count = calibration ? 1 : param.repeat;
     
     if (repeat_count < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;
@@ -1693,7 +1693,7 @@ void ZProbe::probe_insideCorner() //M463
     float mpos[3];
 
     if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;
@@ -1777,7 +1777,7 @@ void ZProbe::probe_outsideCorner() //M464
     float mpos[3];
 
     if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;
@@ -1919,7 +1919,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
         // Validate the values before using them
         if (isnan(machine_offset.anchor1_x) || isnan(machine_offset.anchor1_y) || 
             isnan(machine_offset.rotation_offset_x) || isnan(machine_offset.rotation_offset_y)) {
-            THEKERNEL->streams->printf("ALARM: Invalid machine offset values\n");
+            THEKERNEL->streams->printf("ERROR: Invalid machine offset values\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEKERNEL->set_halt_reason(PROBE_FAIL);
             return;
@@ -1932,7 +1932,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
         float target_y = machine_offset.anchor1_y + machine_offset.rotation_offset_y;
 
         if (isnan(target_x) || isnan(target_y)) {
-            THEKERNEL->streams->printf("ALARM: Invalid target coordinates\n");
+            THEKERNEL->streams->printf("ERROR: Invalid target coordinates\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEKERNEL->set_halt_reason(PROBE_FAIL);
             return;
@@ -1957,7 +1957,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
         }
 
         if (param.repeat < 1){
-            THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+            THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEKERNEL->set_halt_reason(PROBE_FAIL);
             return;
@@ -2003,7 +2003,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
 
             // probe along x axis to second position, alarm if hit
             if (xy_probe_move_alarm_when_hit(POS, param.probe_g38_subcode, 0.0, param.y_rotated_y, param.rapid_rate) == 1) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: hit wall during first move\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: hit wall during first move\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2013,14 +2013,14 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             if (check_last_probe_ok()){
                 out_coords.y_positive_y_out = out_coords.z_negative_z_out;
             }else{
-                THEKERNEL->streams->printf("ALARM: Probe fail: first point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: first point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
             }
             
             if (xy_probe_move_alarm_when_hit(NEG, param.probe_g38_subcode, 0.0, 2 * param.y_rotated_y, param.rapid_rate) == 1) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: hit wall during second move\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: hit wall during second move\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2030,7 +2030,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
                 out_coords.y_negative_y_out = out_coords.z_negative_z_out;
             }
             else{
-                THEKERNEL->streams->printf("ALARM: Probe fail: second point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: second point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2047,7 +2047,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: first point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: first point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2061,7 +2061,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
             //probe along x axis to second position, alarm if hit
             if (xy_probe_move_alarm_when_hit(POS, param.probe_g38_subcode, param.x_rotated_x, param.x_rotated_y, param.rapid_rate) == 1) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: hit wall during move to second position\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: hit wall during move to second position\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2072,7 +2072,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: second point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: second point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2096,7 +2096,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: first point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: first point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2110,7 +2110,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
             //probe along x axis to second position, alarm if hit
             if (xy_probe_move_alarm_when_hit(POS, param.probe_g38_subcode, param.y_rotated_x, param.y_rotated_y, param.rapid_rate) == 1) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: hit wall during move to second position\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: hit wall during move to second position\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2121,7 +2121,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
-                THEKERNEL->streams->printf("ALARM: Probe fail: second point not found\n");
+                THEKERNEL->streams->printf("ERROR: Probe fail: second point not found\n");
                 THEKERNEL->call_event(ON_HALT, nullptr);
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
@@ -2212,7 +2212,7 @@ void ZProbe::probe_square(){
     float mpos[5];
 
     if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;
@@ -2428,7 +2428,7 @@ void ZProbe::single_axis_probe_double_tap(){
     THEKERNEL->streams->printf("Probing Single Axis\n");
 
     if (param.repeat < 1){
-        THEKERNEL->streams->printf("ALARM: Probe fail: repeat value cannot be less than 1\n");
+        THEKERNEL->streams->printf("ERROR: Probe fail: repeat value cannot be less than 1\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         return;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -826,7 +826,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
     THEKERNEL->conveyor->wait_for_idle();
 
     if(this->pin.get() != invert_probe) {
-        gcode->stream->printf("Error:ZProbe triggered before move, aborting command.\n");
+        gcode->stream->printf("ALARM: ZProbe triggered before move, aborting command.\n");
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
@@ -845,7 +845,7 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
     float delta[3]= {x, y, z};
     THEKERNEL->set_zprobing(true);
     if(!THEROBOT->delta_move(delta, rate, 3)) {
-    	gcode->stream->printf("ERROR: Move too small,  %1.3f, %1.3f, %1.3f\n", x, y, z);
+    	gcode->stream->printf("ALARM: Probing move too small,  %1.3f, %1.3f, %1.3f\n", x, y, z);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         probing = false;
@@ -877,10 +877,9 @@ bool ZProbe::probe_XYZ(Gcode *gcode)
 
     if(probeok == 0 && (gcode->subcode == 2 || gcode->subcode == 4)) {
         // issue error if probe was not triggered and subcode is 2 or 4
-        gcode->stream->printf("ALARM: Probe fail\n");
+        gcode->stream->printf("ALARM: Probe failed to trigger\n");
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
-        THEKERNEL->set_halt_reason(PROBE_FAIL);
         return false; //probe was not activated but failed due to subcodes
     }
     if(probeok == 0){
@@ -964,7 +963,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     float delta[3]= {0, 0, z};
     THEKERNEL->set_zprobing(true);
     if(!THEROBOT->delta_move(delta, rate, 3)) {
-        gcode->stream->printf("ERROR: Move too small,  %1.3f\n", z);
+        gcode->stream->printf("ALARM: Probing move too small,  %1.3f\n", z);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         calibrating = false;
@@ -992,9 +991,6 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     if (safety_margin_exceeded) {
         safety_margin_exceeded = false;
         THEKERNEL->set_halt_reason(PROBE_FAIL);
-        THEKERNEL->call_event(ON_HALT, nullptr);
-        gcode->stream->printf("ALARM: Probe failed to trigger within safety margin (%.2fmm)\n", 
-                             this->probe_calibration_safety_margin);
         gcode->stream->printf("Distance moved: %.3f\n", distance_moved);
         gcode->stream->printf("Probe pin triggered: %d, position: %.3f\n", probe_detected, probe_pin_position);
         gcode->stream->printf("Calibrate pin triggered: %d, position: %.3f\n", calibrate_detected, calibrate_pin_position);
@@ -1002,6 +998,8 @@ void ZProbe::calibrate_Z(Gcode *gcode)
         gcode->stream->printf("Error detected at position: %.3f\n", calibrate_current_z);
         gcode->stream->printf("Safety Margin Value: %.3f\n",  probe_calibration_safety_margin);
         gcode->stream->printf("debounce: %d, cali_debounce: %d, debounce_ms: %d\n", debounce, cali_debounce, debounce_ms);
+        gcode->stream->printf("ALARM: Probe failed to trigger within safety margin (%.2fmm). See MDI\n", this->probe_calibration_safety_margin);
+        THEKERNEL->call_event(ON_HALT, nullptr);
         return;
     }
 

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -149,7 +149,7 @@ void MainButton::on_second_tick(void *)
     // check if sd card is ok
 	if (!this->sd_ok && !THEKERNEL->is_halted()) {
         THEKERNEL->set_halt_reason(SD_ERROR);
-		THEKERNEL->streams->printf("ALARM: SD card error\n");
+		THEKERNEL->streams->printf("ERROR: SD card error\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
 	}
 
@@ -264,7 +264,7 @@ void MainButton::on_idle(void *argument)
     			case HOME:
     				// Halt
     		        THEKERNEL->set_halt_reason(MANUAL);
-					THEKERNEL->streams->printf("ALARM: Front Button ESTOP\n");
+					THEKERNEL->streams->printf("ERROR: Front Button ESTOP\n");
     		        THEKERNEL->call_event(ON_HALT, nullptr);
     				break;
     			case HOLD:

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -149,6 +149,7 @@ void MainButton::on_second_tick(void *)
     // check if sd card is ok
 	if (!this->sd_ok && !THEKERNEL->is_halted()) {
         THEKERNEL->set_halt_reason(SD_ERROR);
+		THEKERNEL->streams->printf("ALARM: SD card error\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
 	}
 
@@ -263,6 +264,7 @@ void MainButton::on_idle(void *argument)
     			case HOME:
     				// Halt
     		        THEKERNEL->set_halt_reason(MANUAL);
+					THEKERNEL->streams->printf("ALARM: Front Button ESTOP\n");
     		        THEKERNEL->call_event(ON_HALT, nullptr);
     				break;
     			case HOLD:

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -357,7 +357,7 @@ void Player::on_gcode_received(void *argument)
                 return;
             }else{
                     //error: no filepath found
-                    THEKERNEL->streams->printf("M97 Command missing P parameter for line to goto, aborting \n");
+                    THEKERNEL->streams->printf("ALARM: M97 Command missing P parameter for line to goto, aborting \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -383,7 +383,7 @@ void Player::on_gcode_received(void *argument)
                     new_filepath = "/sd/gcodes/macros/" + new_filepath + ".cnc";
                 }else{
                     //error:
-                    THEKERNEL->streams->printf("invalid number in M98 command \n");
+                    THEKERNEL->streams->printf("ALARM: invalid number in M98 command \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -393,7 +393,7 @@ void Player::on_gcode_received(void *argument)
                 num_repeats = floor(gcode->get_value('L'));
                 if (num_repeats <1){
                     //error:
-                    THEKERNEL->streams->printf("M98 command has an invalid value, which will lead to errors \n");
+                    THEKERNEL->streams->printf("ALARM: M98 command has an invalid value, which will lead to errors \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -413,7 +413,7 @@ void Player::on_gcode_received(void *argument)
                     }
                 }else{
                     //error: no filepath found
-                    THEKERNEL->streams->printf("no filepath found in M98.1 command \n");
+                    THEKERNEL->streams->printf("ALARM: no filepath found in M98.1 command \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -524,7 +524,7 @@ void Player::play_command( string parameters, StreamOutput *stream )
 //	if (!tool_ok) {
 //		THEKERNEL->set_halt_reason(MANUAL);
 //		THEKERNEL->call_event(ON_HALT, nullptr);
-//		THEKERNEL->streams->printf("ERROR: No tool or probe tool!\n");
+//		THEKERNEL->streams->printf("ALARM: No tool or probe tool!\n");
 //		return;
 //	}
 

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -357,7 +357,7 @@ void Player::on_gcode_received(void *argument)
                 return;
             }else{
                     //error: no filepath found
-                    THEKERNEL->streams->printf("ALARM: M97 Command missing P parameter for line to goto, aborting \n");
+                    THEKERNEL->streams->printf("ERROR: M97 Command missing P parameter for line to goto, aborting \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -383,7 +383,7 @@ void Player::on_gcode_received(void *argument)
                     new_filepath = "/sd/gcodes/macros/" + new_filepath + ".cnc";
                 }else{
                     //error:
-                    THEKERNEL->streams->printf("ALARM: invalid number in M98 command \n");
+                    THEKERNEL->streams->printf("ERROR: invalid number in M98 command \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -393,7 +393,7 @@ void Player::on_gcode_received(void *argument)
                 num_repeats = floor(gcode->get_value('L'));
                 if (num_repeats <1){
                     //error:
-                    THEKERNEL->streams->printf("ALARM: M98 command has an invalid value, which will lead to errors \n");
+                    THEKERNEL->streams->printf("ERROR: M98 command has an invalid value, which will lead to errors \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -413,7 +413,7 @@ void Player::on_gcode_received(void *argument)
                     }
                 }else{
                     //error: no filepath found
-                    THEKERNEL->streams->printf("ALARM: no filepath found in M98.1 command \n");
+                    THEKERNEL->streams->printf("ERROR: no filepath found in M98.1 command \n");
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     THEKERNEL->set_halt_reason(MANUAL);
                     return;
@@ -524,7 +524,7 @@ void Player::play_command( string parameters, StreamOutput *stream )
 //	if (!tool_ok) {
 //		THEKERNEL->set_halt_reason(MANUAL);
 //		THEKERNEL->call_event(ON_HALT, nullptr);
-//		THEKERNEL->streams->printf("ALARM: No tool or probe tool!\n");
+//		THEKERNEL->streams->printf("ERROR: No tool or probe tool!\n");
 //		return;
 //	}
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1272,6 +1272,7 @@ void SimpleShell::test_4th_command( string parameters, StreamOutput *stream )
 		if( (false == btriggered) || (false == Nontriggered))
 		{
             THEKERNEL->set_halt_reason(HOME_FAIL);
+            THEKERNEL->streams->printf("ALARM: Failed to Home 4th axis\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEROBOT->disable_segmentation= false;
         }
@@ -1365,6 +1366,7 @@ void SimpleShell::test_5th_command( string parameters, StreamOutput *stream )
 		if( (false == btriggered) || (true == bAlwaystrigger))
 		{
             THEKERNEL->set_halt_reason(HOME_FAIL);
+            THEKERNEL->streams->printf("ALARM: Failed To Home 5th axis\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEROBOT->disable_segmentation= false;
         }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1272,7 +1272,7 @@ void SimpleShell::test_4th_command( string parameters, StreamOutput *stream )
 		if( (false == btriggered) || (false == Nontriggered))
 		{
             THEKERNEL->set_halt_reason(HOME_FAIL);
-            THEKERNEL->streams->printf("ALARM: Failed to Home 4th axis\n");
+            THEKERNEL->streams->printf("ERROR: Failed to Home 4th axis\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEROBOT->disable_segmentation= false;
         }
@@ -1366,7 +1366,7 @@ void SimpleShell::test_5th_command( string parameters, StreamOutput *stream )
 		if( (false == btriggered) || (true == bAlwaystrigger))
 		{
             THEKERNEL->set_halt_reason(HOME_FAIL);
-            THEKERNEL->streams->printf("ALARM: Failed To Home 5th axis\n");
+            THEKERNEL->streams->printf("ERROR: Failed To Home 5th axis\n");
             THEKERNEL->call_event(ON_HALT, nullptr);
             THEROBOT->disable_segmentation= false;
         }

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -342,12 +342,9 @@ void WifiProvider::on_idle(void *argument)
     if (halt_flag) {
         halt_flag = false;
         THEKERNEL->set_halt_reason(MANUAL);
+		puts("ALARM: Controller Abort during cycle\r\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
-        if(THEKERNEL->is_grbl_mode()) {
-            puts("ALARM: Abort during cycle\r\n");
-        } else {
-            puts("HALTED, M999 or $X to exit HALT state\r\n");
-        }
+		
     }
 }
 

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -342,7 +342,7 @@ void WifiProvider::on_idle(void *argument)
     if (halt_flag) {
         halt_flag = false;
         THEKERNEL->set_halt_reason(MANUAL);
-		puts("ALARM: Controller Abort during cycle\r\n");
+		puts("ERROR: Controller Abort during cycle\r\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
 		
     }

--- a/version.txt
+++ b/version.txt
@@ -7,6 +7,7 @@
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
+- Lint: conformed all error messages to the format ALARM: <message> for easier hooks in the controller
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -7,7 +7,7 @@
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
-- Lint: conformed all error messages to the format ALARM: <message> for easier hooks in the controller
+- Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
Related to https://github.com/Carvera-Community/Carvera_Controller/pull/559


This PR changes all halt messages to use the same formatting for easier hooks in the controller. 

The new format is 

ERROR: message


EDIT: I have updated to use ERROR: per discussions with Serge and Lyrkan



@Lyrkan @SergeBakharev what are your thoughts?