### PR TITLE
Fix protocol switching and Makera transport handling

### DIFF
--- a/src/libs/StreamOutput.cpp
+++ b/src/libs/StreamOutput.cpp
@@ -60,7 +60,7 @@ int StreamOutput::printf(const char *format, ...)
     }
     va_end(args);
 
-    if (communication_protocol == PROTOCOL_SMOOTHIE) {
+    if (communication_protocol == PROTOCOL_SMOOTHIE || !frames_protocol_output()) {
         puts(buffer, strlen(buffer));
     } else {
         PacketMessage(PTYPE_NORMAL_INFO, buffer, strlen(buffer));
@@ -70,5 +70,34 @@ int StreamOutput::printf(const char *format, ...)
     if (buffer != b)
         delete[] buffer;
 
+    return size - 1;
+}
+
+int StreamOutput::printfcmd(const char cmd, const char *format, ...)
+{
+    char b[64];
+    char *buffer;
+    va_list args;
+    va_start(args, format);
+
+    int size = vsnprintf(b, sizeof(b), format, args) + 1;
+    va_end(args);
+
+    if (size < static_cast<int>(sizeof(b))) {
+        buffer = b;
+    } else {
+        buffer = new char[size];
+        va_start(args, format);
+        vsnprintf(buffer, size, format, args);
+        va_end(args);
+    }
+
+    if (communication_protocol == PROTOCOL_SMOOTHIE || !frames_protocol_output()) {
+        puts(buffer, strlen(buffer));
+    } else {
+        PacketMessage(cmd, buffer, strlen(buffer));
+    }
+
+    if (buffer != b) delete[] buffer;
     return size - 1;
 }

--- a/src/libs/StreamOutput.h
+++ b/src/libs/StreamOutput.h
@@ -38,7 +38,9 @@ class StreamOutput {
         virtual bool ready() { return true; };
         virtual int type() {return 0; }; // 0: serial, 1: wifi
         virtual void reset(void) {return ; };
-        virtual int printfcmd(const char cmd, const char *format, ...) __attribute__ ((format(printf, 3, 4))){ return -1; };
+        virtual bool frames_protocol_output() const { return false; }
+        virtual void on_protocol_changed() {}
+        virtual int printfcmd(const char cmd, const char *format, ...) __attribute__ ((format(printf, 3, 4)));
 
         static NullStreamOutput NullStream;
         void PacketMessage(char cmd, const char* s, int size);

--- a/src/libs/StreamOutputPool.h
+++ b/src/libs/StreamOutputPool.h
@@ -50,6 +50,15 @@ public:
         this->streams.erase(stream);
     }
 
+    bool frames_protocol_output() const { return true; }
+
+    void on_protocol_changed()
+    {
+        for(set<StreamOutput*>::iterator i = this->streams.begin(); i != this->streams.end(); i++) {
+            (*i)->on_protocol_changed();
+        }
+    }
+
 private:
     set<StreamOutput*> streams;
 };

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -25,6 +25,10 @@ using std::string;
 #include "ConfigValue.h"
 
 #define uart_checksum CHECKSUM("uart")
+#define XBUFF_LENGTH 8208
+
+extern unsigned char xbuff[XBUFF_LENGTH];
+alignas(4) static unsigned char serial_protocol_buffer[544];
 
 // Serial reading module
 // Treats every received line as a command and passes it ( via event call ) to the command dispatcher.
@@ -37,6 +41,9 @@ SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate ){
     this->default_baud_rate = baud_rate;
     this->temp_baud_rate = 0;
     this->last_activity_ms = 0;
+    this->makera_command_pending = false;
+    this->reset_makera_command_parser();
+    this->reset_file_parser();
 }
 
 SerialConsole::~SerialConsole(){
@@ -104,6 +111,15 @@ void SerialConsole::on_serial_char_received() {
 		if(THEKERNEL->is_cachewait()) {
 			continue;
 		}
+
+        if (communication_protocol == PROTOCOL_MAKERA) {
+            process_makera_byte(static_cast<uint8_t>(received));
+            if (makera_command_pending) {
+                attach_irq(false);
+                return;
+            }
+            continue;
+        }
 		
 		if (received == '?') {
 			query_flag = true;
@@ -173,19 +189,29 @@ void SerialConsole::on_idle(void * argument)
 
     if (query_flag ) {
         query_flag = false;
-        puts(THEKERNEL->get_query_string().c_str(), 0);
+        if (communication_protocol == PROTOCOL_SMOOTHIE) {
+            puts(THEKERNEL->get_query_string().c_str(), 0);
+        } else {
+            PacketMessage(PTYPE_STATUS_RES, THEKERNEL->get_query_string().c_str(), 0);
+        }
     }
 
     if (diagnose_flag) {
     	diagnose_flag = false;
-    	puts(THEKERNEL->get_diagnose_string().c_str(), 0);
+        if (communication_protocol == PROTOCOL_SMOOTHIE) {
+			puts(THEKERNEL->get_diagnose_string().c_str(), 0);
+        } else {
+            PacketMessage(PTYPE_DIAG_RES, THEKERNEL->get_diagnose_string().c_str(), 0);
+        }
     }
 
     if (halt_flag) {
         halt_flag= false;
         THEKERNEL->set_halt_reason(MANUAL);
         
-        if(THEKERNEL->is_grbl_mode()) {
+        if (communication_protocol == PROTOCOL_MAKERA) {
+            PacketMessage(PTYPE_NORMAL_INFO, "ERROR: Abort during cycle\r\n", 0);
+        } else if(THEKERNEL->is_grbl_mode()) {
             puts("ERROR: Abort during cycle\r\n", 0);
         } else {
             puts("ERROR: Abort during cycle\r\nM999 or $X to exit HALT state\r\n", 0);
@@ -196,6 +222,30 @@ void SerialConsole::on_idle(void * argument)
 
 // Actual event calling must happen in the main loop because if it happens in the interrupt we will loose data
 void SerialConsole::on_main_loop(void * argument){
+    if (communication_protocol == PROTOCOL_MAKERA) {
+        if (makera_command_pending) {
+            if (makera_data_length < 3) {
+                makera_command_pending = false;
+                reset_makera_command_parser();
+                attach_irq(true);
+                return;
+            }
+
+            uint16_t payload_length = makera_data_length - 3;
+            struct SerialMessage message;
+            message.message.assign(reinterpret_cast<char *>(&serial_protocol_buffer[5]), payload_length);
+            message.stream = this;
+            message.line = 0;
+
+            makera_command_pending = false;
+            reset_makera_command_parser();
+            THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+            attach_irq(false);
+            if (!makera_command_pending) attach_irq(true);
+        }
+        return;
+    }
+
     if ( this->has_char('\n') ){
         string received;
         received.reserve(20);
@@ -228,9 +278,186 @@ int SerialConsole::puts(const char* s, int size)
 
 int SerialConsole::gets(char** buf, int size)
 {
+	if (communication_protocol == PROTOCOL_MAKERA) {
+        while (this->serial->readable()) {
+            uint8_t received = static_cast<uint8_t>(this->serial->getc());
+            uint16_t checksum;
+
+            switch (file_parse_state) {
+                case FILE_WAIT_HEADER:
+                    file_header[0] = file_header[1];
+                    file_header[1] = received;
+                    if (((file_header[0] << 8) | file_header[1]) == HEADER) {
+                        file_parse_state = FILE_READ_LENGTH;
+                        file_bytes_needed = 2;
+                        file_frame_index = 0;
+                    }
+                    break;
+
+                case FILE_READ_LENGTH:
+                    xbuff[file_frame_index++] = received;
+                    if (--file_bytes_needed == 0) {
+                        uint16_t expected_length = (xbuff[0] << 8) | xbuff[1];
+                        if (expected_length >= 3 && expected_length <= XBUFF_LENGTH - 2) {
+                            file_parse_state = FILE_READ_DATA;
+                            file_bytes_needed = expected_length;
+                        } else {
+                            reset_file_parser();
+                        }
+                    }
+                    break;
+
+                case FILE_READ_DATA:
+                    xbuff[file_frame_index++] = received;
+                    if (--file_bytes_needed == 0) {
+                        file_parse_state = FILE_CHECK_FOOTER;
+                        file_bytes_needed = 2;
+                    }
+                    break;
+
+                case FILE_CHECK_FOOTER:
+                    file_footer[0] = file_footer[1];
+                    file_footer[1] = received;
+                    if (--file_bytes_needed == 0) {
+                        checksum = (file_footer[0] << 8) | file_footer[1];
+                        int command = checksum == FOOTER ? check_file_packet(buf) : 0;
+                        reset_file_parser();
+                        if (command != 0) return command;
+                    }
+                    break;
+            }
+        }
+        return 0;
+    }
+
 	getc_result = this->_getc();
 	*buf = &getc_result;
 	return 1;
+}
+
+void SerialConsole::reset_makera_command_parser()
+{
+    makera_header = 0;
+    makera_received = 0;
+    makera_data_length = 0;
+}
+
+void SerialConsole::process_makera_byte(uint8_t received)
+{
+    if (makera_received < 2) {
+        makera_header = (makera_header << 8) | received;
+        if (makera_header == HEADER) {
+            serial_protocol_buffer[0] = (HEADER >> 8) & 0xff;
+            serial_protocol_buffer[1] = HEADER & 0xff;
+            makera_received = 2;
+        }
+        return;
+    }
+
+    serial_protocol_buffer[makera_received++] = received;
+    if (makera_received == 4) {
+        makera_data_length = (serial_protocol_buffer[2] << 8) | serial_protocol_buffer[3];
+        if (makera_data_length < 3 || makera_data_length + 6 > sizeof(serial_protocol_buffer)) {
+            reset_makera_command_parser();
+        }
+        return;
+    }
+
+    if (makera_received < makera_data_length + 6) return;
+
+    uint16_t footer = (serial_protocol_buffer[makera_received - 2] << 8)
+                    | serial_protocol_buffer[makera_received - 1];
+    uint16_t received_crc = (serial_protocol_buffer[makera_received - 4] << 8)
+                          | serial_protocol_buffer[makera_received - 3];
+    uint16_t calculated_crc = crc16_ccitt(&serial_protocol_buffer[2], makera_data_length);
+    if (footer != FOOTER || received_crc != calculated_crc) {
+        reset_makera_command_parser();
+        return;
+    }
+
+    uint8_t command = serial_protocol_buffer[4];
+    if (command == PTYPE_CTRL_SINGLE) {
+        if (makera_data_length >= 4) {
+            uint8_t control = serial_protocol_buffer[5];
+            if (control == '?') {
+                query_flag = true;
+            } else if (control == '*') {
+                diagnose_flag = true;
+            } else if (control == 'X' - 'A' + 1) {
+                halt_flag = true;
+            } else if (control == 'Y' - 'A' + 1) {
+                if (THEKERNEL->get_internal_stop_request()) {
+                    THEKERNEL->set_internal_stop_request(false);
+                } else {
+                    THEKERNEL->set_stop_request(true);
+                    THEKERNEL->set_stop_request_time(us_ticker_read() / 1000);
+                }
+            } else if (control == 'Z' - 'A' + 1) {
+                THEKERNEL->set_keep_alive_request(true);
+            } else if (THEKERNEL->is_feed_hold_enabled() && control == '!') {
+                THEKERNEL->set_feed_hold(true);
+            } else if (THEKERNEL->is_feed_hold_enabled() && control == '~') {
+                THEKERNEL->set_feed_hold(false);
+            }
+        }
+    } else if (command == PTYPE_CTRL_MULTI || command == PTYPE_FILE_START) {
+        makera_command_pending = true;
+        return;
+    }
+
+    reset_makera_command_parser();
+}
+
+void SerialConsole::reset_file_parser()
+{
+    file_parse_state = FILE_WAIT_HEADER;
+    file_frame_index = 0;
+    file_bytes_needed = 2;
+    file_header[0] = file_header[1] = 0;
+    file_footer[0] = file_footer[1] = 0;
+}
+
+int SerialConsole::check_file_packet(char **buf)
+{
+    if (file_frame_index < 5) return 0;
+
+    uint16_t calculated_crc = crc16_ccitt(xbuff, file_frame_index - 2);
+    uint16_t received_crc = (xbuff[file_frame_index - 2] << 8) | xbuff[file_frame_index - 1];
+    if (calculated_crc != received_crc) return 0;
+
+    uint8_t command = xbuff[2];
+    switch (command) {
+        case PTYPE_FILE_MD5:
+        case PTYPE_FILE_CAN:
+        case PTYPE_FILE_VIEW:
+        case PTYPE_FILE_DATA:
+        case PTYPE_FILE_END:
+        case PTYPE_FILE_RETRY:
+        case 0xA0:
+        case PTYPE_CTRL_SINGLE:
+        case PTYPE_CTRL_MULTI:
+            *buf = reinterpret_cast<char *>(xbuff);
+            return command;
+        default:
+            return 0;
+    }
+}
+
+void SerialConsole::reset()
+{
+    reset_file_parser();
+}
+
+void SerialConsole::on_protocol_changed()
+{
+    buffer.tail = buffer.head;
+    previous_char = 0;
+    query_flag = false;
+    halt_flag = false;
+    diagnose_flag = false;
+    makera_command_pending = false;
+    reset_makera_command_parser();
+    reset_file_parser();
 }
 
 int SerialConsole::_putc(int c)

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -38,6 +38,9 @@ class SerialConsole : public Module, public StreamOutput {
         int puts(const char*, int size = 0);
         int gets(char** buf, int size = 0);
         bool ready();
+        bool frames_protocol_output() const { return true; }
+        void on_protocol_changed();
+        void reset();
         char getc_result;
 
         int get_baud() const { return current_baud_rate; }
@@ -52,6 +55,26 @@ class SerialConsole : public Module, public StreamOutput {
         int default_baud_rate;
         int temp_baud_rate;                       // non-zero = temporary baud active
         uint32_t last_activity_ms;                // for 15s timeout revert
+        volatile bool makera_command_pending;
+        uint16_t makera_header;
+        uint16_t makera_received;
+        uint16_t makera_data_length;
+
+        enum FileParseState {
+            FILE_WAIT_HEADER,
+            FILE_READ_LENGTH,
+            FILE_READ_DATA,
+            FILE_CHECK_FOOTER
+        } file_parse_state;
+        uint16_t file_frame_index;
+        uint16_t file_bytes_needed;
+        uint8_t file_header[2];
+        uint8_t file_footer[2];
+
+        void process_makera_byte(uint8_t received);
+        void reset_makera_command_parser();
+        void reset_file_parser();
+        int check_file_packet(char **buf);
         struct {
           bool query_flag:1;
           bool halt_flag:1;

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -2005,25 +2005,6 @@ void Player::upload_command( string parameters, StreamOutput *stream )
                 SendMessage(PTYPE_FILE_CAN, buf, sizeof(buf), stream);
                 goto upload_error;
             }
-            else
-            {
-                retry ++;
-                if(retry > RETRYTIME*10)
-                {
-                    SendMessage(PTYPE_FILE_RETRY, buf, 0, stream);	//resend the last package
-                    retry = 0;				
-                    tatalretry ++;
-                    stream->reset();
-                }
-
-            }
-            THEKERNEL->call_event(ON_IDLE);		
-            if(tatalretry > MAXRETRANS)
-            {
-                sprintf(error_msg, "Info: Machine receive file too many retry error!\r\n");			
-                SendMessage(PTYPE_FILE_CAN, buf, sizeof(buf), stream);
-                goto upload_error;
-            }
         }
     }
 upload_error:

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -200,12 +200,25 @@ static uint32_t heapWalk(StreamOutput *stream, bool verbose)
 
 void SimpleShell::on_module_loaded()
 {
+    this->register_for_event(ON_MAIN_LOOP);
     this->register_for_event(ON_CONSOLE_LINE_RECEIVED);
     this->register_for_event(ON_GCODE_RECEIVED);
     this->register_for_event(ON_SECOND_TICK);
     this->cont_mode_active = false;
 
     reset_delay_secs = 0;
+}
+
+void SimpleShell::on_main_loop(void *)
+{
+    if (!protocol_change_pending) return;
+
+    ProtocolMode new_protocol = pending_protocol_makera ? PROTOCOL_MAKERA : PROTOCOL_SMOOTHIE;
+    protocol_change_pending = false;
+    if (new_protocol != communication_protocol) {
+        communication_protocol = new_protocol;
+        THEKERNEL->streams->on_protocol_changed();
+    }
 }
 
 void SimpleShell::on_second_tick(void *)
@@ -222,6 +235,26 @@ void SimpleShell::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode *>(argument);
     string args = get_arguments(gcode->get_command());
+
+    if (gcode->has_m && gcode->m == 485) {
+        ProtocolMode new_protocol = communication_protocol;
+        if (gcode->subcode == 1) {
+            gcode->stream->printf("setting to smoothie communication protocol\n");
+            new_protocol = PROTOCOL_SMOOTHIE;
+        } else if (gcode->subcode == 2) {
+            gcode->stream->printf("setting to makera communication protocol\n");
+            new_protocol = PROTOCOL_MAKERA;
+        } else {
+            gcode->stream->printf("current communication protocol: %s\n",
+                    communication_protocol == PROTOCOL_SMOOTHIE ? "smoothie" : "makera");
+        }
+
+        if (new_protocol != communication_protocol) {
+            pending_protocol_makera = new_protocol == PROTOCOL_MAKERA;
+            protocol_change_pending = true;
+        }
+        return;
+    }
 
     if (gcode->has_m) {
         if (gcode->m == 20) { // list sd card
@@ -479,6 +512,7 @@ void SimpleShell::ls_command( string parameters, StreamOutput *stream )
     struct tm timeinfo;
     char dirTmp[256]; 
     unsigned int npos=0;
+    const unsigned int chunk_limit = communication_protocol == PROTOCOL_SMOOTHIE ? 7900 : 4000;
     d = fwfs::opendir(path.c_str());
     if (d != NULL) {
         while ((p = readdir(d)) != NULL) {
@@ -490,26 +524,34 @@ void SimpleShell::ls_command( string parameters, StreamOutput *stream )
         	}
         	if (opts.find("-s", 0, 2) != string::npos) {
         	    get_fftime(p->d_date, p->d_time, &timeinfo);
-        		// name size date
-                memset(dirTmp, 0, sizeof(dirTmp));
-                sprintf(dirTmp, "%s%s %d %04d%02d%02d%02d%02d%02d\r\n", string(p->d_name).c_str(),  p->d_isdir ? "/" : "",
+			// name size date
+				snprintf(dirTmp, sizeof(dirTmp), "%s%s %d %04d%02d%02d%02d%02d%02d\r\n", string(p->d_name).c_str(),  p->d_isdir ? "/" : "",
                 		p->d_isdir ? 0 : p->d_fsize, timeinfo.tm_year + 1980, timeinfo.tm_mon, timeinfo.tm_mday,
                 				timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
         	} else {
         		// only name
-                memset(dirTmp, 0, sizeof(dirTmp));
-                sprintf(dirTmp, "%s%s\r\n", string(p->d_name).c_str(), p->d_isdir ? "/" : "");
+				snprintf(dirTmp, sizeof(dirTmp), "%s%s\r\n", string(p->d_name).c_str(), p->d_isdir ? "/" : "");
         	}
-        	memcpy(&xbuff[npos], dirTmp, strlen(dirTmp));
-        	npos += strlen(dirTmp);
+
+			size_t entry_length = strlen(dirTmp);
+			if (npos != 0 && npos + entry_length > chunk_limit) {
+				if (communication_protocol == PROTOCOL_SMOOTHIE) {
+					stream->puts((char *)xbuff, npos);
+				} else {
+					PacketMessage(PTYPE_LOAD_INFO, (char *)xbuff, npos, stream);
+				}
+				npos = 0;
+			}
+			memcpy(&xbuff[npos], dirTmp, entry_length);
+			npos += entry_length;
             if (communication_protocol == PROTOCOL_SMOOTHIE) {
-                if(npos >= 7900)
+                if(npos >= chunk_limit)
                 {
         		    stream->puts((char *)xbuff, npos);
                     npos = 0;
                 }
             } else {
-                if(npos >= 4000)
+                if(npos >= chunk_limit)
                 {
                     PacketMessage(PTYPE_LOAD_INFO, (char *)xbuff, npos, stream);
                     npos = 0;
@@ -1095,17 +1137,24 @@ void SimpleShell::wlan_command( string parameters, StreamOutput *stream)
         		}
             	if (send_eof) {
                     if (communication_protocol == PROTOCOL_SMOOTHIE) {
-                        stream->_putc(CAN);
+                        stream->_putc(EOT);
                     } else {
                 	    PacketMessage(PTYPE_LOAD_FINISH, "ok\r\n", 0, stream);
                     }
             	}
         	}
         } else {
-            PacketMessage(PTYPE_LOAD_INFO, "Parameter error when setting wlan!\n", 0, stream);
-        	if (send_eof) {
-        		PacketMessage(PTYPE_LOAD_ERROR, "Parameter error when setting wlan!\r\n", 0, stream);
-        	}
+            if (communication_protocol == PROTOCOL_SMOOTHIE) {
+                stream->printf("Parameter error when setting wlan!\n");
+                if (send_eof) {
+                    stream->_putc(CAN);
+                }
+            } else {
+                PacketMessage(PTYPE_LOAD_INFO, "Parameter error when setting wlan!\n", 0, stream);
+                if (send_eof) {
+                    PacketMessage(PTYPE_LOAD_ERROR, "Parameter error when setting wlan!\r\n", 0, stream);
+                }
+            }
         }
     }
 }

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -19,9 +19,10 @@ class StreamOutput;
 class SimpleShell : public Module
 {
 public:
-    SimpleShell() {}
+    SimpleShell() : protocol_change_pending(false), pending_protocol_makera(false) {}
 
     void on_module_loaded();
+    void on_main_loop(void *);
     void on_console_line_received( void *argument );
     void on_gcode_received(void *argument);
     void on_second_tick(void *);
@@ -112,4 +113,6 @@ private:
     static int reset_delay_secs;
     uint32_t keep_alive_time;
     bool cont_mode_active;
+    bool protocol_change_pending;
+    bool pending_protocol_makera;
 };

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -58,7 +58,7 @@
 #define XBUFF_LENGTH	8208
 extern unsigned char xbuff[XBUFF_LENGTH];
 extern unsigned char fbuff[4096];
-__attribute__((section("AHBSRAM1"), aligned(4))) char WifiSerialbuff[544];
+alignas(4) static char WifiSerialbuff[544];
 
 
 
@@ -108,6 +108,7 @@ WifiProvider::WifiProvider()
 	ap_auto_disable = true;
 	ap_currently_on = true;
 	ap_off_by_auto_toggle = false;
+	protocol_restart_pending = false;
 }
 
 void WifiProvider::on_module_loaded()
@@ -173,6 +174,24 @@ void WifiProvider::on_module_loaded()
 void WifiProvider::on_pin_rise()
 {
 	has_data_flag = true;
+}
+
+void WifiProvider::on_protocol_changed()
+{
+	buffer.tail = buffer.head;
+	reset();
+	query_flag = false;
+	diagnose_flag = false;
+	halt_flag = false;
+	has_data_flag = false;
+	protocol_restart_pending = true;
+}
+
+void WifiProvider::restart_after_protocol_change()
+{
+	protocol_restart_pending = false;
+	wifi_init_ok = false;
+	init_wifi_module(true);
 }
 
 void WifiProvider::receive_wifi_data() {
@@ -275,7 +294,7 @@ void WifiProvider::receive_wifi_data() {
 		}
 		if( errorcnt > 20)
 		{
-			THEKERNEL->streams->puts("Please use Controller version V0.9.12 or later to connect.\r\n", 124); 
+			THEKERNEL->streams->puts("Please use Controller version V0.9.12 or later to connect.\r\n", 0);
 			return;
 		}
 			
@@ -303,7 +322,7 @@ void WifiProvider::receive_wifi_data() {
 		uint16_t data_len = (WifiSerialbuff[2]<<8) | WifiSerialbuff[3];
 		uint16_t total_len = 4 + data_len + 2; // header + data + crc + tail
 		
-		if (data_len > 513 || total_len > sizeof(WifiSerialbuff)){
+		if (data_len < 3 || data_len > 513 || total_len > sizeof(WifiSerialbuff)){
 	//	    	PacketMessage(PTYPE_NORMAL_INFO, "ALARM: Abort receive datalen error\r\n", 0);
 			return; 
 		}
@@ -330,7 +349,6 @@ void WifiProvider::receive_wifi_data() {
 			return;
 		}
 		
-	/*	    
 		// check CRC
 		uint16_t received_crc = (WifiSerialbuff[total_len-4] << 8) | WifiSerialbuff[total_len-3];
 		uint16_t calculated_crc = crc16_ccitt((unsigned char *)&WifiSerialbuff[2], data_len);
@@ -338,10 +356,11 @@ void WifiProvider::receive_wifi_data() {
 	//	    	PacketMessage(PTYPE_NORMAL_INFO, "ALARM: Abort receive wrong crc\r\n", 0);
 			return;
 		}
-	*/
+
 		uint8_t cmdType = WifiSerialbuff[4];
 		switch(cmdType) {
 			case PTYPE_CTRL_SINGLE: { 
+				if (data_len < 4) break;
 				if(WifiSerialbuff[5] == '?') {
 					query_flag = true;
 				}
@@ -350,6 +369,7 @@ void WifiProvider::receive_wifi_data() {
 				}
 				else if(WifiSerialbuff[5] == 'Y' - 'A' + 1) { // ^Y
 					THEKERNEL->set_stop_request(true); // generic stop what you are doing request
+					THEKERNEL->set_stop_request_time(us_ticker_read() / 1000);
 				}
 				else if(WifiSerialbuff[5] == 'Z' - 'A' + 1) { // ^Z
 					THEKERNEL->set_keep_alive_request(true);
@@ -624,11 +644,20 @@ void WifiProvider::on_second_tick(void *)
 
 void WifiProvider::on_idle(void *argument)
  {
+	if (protocol_restart_pending) {
+		restart_after_protocol_change();
+		return;
+	}
+
 	if (THEKERNEL->is_uploading()) return;
 
 	if (has_data_flag || M8266WIFI_SPI_Has_DataReceived()) {
 		has_data_flag = false;
 		receive_wifi_data();
+		if (protocol_restart_pending) {
+			restart_after_protocol_change();
+			return;
+		}
 	}
 
     if (query_flag) {
@@ -730,7 +759,7 @@ int WifiProvider::printfcmd(const char cmd, const char *format, ...)
 	if (communication_protocol == PROTOCOL_SMOOTHIE) {
 		puts(buffer, strlen(buffer));
 	} else {
-		PacketMessage(PTYPE_DIAG_RES, buffer, strlen(buffer));
+		PacketMessage(cmd, buffer, strlen(buffer));
 	}
 //    puts(buffer, strlen(buffer));
 	
@@ -763,7 +792,7 @@ int WifiProvider::printf(const char *format, ...)
 	if (communication_protocol == PROTOCOL_SMOOTHIE) {
 		puts(buffer, strlen(buffer));
 	} else {
-		PacketMessage(PTYPE_DIAG_RES, buffer, strlen(buffer));
+		PacketMessage(PTYPE_NORMAL_INFO, buffer, strlen(buffer));
 	}
 
     if (buffer != b)
@@ -1143,17 +1172,6 @@ void WifiProvider::on_gcode_received(void *argument)
 					THEKERNEL->streams->printf("AP param[%d]: %s\n", gcode->subcode, param);
 				}
 			}
-		} else if (gcode->m == 485)  {
-			if (gcode->subcode == 1) {
-				THEKERNEL->streams->printf("setting to smoothie communication protocol\n");
-				communication_protocol = PROTOCOL_SMOOTHIE;
-			}
-			else if (gcode->subcode == 2) {
-				THEKERNEL->streams->printf("setting to makera communication protocol\n");
-				communication_protocol = PROTOCOL_MAKERA;
-			} else {
-				THEKERNEL->streams->printf("current communication protocol: %s\n", (communication_protocol == PROTOCOL_SMOOTHIE) ? "smoothie" : "makera" );
-			}
 		} else if (gcode->m == 489) {
 			// query wifi status
 			query_wifi_status();
@@ -1423,10 +1441,10 @@ void WifiProvider::on_set_public_data(void *argument)
 				} else {
 					u16 status = 0;
 					u8 param_len = 0;
-					char sta_address[16];
-					char ap_address[16];
+					char sta_address[16] = {0};
+					char ap_address[16] = {0};
 					M8266WIFI_SPI_Get_STA_IP_Addr(sta_address, &status);
-					memcpy(s->ip_address,sta_address,16);
+					memcpy(s->ip_address, sta_address, sizeof(s->ip_address));
 					
 					if( M8266WIFI_SPI_Query_AP_Param(AP_PARAM_TYPE_IP_ADDR, (u8 *)ap_address, &param_len, &status) )
 					{
@@ -1534,6 +1552,8 @@ void WifiProvider::init_wifi_module(bool reset) {
 
 
 	if (reset) {
+		// Stop broadcasting to the connection before deleting it.
+		THEKERNEL->streams->remove_stream(this);
 		THEKERNEL->streams->printf("M8266WIFI_SPI_Delete_Connections...\n");
 		// disconnect current links
 		if (M8266WIFI_SPI_Delete_Connection( udp_link_no, &status) == 0){
@@ -1543,8 +1563,6 @@ void WifiProvider::init_wifi_module(bool reset) {
 			THEKERNEL->streams->printf("M8266WIFI_SPI_Delete_Connection ERROR, status:%d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
 		}
 
-		// remove current stream
-		THEKERNEL->streams->remove_stream(this);
 	}
 
 
@@ -1720,5 +1738,3 @@ int WifiProvider::type() {
 ProtocolMode WifiProvider::protocol(){
 	return communication_protocol;
 }
-
-

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -47,6 +47,8 @@ public:
     int type(); // 0: serial, 1: wifi
     ProtocolMode protocol();
     void reset(void){ptrData=0;ptr_xbuff=0;currentState = WAIT_HEADER;};
+    bool frames_protocol_output() const { return true; }
+    void on_protocol_changed();
     int printfcmd(const char cmd, const char *format, ...);
     int printf(const char *format, ...) __attribute__ ((format(printf, 2, 3)));
 
@@ -67,6 +69,7 @@ private:
 
     void on_pin_rise();
     void receive_wifi_data();
+    void restart_after_protocol_change();
     unsigned int crc16_ccitt(unsigned char *data, unsigned int len);
     int CheckFilePacket(char** buf);
 
@@ -103,6 +106,7 @@ private:
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;
     	volatile bool has_data_flag:1;
+        bool protocol_restart_pending:1;
     };
     ParseState currentState = WAIT_HEADER;    
     int ptrData;

--- a/src/modules/utils/wifi/WifiPublicAccess.h
+++ b/src/modules/utils/wifi/WifiPublicAccess.h
@@ -13,7 +13,7 @@
 struct ap_conn_info {
     char ssid[33];
     char password[64];
-    char ip_address[15];
+    char ip_address[16];
     bool has_error;
     char error_info[64];
     bool disconnect;


### PR DESCRIPTION
Add framed Makera command handling for USB and validate Wi-Fi packets. Limit framing to transport streams so file and configuration output remains plain text.

Defer M485 switching until the old protocol is acknowledged, reset transport state during changes, and fix transfer retries, WLAN responses, and buffer bounds. Keep the CPU-only receive buffers in regular SRAM.


