### PR TITLE
Makera PR: Line nunmber discarding modal commands

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -81,19 +81,21 @@ try_again:
         return;
     }
 
-    if ( first_char == 'G' || first_char == 'M' || first_char == 'T' || first_char == 'S' || first_char == 'N' || first_char == '#') {
+	//Get linenumber
 
-        //Get linenumber
-        if ( first_char == 'N' ) {
-            //Strip line number value from possible_command
-			size_t lnsize = possible_command.find_first_not_of("N0123456789.,- ");
-			if(lnsize != string::npos) {
-				possible_command = possible_command.substr(lnsize);
-			}else{
-				// it is a blank line
-				possible_command.clear();
-			}
-        }
+
+    if ( first_char == 'N' ) {
+        //Strip line number value from possible_command
+		size_t lnsize = possible_command.find_first_not_of("N0123456789.,- ");
+		if(lnsize != string::npos) {
+			possible_command = possible_command.substr(lnsize);
+		}else{
+			// it is a blank line
+			possible_command.clear();
+		}
+    }
+
+    if ( first_char == 'G' || first_char == 'M' || first_char == 'T' || first_char == 'S' || first_char == '#') {
 
         if ( first_char == 'G'){
 			//check if has G90/G91

--- a/version.txt
+++ b/version.txt
@@ -7,7 +7,7 @@
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
-- Fixed: Corrected issue with line numbered gcode files where a modal command without the letter G would be discarded. Change from Makera
+Fixed: Line-numbered gcode (e.g. N123 X10) are no longer dropped. After the line number is stripped, the rest of the line is now reprocessed normally, so modal moves without an explicit G word (e.g. N123 X10 Y10) run instead of being discarded. Backported and simplified from Makera firmware
 - Changed: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
 
 [2.1.0c]

--- a/version.txt
+++ b/version.txt
@@ -7,6 +7,7 @@
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
+- Fixed: Corrected issue with line numbered gcode files where a modal command without the letter G would be discarded. Change from Makera
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
Fixed: Corrected issue with line numbered gcode files where a modal command without the letter G would be discarded. Change from Makera

Due to the nature of Makera's pull request structure I have sorted through their code to parse out each change as a separate PR as it is difficult to cherry pick their commits.

This PR is up for discussion to determine if we want to add it to the community firmware. It is a direct uplift of makera's code and likely needs reformatting or other fixes, I modified it so that it compiles.