### PR TITLE
Add option to auto-disable on-board AP once STA is connected

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -86,6 +86,7 @@ epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for exampl
 # wifi.udp_recv_port							4444
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
+# wifi.ap_auto_disable							false			# true to auto-disable AP when STA is connected
 
 # ATC
 # atc.enable									true

--- a/src/config.default
+++ b/src/config.default
@@ -86,7 +86,7 @@ epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for exampl
 # wifi.udp_recv_port							4444
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
-# wifi.ap_auto_disable							false			# true to auto-disable AP when STA is connected
+# wifi.ap_auto_disable							true			# false to keep AP enabled even when STA is connected
 
 # ATC
 # atc.enable									true

--- a/src/config2.default
+++ b/src/config2.default
@@ -86,6 +86,7 @@ epsilon_steps_per_mm						888.88888		# may be steps per degree for example (26.6
 # wifi.udp_recv_port							4444
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
+# wifi.ap_auto_disable							false			# true to auto-disable AP when STA is connected
 
 # ATC
 # atc.enable									true

--- a/src/config2.default
+++ b/src/config2.default
@@ -86,7 +86,7 @@ epsilon_steps_per_mm						888.88888		# may be steps per degree for example (26.6
 # wifi.udp_recv_port							4444
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
-# wifi.ap_auto_disable							false			# true to auto-disable AP when STA is connected
+# wifi.ap_auto_disable							true			# false to keep AP enabled even when STA is connected
 
 # ATC
 # atc.enable									true

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -63,8 +63,9 @@ WifiProvider::WifiProvider()
 	has_data_flag = false;
 	connection_fail_count = 0;
 	sta_stable_seconds = 0;
-	ap_auto_disable = false;
+	ap_auto_disable = true;
 	ap_currently_on = true;
+	ap_off_by_auto_toggle = false;
 }
 
 void WifiProvider::on_module_loaded()
@@ -75,13 +76,12 @@ void WifiProvider::on_module_loaded()
         return;
     }
 
-
 	this->tcp_port = THEKERNEL->config->value(wifi_checksum, tcp_port_checksum)->as_int(2222);
 	this->udp_send_port = THEKERNEL->config->value(wifi_checksum, udp_send_port_checksum)->as_int(3333);
 	this->udp_recv_port = THEKERNEL->config->value(wifi_checksum, udp_recv_port_checksum)->as_int(4444);
 	this->tcp_timeout_s = THEKERNEL->config->value(wifi_checksum, tcp_timeout_s_checksum)->as_int(10);
     std::string config_name = THEKERNEL->config->value(wifi_checksum, machine_name_checksum)->as_string("CARVERA");
-	this->ap_auto_disable = THEKERNEL->config->value(wifi_checksum, ap_auto_disable_checksum)->as_bool(false);
+	this->ap_auto_disable = THEKERNEL->config->value(wifi_checksum, ap_auto_disable_checksum)->as_bool(true);
 
     strncpy(this->machine_name, config_name.c_str(), sizeof(this->machine_name) - 1);
     this->machine_name[sizeof(this->machine_name) - 1] = '\0'; // Ensure null termination
@@ -89,12 +89,12 @@ void WifiProvider::on_module_loaded()
     // Init Wifi Module
     this->init_wifi_module(false);
 
-    // force AP on at boot so a stale mode-1 in flash can't lock us out (saved=0)
-    if (this->ap_auto_disable) {
+    // sync ap_currently_on with the saved op-mode the M8266 booted into
+    {
+        u8 boot_op_mode = 3;
         u16 op_status = 0;
-        M8266WIFI_SPI_Set_Opmode(3, 0, &op_status);
-        this->ap_currently_on = true;
-        this->sta_stable_seconds = 0;
+        M8266WIFI_SPI_Get_Opmode(&boot_op_mode, &op_status);
+        this->ap_currently_on = (boot_op_mode != 1);
     }
 
     // Add interrupt for WIFI data receving
@@ -313,14 +313,17 @@ void WifiProvider::on_second_tick(void *)
 				u16 op_status = 0;
 				if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
 					this->ap_currently_on = false;
+					this->ap_off_by_auto_toggle = true;
 				}
 			}
 		} else {
 			this->sta_stable_seconds = 0;
-			if (!this->ap_currently_on) {
+			// only re-enable if we were the ones who turned it off; ap disable stays off
+			if (!this->ap_currently_on && this->ap_off_by_auto_toggle) {
 				u16 op_status = 0;
 				if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
 					this->ap_currently_on = true;
+					this->ap_off_by_auto_toggle = false;
 				}
 			}
 		}
@@ -851,9 +854,11 @@ void WifiProvider::on_set_public_data(void *argument)
         	set_wifi_op_mode(3);
         	this->ap_currently_on = true;
         	this->sta_stable_seconds = 0;
+        	this->ap_off_by_auto_toggle = false;
     	} else {
         	set_wifi_op_mode(1);
         	this->ap_currently_on = false;
+        	this->ap_off_by_auto_toggle = false;
     	}
     }
 	pdr->set_taken();

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -50,6 +50,9 @@
 #define udp_send_port_checksum		      CHECKSUM("udp_send_port")
 #define udp_recv_port_checksum		      CHECKSUM("udp_recv_port")
 #define tcp_timeout_s_checksum			  CHECKSUM("tcp_timeout_s")
+#define ap_auto_disable_checksum          CHECKSUM("ap_auto_disable")
+
+#define WIFI_AP_OFF_DELAY_S          3
 
 
 WifiProvider::WifiProvider()
@@ -59,6 +62,9 @@ WifiProvider::WifiProvider()
 	wifi_init_ok = false;
 	has_data_flag = false;
 	connection_fail_count = 0;
+	sta_stable_seconds = 0;
+	ap_auto_disable = false;
+	ap_currently_on = true;
 }
 
 void WifiProvider::on_module_loaded()
@@ -69,16 +75,27 @@ void WifiProvider::on_module_loaded()
         return;
     }
 
+
 	this->tcp_port = THEKERNEL->config->value(wifi_checksum, tcp_port_checksum)->as_int(2222);
 	this->udp_send_port = THEKERNEL->config->value(wifi_checksum, udp_send_port_checksum)->as_int(3333);
 	this->udp_recv_port = THEKERNEL->config->value(wifi_checksum, udp_recv_port_checksum)->as_int(4444);
 	this->tcp_timeout_s = THEKERNEL->config->value(wifi_checksum, tcp_timeout_s_checksum)->as_int(10);
     std::string config_name = THEKERNEL->config->value(wifi_checksum, machine_name_checksum)->as_string("CARVERA");
+	this->ap_auto_disable = THEKERNEL->config->value(wifi_checksum, ap_auto_disable_checksum)->as_bool(false);
+
     strncpy(this->machine_name, config_name.c_str(), sizeof(this->machine_name) - 1);
     this->machine_name[sizeof(this->machine_name) - 1] = '\0'; // Ensure null termination
 
     // Init Wifi Module
     this->init_wifi_module(false);
+
+    // force AP on at boot so a stale mode-1 in flash can't lock us out (saved=0)
+    if (this->ap_auto_disable) {
+        u16 op_status = 0;
+        M8266WIFI_SPI_Set_Opmode(3, 0, &op_status);
+        this->ap_currently_on = true;
+        this->sta_stable_seconds = 0;
+    }
 
     // Add interrupt for WIFI data receving
     Pin *smoothie_pin = new Pin();
@@ -286,7 +303,31 @@ void WifiProvider::on_second_tick(void *)
 		connection_fail_count = 0;
 	}
 
+	// AP off when STA is up, AP back on when STA drops. saved=0 to avoid flash wear.
+	if (this->ap_auto_disable) {
+		if (connection_status == 5) {
+			if (this->sta_stable_seconds < WIFI_AP_OFF_DELAY_S) {
+				this->sta_stable_seconds++;
+			}
+			if (this->sta_stable_seconds >= WIFI_AP_OFF_DELAY_S && this->ap_currently_on) {
+				u16 op_status = 0;
+				if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
+					this->ap_currently_on = false;
+				}
+			}
+		} else {
+			this->sta_stable_seconds = 0;
+			if (!this->ap_currently_on) {
+				u16 op_status = 0;
+				if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
+					this->ap_currently_on = true;
+				}
+			}
+		}
+	}
+
 	// send ap info through UDP
+	if (!this->ap_currently_on) return;
 	memset(udp_buff, 0, sizeof(udp_buff));
 	{
 		// Inlined get_broadcast_from_ip_and_netmask
@@ -808,8 +849,11 @@ void WifiProvider::on_set_public_data(void *argument)
     	bool *enable_op = static_cast<bool *>(pdr->get_data_ptr());
     	if (*enable_op) {
         	set_wifi_op_mode(3);
+        	this->ap_currently_on = true;
+        	this->sta_stable_seconds = 0;
     	} else {
         	set_wifi_op_mode(1);
+        	this->ap_currently_on = false;
     	}
     }
 	pdr->set_taken();

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -75,6 +75,7 @@ private:
 	int udp_recv_port;
 	int tcp_timeout_s;
 	int connection_fail_count;
+	int sta_stable_seconds;
 	char machine_name[64]; // Fixed-size buffer to avoid std::string heap allocation
 	char ap_address[16];
 	char ap_netmask[16];
@@ -85,6 +86,8 @@ private:
     	u8  tcp_link_no;
     	u8  udp_link_no;
     	bool wifi_init_ok:1;
+    	bool ap_auto_disable:1;
+    	bool ap_currently_on:1;
     	volatile bool halt_flag:1;
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -88,6 +88,7 @@ private:
     	bool wifi_init_ok:1;
     	bool ap_auto_disable:1;
     	bool ap_currently_on:1;
+    	bool ap_off_by_auto_toggle:1;
     	volatile bool halt_flag:1;
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;

--- a/version.txt
+++ b/version.txt
@@ -6,6 +6,7 @@
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
+- Enhancement: Add option to auto-disable on-board AP once STA is connected
 - Fixed: Prevent incorrect current line reporting after a tool change
 
 [2.1.0c]

--- a/version.txt
+++ b/version.txt
@@ -6,7 +6,7 @@
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
-- Enhancement: Add option to auto-disable on-board AP once STA is connected
+- Enhancement: Add option to auto-disable on-board wifi AP once machine is connected to external wifi (STA). By default this is turned on, to turn off type config-set sd wifi.ap_auto_disable false into the MDI
 - Fixed: Prevent incorrect current line reporting after a tool change
 
 [2.1.0c]


### PR DESCRIPTION
this is a rebasing and clean up of @turley 's Auto disable of the access point. I am reusing the text from this PR: https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/305

After any final comments this PR will be merged. 

## Motivation

**Subnet conflict.** The Carvera's on-board WiFi runs in STA+AP mode and the AP's default subnet is 192.168.4.0/24 (ESP8266 factory default). When the user's home network is also on 192.168.4.0/24, the M8266 ends up with two interfaces on the same /24 and TCP return-path routing breaks for any peer that's also on that subnet:

- ARP resolves fine, so ping works.
- TCP SYN-ACKs get sent out the AP interface instead of the STA interface, so connecting to port 2222 from any device on the home network hangs.
- Connecting from a different subnet/VLAN works, because return packets route via the gateway.

**Security.** The on-board AP ships open (no password) by default. For users who don't have a need for it after the Carvera has joined their home network, leaving an unprotected SSID broadcasting indefinitely from the machine isn't ideal.


## Change

Adds a new optional config option:

```
wifi.ap_auto_disable    true    # true to auto-disable AP when STA is connected
```

When set to `true`, `on_second_tick` switches op-mode to STA-only after STA has been connected (`connection_status == 5`) for a 3-second hysteresis window, and switches back to STA+AP whenever STA drops. That keeps `CARVERA_WIFI_xxxxx` available as a recovery path whenever the home network isn't, and removes the dual-interface conflict the rest of the time.

`Set_Opmode` is called with `saved=0` for the auto-toggle so the M8266 flash isn't written each cycle. At boot, when `wifi.ap_auto_disable=true`, op-mode is forced to STA+AP via `saved=0` so a stale saved mode-1 can't lock anyone out.


## Backward compatibility

Default is `false`, which is opt-in to the new behavior - when the new option isn't set, no new `Set_Opmode` calls happen at boot and the on-second-tick auto-toggle is skipped entirely. Behavior matches prior versions.

Note: this is intentionally a separate config option from the existing ap enable/ap disable [console commands](https://github.com/Carvera-Community/docs/tree/main/firmware/supported-commands/console-commands). Those still work as before - they unconditionally disable the AP and persist via the M8266's flash. The new wifi.ap_auto_disable adds smart auto-management gated on STA state, which keeps the AP available as a recovery path.


## Future work

If this gets merged, I plan to open a PR on https://github.com/Carvera-Community/Carvera_Controller to add the corresponding configuration option in the UI.


## Testing

Done:
- Builds clean against GCC 14.2 (`./build/build.sh`)
- With default config, no new SPI calls at boot and `on_second_tick` skips the new branch - behavior is unchanged from prior code
- Using `config-set sd wifi.ap_auto_disable true` updates the value as expected
- With wifi.ap_auto_disable set to true: AP disappears within ~3s of STA associating, returns when home AP goes down, and TCP from a same-subnet peer succeeds while AP is off
