### PR TITLE
Pr variable fixes

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -318,7 +318,16 @@ try_again:
 						{    // concatenate the command again and send to the MDI
 							if (gcode->subcode == 1){
 								if (gcode->has_letter('P')) {
-									THEKERNEL->streams->printf("result = %.3f \n", gcode->get_value('P'));
+									float final_value = gcode->get_value('P');
+									size_t ppos = single_command.find_first_of("P");
+									if (ppos == string::npos || ppos + 1 >= single_command.length()) {
+										THEKERNEL->streams->printf("no value for M118.1 command\r\n");
+										delete gcode;
+										return;
+									}
+									string str = single_command.substr(ppos + 1);
+									str += possible_command;
+									THEKERNEL->streams->printf(" %s = %.3f \r\n", str.c_str(), final_value); // the space at the start is important for variable displays
 									delete gcode;
 									return;
 								}

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -166,14 +166,18 @@ float Gcode::set_variable_value() const {
             this->stream->printf("Variable %d set %.4f \n", var_num, value);
             return value;
         } else {
-            // If the variable number is out of the expected range, print an error
-            this->stream->printf("Variable not found \n");
-            return NAN; // Variable not found
+            // If the variable number is out of the expected range, print an error;
+            THEKERNEL->set_halt_reason(MANUAL);
+            THEKERNEL->streams->printf("ERROR: Variable %d out of range \n", var_num);
+            THEKERNEL->call_event(ON_HALT, nullptr);
+            return NAN;
         }
     }
 
     // If the input doesn't start with '#', print an error message
+    THEKERNEL->set_halt_reason(MANUAL);
     this->stream->printf("Variable not found \n");
+    THEKERNEL->call_event(ON_HALT, nullptr);
     return 0; // Default return value
 }
 

--- a/version.txt
+++ b/version.txt
@@ -21,6 +21,7 @@
 - Enhancement: Support for turning On an external connected vacuum via M851/M852. Backported from Makera firmware
 - Changed: reduce PWM period in software spindle speed pwm. Change from Makera
 - Changed: Increased Software based PWM frequency from 50hz to 100hz. Backported from Makera firmware.
+- Changed: improved M118.1 P command return to give more information. M118.1 P#101 now returns #101 = (value), will also return #101+3 = (value)
 
 [2.1.0c]
 - Fixed: Unused Variables removed

--- a/version.txt
+++ b/version.txt
@@ -22,6 +22,7 @@
 - Changed: reduce PWM period in software spindle speed pwm. Change from Makera
 - Changed: Increased Software based PWM frequency from 50hz to 100hz. Backported from Makera firmware.
 - Changed: improved M118.1 P command return to give more information. M118.1 P#101 now returns #101 = (value), will also return #101+3 = (value)
+- Fixed: any call to a variable out of range will now return a machine halt. 
 
 [2.1.0c]
 - Fixed: Unused Variables removed


### PR DESCRIPTION
- Changed: improved M118.1 P command return to give more information. M118.1 P#101 now returns # 101 = (value), will also return # 101+3 = (value)
- Fixed: any call to a variable out of range will now return a machine halt. 