### PR TITLE
Makera pr  ext out and beep

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -168,12 +168,11 @@ switch.probecharger.ignore_on_halt			true			# ignore on halt
 switch.probecharger.startup_state			true			# wireless probe startup state
 
 
-switch.extend.enable						true			# Enable this module
-# switch.extend.input_pin						0.21			# Pin this module controls
-switch.extend.output_pin					2.2				# Pin this module controls
-switch.extend.output_type					hwpwm			# Digital means this is just an on or off pin
-switch.extend.input_on_command				M851			# Command that will turn this switch on
-switch.extend.input_off_command				M852			# Command that will turn this switch off
+switch.extendout.enable						true			# Enable this module
+switch.extendout.output_pin					0.29			# Pin this module controls
+switch.extendout.output_type				swpwm			# Digital means this is just an on or off pin
+switch.extendout.input_on_command			M851			# Command that will turn this switch on
+switch.extendout.input_off_command			M852			# Command that will turn this switch off
 
 switch.air.enable							true			# Enable this module
 switch.air.output_pin						0.11				# Pin this module controls

--- a/src/config2.default
+++ b/src/config2.default
@@ -392,7 +392,7 @@ sd_ok false								# Indicate SD card is corrected read
 switch.vacuum.enable 	true			# Enable this module
 switch.vacuum.input_on_command			M801			# Command that will turn this switch on
 switch.vacuum.input_off_command			M802			# Command that will turn this switch off
-switch.vacuum.output_pin				2.2				# Pin this module controls
+switch.vacuum.output_pin				nc				# Pin this module controls
 switch.vacuum.output_type				hwpwm		# Digital means this is just an on or off pin
 switch.vacuum.default_on_value 80		# Default vacuum power when open (50 - 100)
 

--- a/src/config2.default
+++ b/src/config2.default
@@ -389,6 +389,11 @@ sd_ok false								# Indicate SD card is corrected read
 
 ## Basic Settings ##
 # Vacuum
+switch.vacuum.enable 	true			# Enable this module
+switch.vacuum.input_on_command			M801			# Command that will turn this switch on
+switch.vacuum.input_off_command			M802			# Command that will turn this switch off
+switch.vacuum.output_pin				2.2				# Pin this module controls
+switch.vacuum.output_type				hwpwm		# Digital means this is just an on or off pin
 switch.vacuum.default_on_value 80		# Default vacuum power when open (50 - 100)
 
 # Light

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -79,6 +79,7 @@ Kernel::Kernel()
     uploading = false;
     laser_mode = false;
     vacuum_mode = false;
+    extout_mode = false;
     optional_stop_mode = false;
     line_by_line_exec_mode = false;
     sleeping = false;
@@ -385,11 +386,14 @@ std::string Kernel::get_query_string()
 	
     // get power temperature
     ok = PublicData::get_value( temperature_control_checksum, current_temperature_checksum, power_temperature_checksum, &temp );
-	if (ok) {
-        n= snprintf(buf, sizeof(buf), ",%1.1f", temp.current_temperature);
-        if(n > sizeof(buf)) n= sizeof(buf);
-        str.append(buf, n);
-	}
+	if (!ok) temp.current_temperature = 0;
+    n= snprintf(buf, sizeof(buf), ",%1.1f", temp.current_temperature);
+    if(n > sizeof(buf)) n= sizeof(buf);
+    str.append(buf, n);
+	// get extout_mode 
+	n= snprintf(buf, sizeof(buf), ",%d,%d,%d", 0, 0, int(this->get_extout_mode()));
+    if(n > sizeof(buf)) n= sizeof(buf);
+    str.append(buf, n);
 
     // current tool number and tool offset
     struct tool_status tool;
@@ -541,21 +545,18 @@ std::string Kernel::get_diagnose_string()
         if(n > sizeof(buf)) n = sizeof(buf);
         str.append(buf, n);
     }
-    if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
-	{	
-    	bool ok2 = false;
-    	bool ok3 = false;
-    	struct pad_switch pad2,pad3;
-	    ok = PublicData::get_value(switch_checksum, get_checksum("beep"), 0, &pad);
-	    ok2 = PublicData::get_value(switch_checksum, get_checksum("extendin"), 0, &pad2);
-	   	ok3 = PublicData::get_value(switch_checksum, get_checksum("extendout"), 0, &pad3);
-	    if (ok&&ok2&&ok3) {
-	        n = snprintf(buf, sizeof(buf), ",%d,%d,%d,%d", (int)pad.state, (int)pad2.state, (int)pad3.state, (int)pad3.value);
-	        if(n > sizeof(buf)) n = sizeof(buf);
-	        str.append(buf, n);
-	    }
-	    
-	}
+    bool ok2 = false;
+	bool ok3 = false;
+	struct pad_switch pad2,pad3;
+    ok = PublicData::get_value(switch_checksum, get_checksum("beep"), 0, &pad);
+    ok2 = PublicData::get_value(switch_checksum, get_checksum("extendin"), 0, &pad2);
+   	ok3 = PublicData::get_value(switch_checksum, get_checksum("extendout"), 0, &pad3);
+    if(!ok) pad.state = false;
+    if(!ok2) pad2.state = false;
+    if(ok3) pad3.state = false; pad3.value = 0;
+    n = snprintf(buf, sizeof(buf), ",%d,%d,%d,%d", (int)pad.state, (int)pad2.state, (int)pad3.state, (int)pad3.value);
+    if(n > sizeof(buf)) n = sizeof(buf);
+    str.append(buf, n);
     ok = PublicData::get_value(switch_checksum, get_checksum("toolsensor"), 0, &pad);
     if (ok) {
         n = snprintf(buf, sizeof(buf), "|T:%d", (int)pad.state);

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -553,7 +553,7 @@ std::string Kernel::get_diagnose_string()
    	ok3 = PublicData::get_value(switch_checksum, get_checksum("extendout"), 0, &pad3);
     if(!ok) pad.state = false;
     if(!ok2) pad2.state = false;
-    if(ok3) pad3.state = false; pad3.value = 0;
+    if(!ok3) { pad3.state = false; pad3.value = 0; }
     n = snprintf(buf, sizeof(buf), ",%d,%d,%d,%d", (int)pad.state, (int)pad2.state, (int)pad3.state, (int)pad3.value);
     if(n > sizeof(buf)) n = sizeof(buf);
     str.append(buf, n);

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -172,6 +172,9 @@ class Kernel {
         bool get_optional_stop_mode() const { return optional_stop_mode; }
         void set_line_by_line_exec_mode(bool f) { line_by_line_exec_mode = f; }
         bool get_line_by_line_exec_mode() const { return line_by_line_exec_mode; }
+        
+        void set_extout_mode(bool f) { extout_mode = f; }
+        bool get_extout_mode() const { return extout_mode; }
 
         void set_sleeping(bool f) { sleeping = f; }
         bool is_sleeping() const { return sleeping; }
@@ -286,6 +289,7 @@ class Kernel {
             volatile bool uploading:1;
             bool laser_mode:1;
             bool vacuum_mode:1;
+            bool extout_mode:1;
             bool optional_stop_mode:1;
             bool line_by_line_exec_mode:1;
             bool sleeping:1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,7 +168,7 @@ void init() {
     kernel->add_module( new ATCHandler() );
 
     // MSC File System Handler
-    //kernel->add_module( new MSCFileSystem("ud") );
+    kernel->add_module( new MSCFileSystem("ud") );
 
     // Serial Console handles IO with the wireless probe
     kernel->add_module( new(AHB) SerialConsole2() ); // must stay in AHB: UART RxIrq writes RingBuffer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,15 @@ void init() {
     GPIO beep = GPIO(P1_14);
     beep.output();
     beep = 0;
+    GPIO extout = GPIO(P0_29);
+    extout.output();
+    extout = 0;
+    extout = GPIO(P0_30);
+    extout.output();
+    extout = 0;
+    extout = GPIO(P1_19);
+    extout.output();
+    extout = 0;
 
     // open 12V
     // GPIO v12 = GPIO(P0_11);
@@ -159,7 +168,7 @@ void init() {
     kernel->add_module( new ATCHandler() );
 
     // MSC File System Handler
-    kernel->add_module( new MSCFileSystem("ud") );
+    //kernel->add_module( new MSCFileSystem("ud") );
 
     // Serial Console handles IO with the wireless probe
     kernel->add_module( new(AHB) SerialConsole2() ); // must stay in AHB: UART RxIrq writes RingBuffer

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -64,7 +64,14 @@ void SpindleControl::on_gcode_received(void *argument)
             	if (THEKERNEL->get_vacuum_mode()) {
             		// open vacuum
             		bool b = true;
-                    PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+                    if(CARVERA == THEKERNEL->factory_set->MachineModel)
+	        		{
+                    	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+                    }
+	                else
+	                {
+	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+	                }
             	}
 
                 // M3 with S value provided: set speed
@@ -87,7 +94,14 @@ void SpindleControl::on_gcode_received(void *argument)
             	if (THEKERNEL->get_vacuum_mode()) {
             		// close vacuum
             		bool b = false;
-                    PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+                    if(CARVERA == THEKERNEL->factory_set->MachineModel)
+	        		{
+                    	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+                    }
+	                else
+	                {
+	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+	                }
             	}
 
                 // M5: spindle off

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -60,19 +60,6 @@ void SpindleControl::on_gcode_received(void *argument)
             	}
 
                 THECONVEYOR->wait_for_idle();
-                // open vacuum if set
-            	if (THEKERNEL->get_vacuum_mode()) {
-            		// open vacuum
-            		bool b = true;
-                    if(CARVERA == THEKERNEL->factory_set->MachineModel)
-	        		{
-                    	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-                    }
-	                else
-	                {
-	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-	                }
-            	}
 
                 // M3 with S value provided: set speed
                 if (gcode->has_letter('S'))
@@ -84,30 +71,50 @@ void SpindleControl::on_gcode_received(void *argument)
                     turn_on();
                 }
         	}
+            // open vacuum if set
+
+
+        	if (THEKERNEL->get_vacuum_mode()) {
+        		// open vacuum
+        		bool b = true;
+        		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+        	}
+            // open extout if set
+        	if (THEKERNEL->get_extout_mode()) {
+        		// open extout
+        		bool b = true;
+        		struct pad_switch pad;
+			    bool ok = false;
+            	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+			    ok = PublicData::get_value(switch_checksum, vacuum_checksum, 0, &pad);
+			    if (ok) {
+			    	pad.state = true;
+			    	pad.value = pad.defaultvalue;
+			    	PublicData::set_value( switch_checksum, extendout_checksum, state_value_checksum, &pad );
+			    }
+        	}
         }
         else if (gcode->m == 5)
         {
         	if (!THEKERNEL->get_laser_mode()) {
                 THECONVEYOR->wait_for_idle();
 
-                // close vacuum if set
-            	if (THEKERNEL->get_vacuum_mode()) {
-            		// close vacuum
-            		bool b = false;
-                    if(CARVERA == THEKERNEL->factory_set->MachineModel)
-	        		{
-                    	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-                    }
-	                else
-	                {
-	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-	                }
-            	}
-
                 // M5: spindle off
                 if (spindle_on) {
                     turn_off();
                 }
+        	}
+            // close vacuum if set
+        	if (THEKERNEL->get_vacuum_mode()) {
+        		// close vacuum
+        		bool b = false;
+                PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+        	}
+            // close extout if set
+        	if (THEKERNEL->get_extout_mode()) {
+        		// close extout
+        		bool b = false;
+                PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
         	}
         }
         else if (gcode->m == 223)

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -264,7 +264,7 @@ void Switch::on_config_reload(void *argument)
 
         } else if(this->output_type == SWPWM) {
             // default is 50Hz
-            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->as_number(20); // ms fractions are not allowed
+            float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->as_number(10); // ms fractions are not allowed
             this->swpwm_pin->period_ms(p);
 
             // default is 0% duty cycle

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -470,6 +470,7 @@ void Switch::on_get_public_data(void *argument)
     pad->name = this->name_checksum;
     pad->state = this->switch_state;
     pad->value = this->switch_value;
+    pad->defaultvalue = this->default_on_value;
     pdr->set_taken();
 }
 

--- a/src/modules/tools/switch/SwitchPublicAccess.h
+++ b/src/modules/tools/switch/SwitchPublicAccess.h
@@ -13,6 +13,7 @@
 #define probecharger_checksum        CHECKSUM("probecharger")
 #define air_checksum               	 CHECKSUM("air")
 #define beep_checksum          	     CHECKSUM("beep")
+#define extendout_checksum			 CHECKSUM("extendout")
 
 struct pad_switch {
     int name;

--- a/src/modules/tools/switch/SwitchPublicAccess.h
+++ b/src/modules/tools/switch/SwitchPublicAccess.h
@@ -19,6 +19,7 @@ struct pad_switch {
     int name;
     bool state;
     float value;
+    float defaultvalue;
 };
 
 #endif // __SWITCHPUBLICACCESS_H

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -242,7 +242,8 @@ void SimpleShell::on_gcode_received(void *argument)
 		        		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
 			    	}
 	        	}
-	        	PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode on\r\n", 0, gcode->stream);
+	        	//PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode on\r\n", 0, gcode->stream);
+                gcode->stream->printf("turning vacuum mode on\r\n");
 			}
 			else if (gcode->subcode == 3) {
 				THEKERNEL->set_extout_mode(true);
@@ -256,7 +257,8 @@ void SimpleShell::on_gcode_received(void *argument)
 		        		PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
 			    	}
 	        	}
-	        	PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode on\r\n", 0, gcode->stream);
+	        	//PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode on\r\n", 0, gcode->stream);
+                gcode->stream->printf("turning extend out mode on\r\n");
             }
         } else if (gcode->m == 332) { // change to CNC mode			
 			if (gcode->subcode == 0) {
@@ -273,12 +275,14 @@ void SimpleShell::on_gcode_received(void *argument)
 	        	}
 				// turn off vacuum mode
 		
-				PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode off\r\n", 0, gcode->stream);
+				//PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode off\r\n", 0, gcode->stream);
+                gcode->stream->printf("turning vacuum mode off\r\n");
 			}
 			else
 			{
 				// turn on extend out mode
-				PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode off\r\n", 0, gcode->stream);
+				//PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode off\r\n", 0, gcode->stream);
+                gcode->stream->printf("turning extend out mode off\r\n");
 			}
 
 		} else if (gcode->m == 333) { // turn off optional stop mode

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -230,56 +230,49 @@ void SimpleShell::on_gcode_received(void *argument)
             if(!args.empty() && !THEKERNEL->is_grbl_mode())
                 rm_command("/sd/" + args, gcode->stream);
         } else if (gcode->m == 331) { // change to vacuum mode
-        	THEKERNEL->set_vacuum_mode(true);
-		    // get spindle state
-		    struct spindle_status ss;
-		    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
-		    if (ok) {
-		    	if (ss.state) {
-	        		// open vacuum
-	        		bool b = true;
-	        		if(CARVERA == THEKERNEL->factory_set->MachineModel)
-	        		{
-	                	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-	                }
-	                else
-	                {
-	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-	                }
-		    	}
-        	}
-        	if(CARVERA == THEKERNEL->factory_set->MachineModel)
-            {
-                PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode on\r\n", 0, gcode->stream);
+        	if (gcode->subcode == 0) {
+				THEKERNEL->set_vacuum_mode(true);
+			    // get spindle state
+			    struct spindle_status ss;
+			    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+			    if (ok) {
+			    	if (ss.state) {
+		        		// open vacuum
+		        		bool b = true;
+		        		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+			    	}
+	        	}
+	        	PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode on\r\n", 0, gcode->stream);
 			}
-			else
-			{
-				// turn on extend out mode
-				PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode on\r\n", 0, gcode->stream);
+			else if (gcode->subcode == 3) {
+				THEKERNEL->set_extout_mode(true);
+			    // get spindle state
+			    struct spindle_status ss;
+			    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+			    if (ok) {
+			    	if (ss.state) {
+		        		// open vacuum
+		        		bool b = true;
+		        		PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+			    	}
+	        	}
+	        	PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode on\r\n", 0, gcode->stream);
             }
-		} else if (gcode->m == 332) { // change to CNC mode
-			
-        	THEKERNEL->set_vacuum_mode(false);
-		    // get spindle state
-		    struct spindle_status ss;
-		    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
-		    if (ok) {
-		    	if (ss.state) {
-	        		// close vacuum
-	        		bool b = false;
-	        		if(CARVERA == THEKERNEL->factory_set->MachineModel)
-	        		{
-	                	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-	                }
-	                else
-	                {
-	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-	                }
-		    	}
-        	}
-			if(CARVERA == THEKERNEL->factory_set->MachineModel)
-	        {
-			    // turn off vacuum mode
+        } else if (gcode->m == 332) { // change to CNC mode			
+			if (gcode->subcode == 0) {
+				THEKERNEL->set_vacuum_mode(false);
+			    // get spindle state
+			    struct spindle_status ss;
+			    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+			    if (ok) {
+			    	if (ss.state) {
+		        		// close vacuum
+		        		bool b = false;
+		        		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+			    	}
+	        	}
+				// turn off vacuum mode
+		
 				PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode off\r\n", 0, gcode->stream);
 			}
 			else

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -230,41 +230,62 @@ void SimpleShell::on_gcode_received(void *argument)
             if(!args.empty() && !THEKERNEL->is_grbl_mode())
                 rm_command("/sd/" + args, gcode->stream);
         } else if (gcode->m == 331) { // change to vacuum mode
+        	THEKERNEL->set_vacuum_mode(true);
+		    // get spindle state
+		    struct spindle_status ss;
+		    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+		    if (ok) {
+		    	if (ss.state) {
+	        		// open vacuum
+	        		bool b = true;
+	        		if(CARVERA == THEKERNEL->factory_set->MachineModel)
+	        		{
+	                	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+	                }
+	                else
+	                {
+	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+	                }
+		    	}
+        	}
         	if(CARVERA == THEKERNEL->factory_set->MachineModel)
-        	{
-				THEKERNEL->set_vacuum_mode(true);
-			    // get spindle state
-			    struct spindle_status ss;
-			    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
-			    if (ok) {
-			    	if (ss.state) {
-		        		// open vacuum
-		        		bool b = true;
-		                PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-	
-			    	}
-	        	}
-			    // turn on vacuum mode
-				gcode->stream->printf("turning vacuum mode on\r\n");
+            {
+                PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode on\r\n", 0, gcode->stream);
 			}
+			else
+			{
+				// turn on extend out mode
+				PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode on\r\n", 0, gcode->stream);
+            }
 		} else if (gcode->m == 332) { // change to CNC mode
 			
-        	if(CARVERA == THEKERNEL->factory_set->MachineModel)
-        	{
-				THEKERNEL->set_vacuum_mode(false);
-			    // get spindle state
-			    struct spindle_status ss;
-			    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
-			    if (ok) {
-			    	if (ss.state) {
-		        		// close vacuum
-		        		bool b = false;
-		                PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
-	
-			    	}
-	        	}
-				// turn off vacuum mode
-				gcode->stream->printf("turning vacuum mode off\r\n");
+        	THEKERNEL->set_vacuum_mode(false);
+		    // get spindle state
+		    struct spindle_status ss;
+		    bool ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+		    if (ok) {
+		    	if (ss.state) {
+	        		// close vacuum
+	        		bool b = false;
+	        		if(CARVERA == THEKERNEL->factory_set->MachineModel)
+	        		{
+	                	PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
+	                }
+	                else
+	                {
+	                	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
+	                }
+		    	}
+        	}
+			if(CARVERA == THEKERNEL->factory_set->MachineModel)
+	        {
+			    // turn off vacuum mode
+				PacketMessage(PTYPE_NORMAL_INFO, "turning vacuum mode off\r\n", 0, gcode->stream);
+			}
+			else
+			{
+				// turn on extend out mode
+				PacketMessage(PTYPE_NORMAL_INFO, "turning extend out mode off\r\n", 0, gcode->stream);
 			}
 
 		} else if (gcode->m == 333) { // turn off optional stop mode

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1109,21 +1109,25 @@ void SimpleShell::diagnose_command( string parameters, StreamOutput *stream)
         if(n > sizeof(buf)) n = sizeof(buf);
         str.append(buf, n);
     }
-    if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
-	{	
-    	bool ok2 = false;
-    	bool ok3 = false;
-    	struct pad_switch pad2,pad3;
-	    ok = PublicData::get_value(switch_checksum, get_checksum("beep"), 0, &pad);
-	    ok2 = PublicData::get_value(switch_checksum, get_checksum("extendin"), 0, &pad2);
-	   	ok3 = PublicData::get_value(switch_checksum, get_checksum("extendout"), 0, &pad3);
-	    if (ok&&ok2&&ok3) {
-	        n = snprintf(buf, sizeof(buf), ",%d,%d,%d,%d", (int)pad.state, (int)pad2.state, (int)pad3.state, (int)pad3.value);
-	        if(n > sizeof(buf)) n = sizeof(buf);
-	        str.append(buf, n);
-	    }
-	    
-	}
+    bool ok2 = false;
+
+
+	bool ok3 = false;
+
+
+	struct pad_switch pad2,pad3;
+
+
+    ok = PublicData::get_value(switch_checksum, get_checksum("beep"), 0, &pad);
+    ok2 = PublicData::get_value(switch_checksum, get_checksum("extendin"), 0, &pad2);
+   	ok3 = PublicData::get_value(switch_checksum, get_checksum("extendout"), 0, &pad3);
+    if(!ok) pad.state = false;
+    if(!ok2) pad2.state = false;
+    if(!ok3) {pad3.state = false; pad3.value = 0;}
+    n = snprintf(buf, sizeof(buf), ",%d,%d,%d,%d", (int)pad.state, (int)pad2.state, (int)pad3.state, (int)pad3.value);
+    if(n > sizeof(buf)) n = sizeof(buf);
+    str.append(buf, n);
+
     ok = PublicData::get_value(switch_checksum, get_checksum("toolsensor"), 0, &pad);
     if (ok) {
         n = snprintf(buf, sizeof(buf), "|T:%d", (int)pad.state);

--- a/version.txt
+++ b/version.txt
@@ -10,6 +10,7 @@
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
 - Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
 - Changed: reduce PWM period in software spindle speed pwm. Change from Makera
+- Changed: Increased Software based PWM frequency from 50hz to 100hz. Backported from Makera firmware.
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -9,6 +9,7 @@
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
 - Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
+- Changed: reduce PWM period in software spindle speed pwm. Change from Makera
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -8,9 +8,7 @@
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
-- Fixed: Corrected issue with line numbered gcode files where a modal command without the letter G would be discarded. Change from Makera
-- Fixed: Optimized the path movement to the work origin before machining to prevent collisions with the workpiece or fixture. Change from Makera
-- Fixed: improved support for external vacuum on Air. Change from Makera
+- Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -8,6 +8,9 @@
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
+- Fixed: Corrected issue with line numbered gcode files where a modal command without the letter G would be discarded. Change from Makera
+- Fixed: Optimized the path movement to the work origin before machining to prevent collisions with the workpiece or fixture. Change from Makera
+- Fixed: improved support for external vacuum on Air. Change from Makera
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
This PR should allow us to add automatic ext port vacuum capability to the community controller for parity with stock firmware


Due to the nature of Makera's pull request structure I have sorted through their code to parse out each change as a separate PR as it is difficult to cherry pick their commits.

This PR is up for discussion to determine if we want to add it to the community firmware. It is a direct uplift of makera's code and likely needs reformatting or other fixes, I modified it so that it compiles.