### PR TITLE
Fixed: Lid Open Halt, loosely based on makera code

### DIFF
--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -177,6 +177,28 @@ void MainButton::on_second_tick(void *)
 
 void MainButton::on_idle(void *argument)
 {
+	//halt code
+	if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
+		bool cover_endstop_state;
+
+		bool ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
+		if (ok && !cover_endstop_state) {
+			if (THEKERNEL->spindleon) {
+				THEKERNEL->set_halt_reason(COVER_OPEN);
+				THEKERNEL->call_event(ON_HALT, nullptr);
+			}
+			
+			for (size_t i = 0; i < 4; i++) {
+				if(THEROBOT->actuators[i]->is_moving()){
+					THEKERNEL->set_halt_reason(COVER_OPEN);
+					THEKERNEL->call_event(ON_HALT, nullptr);
+					break;
+				}
+			}
+		}
+
+	}
+		
 	bool e_stop_pressed = this->e_stop.get();
     if (e_stop_pressed || button_state == BUTTON_LED_UPDATE || button_state == BUTTON_SHORT_PRESSED || button_state == BUTTON_LONG_PRESSED) {
     	// get current status
@@ -463,25 +485,6 @@ void MainButton::on_idle(void *argument)
 // otherwise it will look for a 2 second press on the kill button to unkill if unkill is set
 uint32_t MainButton::button_tick(uint32_t dummy)
 {
-	bool cover_open_stop = false;
-	if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
-		void *return_value;
-		bool cover_endstop_state;
-
-
-		bool ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
-		if (ok && !cover_endstop_state) {
-			for (size_t i = 0; i < 4; i++) {
-				if(THEROBOT->actuators[i]->is_moving()){
-					cover_open_stop = true;
-					THEKERNEL->set_halt_reason(COVER_OPEN);
-					THEKERNEL->call_event(ON_HALT, nullptr);
-					break;
-				}
-			}
-		}
-
-	}
 
 	if (this->main_button.get()) {
 		if (!this->button_pressed) {

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -23,6 +23,8 @@
 #include "Gcode.h"
 #include "modules/robot/Conveyor.h"
 #include "MainButtonLed.h"
+#include "StepperMotor.h"
+#include "Robot.h"
 
 using namespace std;
 
@@ -175,7 +177,6 @@ void MainButton::on_second_tick(void *)
 
 void MainButton::on_idle(void *argument)
 {
-	bool cover_open_stop = false;
 	bool e_stop_pressed = this->e_stop.get();
     if (e_stop_pressed || button_state == BUTTON_LED_UPDATE || button_state == BUTTON_SHORT_PRESSED || button_state == BUTTON_LONG_PRESSED) {
     	// get current status
@@ -184,22 +185,6 @@ void MainButton::on_idle(void *argument)
     	    THEKERNEL->set_halt_reason(E_STOP);
     	    THEKERNEL->call_event(ON_HALT, nullptr);
     	}
-		if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
-            void *return_value;
-			bool cover_endstop_state;
-            bool ok = PublicData::get_value( player_checksum, is_playing_checksum, &return_value );
-            if (ok) {
-                bool playing = *static_cast<bool *>(return_value);
-                if (playing) {
-                	ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
-					if (ok) {
-						if (!cover_endstop_state) {
-							cover_open_stop = true;
-						}
-					}
-                }
-            }
-		}
 		// turn on/off power fan with delay
 		if ((state == IDLE || state == SLEEP) && !using_12v) {
     		// reset sleep timer
@@ -467,10 +452,6 @@ void MainButton::on_idle(void *argument)
 	        	}
 
 		    }*/
-    		if (cover_open_stop) {
-		        THEKERNEL->set_halt_reason(COVER_OPEN);
-		        THEKERNEL->call_event(ON_HALT, nullptr);
-    		}
     	}
     	button_state = NONE;
     }
@@ -482,6 +463,26 @@ void MainButton::on_idle(void *argument)
 // otherwise it will look for a 2 second press on the kill button to unkill if unkill is set
 uint32_t MainButton::button_tick(uint32_t dummy)
 {
+	bool cover_open_stop = false;
+	if (this->stop_on_cover_open && !THEKERNEL->is_halted()) {
+		void *return_value;
+		bool cover_endstop_state;
+
+
+		bool ok = PublicData::get_value(endstops_checksum, get_cover_endstop_state_checksum, 0, &cover_endstop_state);
+		if (ok && !cover_endstop_state) {
+			for (size_t i = 0; i < 4; i++) {
+				if(THEROBOT->actuators[i]->is_moving()){
+					cover_open_stop = true;
+					THEKERNEL->set_halt_reason(COVER_OPEN);
+					THEKERNEL->call_event(ON_HALT, nullptr);
+					break;
+				}
+			}
+		}
+
+	}
+
 	if (this->main_button.get()) {
 		if (!this->button_pressed) {
 			// button down

--- a/version.txt
+++ b/version.txt
@@ -20,7 +20,7 @@
 - Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
 - Changed: reduce PWM period in software spindle speed pwm. Change from Makera
 - Changed: Increased Software based PWM frequency from 50hz to 100hz. Backported from Makera firmware.
-- Fixed: If config is set to halt when the lid is opened, it will now halt on any movement of the machine after a maximum of 0.1mm movement. Any time the machine is not moving the lid can be opened, fixing an issue with halts during tool changes on the Air. Backported and simplified from Makera firmware.
+- Fixed: If config is set to halt when the lid is opened, the machine will halt if any of the motion motors are moving, or the spindle is on. This change also allows manual changes if the cover is open, but will halt if the machine starts its calibration routine. refactored and signifigantly improved from makera code
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -20,6 +20,7 @@
 - Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
 - Changed: reduce PWM period in software spindle speed pwm. Change from Makera
 - Changed: Increased Software based PWM frequency from 50hz to 100hz. Backported from Makera firmware.
+- Fixed: If config is set to halt when the lid is opened, it will now halt on any movement of the machine after a maximum of 0.1mm movement. Any time the machine is not moving the lid can be opened, fixing an issue with halts during tool changes on the Air. Backported and simplified from Makera firmware.
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
Fixed: If config is set to halt when the lid is opened, it will now halt on any movement of the machine after a maximum of 0.1mm movement. Any time the machine is not moving the lid can be opened, fixing an issue with halts during tool changes on the Air. Backported and simplified from Makera firmware.

