### PR TITLE
Defer flex_compensation load until after config_cache_clear()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,8 @@ void init() {
     // kernel->add_module( new(AHB) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new ZProbe() );
+    ZProbe *zprobe = new ZProbe();
+    kernel->add_module( zprobe );
     #endif
     #ifndef NO_TOOLS_SCARACAL
     kernel->add_module( new SCARAcal() );
@@ -289,6 +290,12 @@ void init() {
 
     // clear up the config cache to save some memory
     kernel->config->config_cache_clear();
+
+    #ifndef NO_TOOLS_ZPROBE
+    // Flex compensation autoload (and anything else that needs main-heap room)
+    // must run only after the config cache is released.
+    zprobe->after_config_cache_clear();
+    #endif
 
     if(kernel->is_using_leds()) {
         // set some leds to indicate status... led0 init done, led1 mainloop running, led2 idle loop running, led3 sdcard ok

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -255,18 +255,27 @@ bool CartGridStrategy::handleConfig()
     reset_flex_compensation();
     reset_bed_level();
 
-    if(flex_compensation_always_active) {
-        if(load_flex_compensation_data(THEKERNEL->streams)) {
-            flex_compensation_active = true;
-            updateCompensationTransform();
-        }else{
-            THEKERNEL->set_flex_compensation_load_error(true);
-            flex_compensation_active = false;
-            updateCompensationTransform();
-        }
-    }
+    // Flex file load is deferred until after_config_cache_clear(): fopen/std::function
+    // and long printf paths allocate on the main heap, which must not grow into the
+    // fixed config-cache region while the cache is still live.
 
     return true;
+}
+
+void CartGridStrategy::after_config_cache_clear()
+{
+    if(!flex_compensation_always_active) {
+        return;
+    }
+
+    if(load_flex_compensation_data(THEKERNEL->streams)) {
+        flex_compensation_active = true;
+        updateCompensationTransform();
+    } else {
+        THEKERNEL->set_flex_compensation_load_error(true);
+        flex_compensation_active = false;
+        updateCompensationTransform();
+    }
 }
 
 void CartGridStrategy::save_grid(StreamOutput *stream)

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -18,6 +18,7 @@ public:
     ~CartGridStrategy();
     bool handleGcode(Gcode* gcode);
     bool handleConfig();
+    void after_config_cache_clear() override;
 
 private:
 

--- a/src/modules/tools/zprobe/LevelingStrategy.h
+++ b/src/modules/tools/zprobe/LevelingStrategy.h
@@ -16,6 +16,8 @@ public:
     virtual ~LevelingStrategy(){};
     virtual bool handleGcode(Gcode* gcode)= 0;
     virtual bool handleConfig()= 0;
+    // Called after config_cache_clear() so strategies can safely allocate on the main heap
+    virtual void after_config_cache_clear() {}
 
 protected:
     ZProbe *zprobe;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -191,6 +191,13 @@ void ZProbe::config_load()
 
 }
 
+void ZProbe::after_config_cache_clear()
+{
+    for(auto ls : strategies) {
+        ls->after_config_cache_clear();
+    }
+}
+
 void ZProbe::on_main_loop(void *argument)
 {
     // Handle deferred halt event from crash detection

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -103,6 +103,7 @@ public:
     void on_module_loaded();
     void on_gcode_received(void *argument);
     void on_main_loop(void *argument);
+    void after_config_cache_clear();
 
     bool check_last_probe_ok();
     bool run_probe(float& mm, float feedrate, float max_dist= -1, bool reverse= false);


### PR DESCRIPTION
Resolves #353 by defering flex-comp load until after config_cache_clear()