### PR TITLE
Changed: increased allowed gcode subcodes from 0-7 to 0-15

### DIFF
--- a/src/modules/communication/utils/Gcode.h
+++ b/src/modules/communication/utils/Gcode.h
@@ -58,7 +58,7 @@ class Gcode {
             bool has_g:1;
             bool stripped:1;
             bool is_error:1;
-            uint8_t subcode:3;
+            uint8_t subcode:4;
         };
 
         StreamOutput* stream;

--- a/version.txt
+++ b/version.txt
@@ -8,6 +8,8 @@
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Fixed: Prevent incorrect current line reporting after a tool change
 - Lint: conformed all error messages to the format ERROR: <message> for easier hooks in the controller
+- Changed: increased allowed gcode subcodes from 0-7 to 0-15
+
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
Changed: increased allowed gcode subcodes from 0-7 to 0-15

would be required for makera's probing macros, but might be nice to have in our project either way if memory permits. I remember having issues with this particular change earlier in the firmware development