### PR TITLE
MakeraPR: Corrected the shrink A command

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -784,10 +784,21 @@ void Robot::on_gcode_received(void *argument)
                     if(gcode->has_letter('A')){
                     	if (gcode->has_letter('S')) {
                     		// shrink A value
-                    		float ma = actuators[A_AXIS]->get_current_position();
-                    		if (fabs(ma) > 360) {
-                    			THEROBOT->reset_axis_position(fmodf(ma, 360.0), A_AXIS);
-                    		}
+                    		float mpos[5];
+							mpos[X_AXIS] = 0;
+							mpos[Y_AXIS] = 0;
+							mpos[Z_AXIS] = 0;
+							mpos[B_AXIS] = 0;
+							mpos[A_AXIS] = THEROBOT->actuators[A_AXIS]->get_current_position();
+							Robot::wcs_t pos = THEROBOT->mcs2wcs(mpos);
+							float wa = THEROBOT->from_millimeters(std::get<A_AXIS>(pos));
+							float ma = THEROBOT->actuators[A_AXIS]->get_current_position();
+							if(fabs(wa) > 360)
+							{
+								float deltwa = wa - fmodf(wa, 360.0);
+								ma = ma - deltwa;
+								THEROBOT->reset_axis_position(ma, A_AXIS);
+							}
                     	} else if(gcode->has_letter('R')){                    		 
                     		float x, y, z, a, b;
                         	std::tie(x, y, z, a, b) = wcs_offsets[current_wcs];    

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -791,7 +791,7 @@ void Robot::on_gcode_received(void *argument)
 							mpos[B_AXIS] = 0;
 							mpos[A_AXIS] = THEROBOT->actuators[A_AXIS]->get_current_position();
 							Robot::wcs_t pos = THEROBOT->mcs2wcs(mpos);
-							float wa = THEROBOT->from_millimeters(std::get<A_AXIS>(pos));
+							float wa = std::get<A_AXIS>(pos);
 							float ma = THEROBOT->actuators[A_AXIS]->get_current_position();
 							if(fabs(wa) > 360)
 							{

--- a/version.txt
+++ b/version.txt
@@ -6,6 +6,7 @@
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
+- Fixed: Corrected the Shrink Acommand, changing it from compressing machine coordinates to compressing work coordinates. Change from makera
 - Fixed: Prevent incorrect current line reporting after a tool change
 
 [2.1.0c]

--- a/version.txt
+++ b/version.txt
@@ -6,7 +6,7 @@
 - Enhancement: Added `debugmode cpuload` to output the % of time spent not in on_idle once per second to console
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
-- Fixed: Corrected the Shrink Acommand, changing it from compressing machine coordinates to compressing work coordinates. Change from makera
+- Fixed: Corrected the Shrink A command G92.4 A0 S0. Now instead of compressing machine coordinates it compresses work coordinates. Backported from Makera firmware
 - Fixed: Prevent incorrect current line reporting after a tool change
 
 [2.1.0c]


### PR DESCRIPTION
Fixed: Corrected the Shrink A command, changing it from compressing machine coordinates to compressing work coordinates. Change from makera

Due to the nature of Makera's pull request structure I have sorted through their code to parse out each change as a separate PR as it is difficult to cherry pick their commits.

This PR is up for discussion to determine if we want to add it to the community firmware