### PR TITLE
Makera PR: Halt when lid opened during air tool change

### DIFF
--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -23,6 +23,8 @@
 #include "Gcode.h"
 #include "modules/robot/Conveyor.h"
 #include "MainButtonLed.h"
+#include "StepperMotor.h"
+#include "Robot.h"
 
 using namespace std;
 
@@ -175,7 +177,6 @@ void MainButton::on_second_tick(void *)
 
 void MainButton::on_idle(void *argument)
 {
-	bool cover_open_stop = false;
 	bool e_stop_pressed = this->e_stop.get();
     if (e_stop_pressed || button_state == BUTTON_LED_UPDATE || button_state == BUTTON_SHORT_PRESSED || button_state == BUTTON_LONG_PRESSED) {
     	// get current status
@@ -184,26 +185,6 @@ void MainButton::on_idle(void *argument)
     	    THEKERNEL->set_halt_reason(E_STOP);
     	    THEKERNEL->call_event(ON_HALT, nullptr);
     	}
-		if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
-            void *return_value;
-			bool cover_endstop_state;
-            bool ok = PublicData::get_value( player_checksum, is_playing_checksum, &return_value );
-            if (ok) {
-                bool playing = *static_cast<bool *>(return_value);
-                if (playing) {
-                	ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
-					if (ok) {
-						if (!cover_endstop_state) {
-							if (THEKERNEL->get_state() != TOOL)
-							{
-								cover_open_stop = true;
-							}
-							
-						}
-					}
-                }
-            }
-		}
 		// turn on/off power fan with delay
 		if ((state == IDLE || state == SLEEP) && !using_12v) {
     		// reset sleep timer
@@ -471,10 +452,6 @@ void MainButton::on_idle(void *argument)
 	        	}
 
 		    }*/
-    		if (cover_open_stop) {
-		        THEKERNEL->set_halt_reason(COVER_OPEN);
-		        THEKERNEL->call_event(ON_HALT, nullptr);
-    		}
     	}
     	button_state = NONE;
     }
@@ -486,6 +463,26 @@ void MainButton::on_idle(void *argument)
 // otherwise it will look for a 2 second press on the kill button to unkill if unkill is set
 uint32_t MainButton::button_tick(uint32_t dummy)
 {
+	bool cover_open_stop = false;
+	if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
+		void *return_value;
+		bool cover_endstop_state;
+
+
+		bool ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
+		if (ok && !cover_endstop_state) {
+			for (size_t i = 0; i < 4; i++) {
+				if(THEROBOT->actuators[i]->is_moving()){
+					cover_open_stop = true;
+					THEKERNEL->set_halt_reason(COVER_OPEN);
+					THEKERNEL->call_event(ON_HALT, nullptr);
+					break;
+				}
+			}
+		}
+
+	}
+
 	if (this->main_button.get()) {
 		if (!this->button_pressed) {
 			// button down

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -194,11 +194,11 @@ void MainButton::on_idle(void *argument)
                 	ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
 					if (ok) {
 						if (!cover_endstop_state) {
-								if (THEKERNEL->get_state() != TOOL)
-								{
-									cover_open_stop = true;
-								}
+							if (THEKERNEL->get_state() != TOOL)
+							{
+								cover_open_stop = true;
 							}
+							
 						}
 					}
                 }

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -194,7 +194,18 @@ void MainButton::on_idle(void *argument)
                 	ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
 					if (ok) {
 						if (!cover_endstop_state) {
-							cover_open_stop = true;
+							if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
+							{
+								cover_open_stop = true;
+							}
+							else
+							{								
+								uint8_t state = THEKERNEL->get_state();
+								if( state != TOOL)
+								{
+									cover_open_stop = true;
+								}
+							}
 						}
 					}
                 }

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -194,14 +194,7 @@ void MainButton::on_idle(void *argument)
                 	ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
 					if (ok) {
 						if (!cover_endstop_state) {
-							if(THEKERNEL->factory_set->FuncSetting & (1<<2))	//ATC 
-							{
-								cover_open_stop = true;
-							}
-							else
-							{								
-								uint8_t state = THEKERNEL->get_state();
-								if( state != TOOL)
+								if (THEKERNEL->get_state() != TOOL)
 								{
 									cover_open_stop = true;
 								}

--- a/version.txt
+++ b/version.txt
@@ -8,6 +8,7 @@
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
+- Fixed: Carvera air would halt if the lid was opened during a manual tool change and stop on lid open was enabled. Change from Makera
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -8,7 +8,7 @@
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
-- Fixed: Carvera air would halt if the lid was opened during a manual tool change and stop on lid open was enabled. Change from Makera
+- Fixed: Machine would halt if the lid was opened during a manual tool change, and the config to stop on lid open was enabled. Backported and simplified from Makera firmware.
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
Carvera air would halt if the lid was opened during a manual tool change and stop on lid open was enabled. Change from Makera

Due to the nature of Makera's pull request structure I have sorted through their code to parse out each change as a separate PR as it is difficult to cherry pick their commits.

This PR is up for discussion to determine if we want to add it to the community firmware. It is a direct uplift of makera's code and likely needs reformatting or other fixes, I modified it so that it compiles.