### PR TITLE
File integrity checking

### DIFF
--- a/src/libs/ChaNFS/FATDirHandle.cpp
+++ b/src/libs/ChaNFS/FATDirHandle.cpp
@@ -32,15 +32,18 @@ struct dirent *FATDirHandle::readdir() {
         return NULL;
     } else {
         char* fn;
-        int stringSize = 0;
 #if _USE_LFN
         fn = *finfo.lfname ? finfo.lfname : finfo.fname;
-        stringSize = *finfo.lfname ? finfo.lfsize : sizeof(finfo.fname);
 #else
-        fn = fno.fname;
-        stringSize =  sizeof(finfo.fname);
+        fn = finfo.fname;
 #endif
-        memcpy(cur_entry.d_name, fn, stringSize);
+        // Copy by strlen so we never rely on lfsize (buffer capacity) and always NUL-terminate
+        size_t namelen = strlen(fn);
+        if (namelen > NAME_MAX) {
+            namelen = NAME_MAX;
+        }
+        memcpy(cur_entry.d_name, fn, namelen);
+        cur_entry.d_name[namelen] = '\0';
         cur_entry.d_isdir= (finfo.fattrib & AM_DIR);
         cur_entry.d_fsize= finfo.fsize;
         cur_entry.d_date = finfo.fdate;

--- a/src/libs/ChaNFS/FATFileHandle.cpp
+++ b/src/libs/ChaNFS/FATFileHandle.cpp
@@ -30,13 +30,15 @@ static const char *FR_ERRORS[] = {
 };
 #endif
 
-FATFileHandle::FATFileHandle(FIL_t fh) {
+FATFileHandle::FATFileHandle(FIL_t *fh) {
     _fh = fh;
 }
     
 int FATFileHandle::close() {
     FFSDEBUG("close\n");
-    int retval = f_close(&_fh);
+    int retval = f_close(_fh);
+    delete _fh;
+    _fh = NULL;
     delete this;
     return retval;
 }
@@ -44,7 +46,7 @@ int FATFileHandle::close() {
 ssize_t FATFileHandle::write(const void* buffer, size_t length) {
     FFSDEBUG("write(%d)\n", length);
     UINT n;
-    FRESULT res = f_write(&_fh, buffer, length, &n);
+    FRESULT res = f_write(_fh, buffer, length, &n);
     if(res) {
         FFSDEBUG("f_write() failed (%d, %s)", res, FR_ERRORS[res]);
         return -1;
@@ -55,7 +57,7 @@ ssize_t FATFileHandle::write(const void* buffer, size_t length) {
 ssize_t FATFileHandle::read(void* buffer, size_t length) {
     FFSDEBUG("read(%d)\n", length);
     UINT n;
-    FRESULT res = f_read(&_fh, buffer, length, &n);
+    FRESULT res = f_read(_fh, buffer, length, &n);
     if(res) {
         FFSDEBUG("f_read() failed (%d, %s)\n", res, FR_ERRORS[res]);
         return -1;
@@ -70,23 +72,23 @@ int FATFileHandle::isatty() {
 off_t FATFileHandle::lseek(off_t position, int whence) {
     FFSDEBUG("lseek(%i,%i)\n",position,whence);
     if(whence == SEEK_END) {
-        position += _fh.fsize;
+        position += _fh->fsize;
     } else if(whence==SEEK_CUR) {
-        position += _fh.fptr;
+        position += _fh->fptr;
     }
-    FRESULT res = f_lseek(&_fh, position);
+    FRESULT res = f_lseek(_fh, position);
     if(res) {
         FFSDEBUG("lseek failed (%d, %s)\n", res, FR_ERRORS[res]);
         return -1;
     } else {
-        FFSDEBUG("lseek OK, returning %i\n", _fh.fptr);
-        return _fh.fptr;
+        FFSDEBUG("lseek OK, returning %i\n", _fh->fptr);
+        return _fh->fptr;
     }
 }
         
 int FATFileHandle::fsync() {
     FFSDEBUG("fsync()\n");
-    FRESULT res = f_sync(&_fh);
+    FRESULT res = f_sync(_fh);
     if (res) {
         FFSDEBUG("f_sync() failed (%d, %s)\n", res, FR_ERRORS[res]);
         return -1;
@@ -96,7 +98,7 @@ int FATFileHandle::fsync() {
 
 off_t FATFileHandle::flen() {
     FFSDEBUG("flen\n");
-    return _fh.fsize;
+    return _fh->fsize;
 }
 
 } // namespace mbed

--- a/src/libs/ChaNFS/FATFileHandle.h
+++ b/src/libs/ChaNFS/FATFileHandle.h
@@ -12,8 +12,8 @@ namespace mbed {
 
 class FATFileHandle : public FileHandle {
 public:
-
-    FATFileHandle(FIL_t fh);
+    // Takes ownership of heap-allocated FIL_t (avoids ~1KB stack copies on open)
+    FATFileHandle(FIL_t *fh);
     virtual int close();
     virtual ssize_t write(const void* buffer, size_t length);
     virtual ssize_t read(void* buffer, size_t length);
@@ -23,9 +23,7 @@ public:
     virtual off_t flen();
 
 protected:
-
-    FIL_t _fh;
-
+    FIL_t *_fh;
 };
 
 }

--- a/src/libs/ChaNFS/FATFileSystem.cpp
+++ b/src/libs/ChaNFS/FATFileSystem.cpp
@@ -80,8 +80,12 @@ FATFileSystem::~FATFileSystem() {
 
 FileHandle *FATFileSystem::open(const char* name, int flags) {
     FFSDEBUG("open(%s) on filesystem [%s], drv [%d]\n", name, _name, _fsid);
-    char n[64];
-    sprintf(n, "%d:/%s", _fsid, name);
+    char n[FATFS_PATH_MAX];
+    int nlen = snprintf(n, sizeof(n), "%d:/%s", _fsid, name);
+    if (nlen < 0 || nlen >= (int)sizeof(n)) {
+        FFSDEBUG("open() path too long\n");
+        return NULL;
+    }
 
     /* POSIX flags -> FatFS open mode */
     BYTE openmode;
@@ -100,14 +104,21 @@ FileHandle *FATFileSystem::open(const char* name, int flags) {
         }
     }
 
-    FIL_t fh;
-    FRESULT res = f_open(&fh, n, openmode);
+    // Heap-allocate FIL_t: it embeds a 512-byte sector buffer. Keeping it on the
+    // stack (and copying by value into FATFileHandle) blew the LPC stack during
+    // M576 and other multi-open workloads.
+    FIL_t *fh = new FIL_t;
+    if (fh == NULL) {
+        return NULL;
+    }
+    FRESULT res = f_open(fh, n, openmode);
     if(res) {
         FFSDEBUG("f_open('w') failed (%d, %s)\n", res, FR_ERRORS[res]);
+        delete fh;
         return NULL;
     }
     if(flags & O_APPEND) {
-        f_lseek(&fh, fh.fsize);
+        f_lseek(fh, fh->fsize);
     }
     return new FATFileHandle(fh);
 }
@@ -141,8 +152,12 @@ int FATFileSystem::format() {
 }
 
 DirHandle *FATFileSystem::opendir(const char *name) {
-    char n[64];
-    sprintf(n, "%d:/%s", _fsid, name);
+    char n[FATFS_PATH_MAX];
+    int nlen = snprintf(n, sizeof(n), "%d:/%s", _fsid, name);
+    if (nlen < 0 || nlen >= (int)sizeof(n)) {
+        FFSDEBUG("opendir() path too long\n");
+        return NULL;
+    }
     DIR_t dir;
     FRESULT res = f_opendir(&dir, n);
     if(res != 0) {

--- a/src/libs/ChaNFS/FATFileSystem.h
+++ b/src/libs/ChaNFS/FATFileSystem.h
@@ -13,6 +13,13 @@
 #define FFSDEBUG_ENABLED 0
 #endif
 
+// Drive-qualified path buffer for open/opendir ("0:/" + relative path).
+// FAT32 LFN allows 255 chars per path component; full path limit is MAX_PATH (260),
+// which includes the terminating NUL (same as Windows FAT32 path limit).
+#ifndef FATFS_PATH_MAX
+#define FATFS_PATH_MAX 260
+#endif
+
 #if FFSDEBUG_ENABLED
 #define FFSDEBUG(FMT, ...) printf(FMT, ##__VA_ARGS__)
 #else

--- a/src/libs/StreamOutput.cpp
+++ b/src/libs/StreamOutput.cpp
@@ -44,7 +44,7 @@ void StreamOutput::PacketMessage(char cmd, const char* s, int size)
 
 int StreamOutput::printf(const char *format, ...)
 {
-    char b[64];
+    char b[256];
     char *buffer;
     // Make the message
     va_list args;
@@ -52,47 +52,55 @@ int StreamOutput::printf(const char *format, ...)
     va_list args_copy;
     va_copy(args_copy, args);
 
-    int size = vsnprintf(b, 64, format, args) + 1; // we add one to take into account space for the terminating \0
+    int len = vsnprintf(b, sizeof(b), format, args);
+    va_end(args);
 
-    if (size < 64) {
+    if (len < 0) {
+        va_end(args_copy);
+        return -1;
+    } else if ((size_t)len < sizeof(b)) {
+        va_end(args_copy);
         buffer = b;
     } else {
-        buffer = new char[size];
-        vsnprintf(buffer, size, format, args_copy);
+        buffer = new char[len + 1];
+        vsnprintf(buffer, len + 1, format, args_copy);
+        va_end(args_copy);
     }
-    va_end(args_copy);
-    va_end(args);
 
     if (communication_protocol == PROTOCOL_SMOOTHIE || !frames_protocol_output()) {
         puts(buffer, strlen(buffer));
     } else {
         PacketMessage(PTYPE_NORMAL_INFO, buffer, strlen(buffer));
     }
-    
 
     if (buffer != b)
         delete[] buffer;
 
-    return size - 1;
+    return len;
 }
 
 int StreamOutput::printfcmd(const char cmd, const char *format, ...)
 {
-    char b[64];
+    char b[256];
     char *buffer;
     va_list args;
     va_start(args, format);
+    va_list args_copy;
+    va_copy(args_copy, args);
 
-    int size = vsnprintf(b, sizeof(b), format, args) + 1;
+    int len = vsnprintf(b, sizeof(b), format, args);
     va_end(args);
 
-    if (size < static_cast<int>(sizeof(b))) {
+    if (len < 0) {
+        va_end(args_copy);
+        return -1;
+    } else if ((size_t)len < sizeof(b)) {
+        va_end(args_copy);
         buffer = b;
     } else {
-        buffer = new char[size];
-        va_start(args, format);
-        vsnprintf(buffer, size, format, args);
-        va_end(args);
+        buffer = new char[len + 1];
+        vsnprintf(buffer, len + 1, format, args_copy);
+        va_end(args_copy);
     }
 
     if (communication_protocol == PROTOCOL_SMOOTHIE || !frames_protocol_output()) {
@@ -102,5 +110,5 @@ int StreamOutput::printfcmd(const char cmd, const char *format, ...)
     }
 
     if (buffer != b) delete[] buffer;
-    return size - 1;
+    return len;
 }

--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -225,13 +225,12 @@ string get_arguments( const string& possible_command )
 // Returns true if the file exists
 bool file_exists( const string file_name )
 {
-    bool exists = false;
     FILE *lp = fwfs::fopen(file_name.c_str(), "r");
-    if(lp) {
-        exists = true;
+    if (lp == NULL) {
+        return false;
     }
     fwfs::fclose(lp);
-    return exists;
+    return true;
 }
 
 // Prepares and executes a watchdog reset for dfu or reboot

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -59,6 +59,8 @@
 
 #include "mbed.h" // for wait_ms()
 #include <strings.h> // For strncasecmp
+#include <string.h>
+#include <vector>
 
 extern unsigned int g_maximumHeapAddress;
 extern const unsigned short crc_table[256];
@@ -239,6 +241,13 @@ void SimpleShell::on_gcode_received(void *argument)
         } else if (gcode->m == 30) { // remove file
             if(!args.empty() && !THEKERNEL->is_grbl_mode())
                 rm_command("/sd/" + args, gcode->stream);
+        } else if (gcode->m == 576) { // check SD file integrity against stored MD5 hashes
+            if (gcode->subcode == 2) {
+                md5check_file_command(args, gcode->stream);
+            } else {
+                // M576 / M576.1 -- walk all files that have a stored MD5
+                md5check_command(args, gcode->stream);
+            }
         } else if (gcode->m == 331) { // change to vacuum mode
         	if (gcode->subcode == 0) {
 				THEKERNEL->set_vacuum_mode(true);
@@ -2082,6 +2091,378 @@ void SimpleShell::md5sum_command( string parameters, StreamOutput *stream )
 	stream->printf("%s %s\n", md5.finalize().hexdigest().c_str(), filename.c_str());
 	fwfs::fclose(lp);
 
+}
+
+// Map an MD5 sidecar path back to the data file path (in-place into out buffer).
+// md5_path: /sd/gcodes/.md5/...  ->  out: /sd/gcodes/...
+// Returns false if the path is not under the MD5 tree or will not fit.
+static bool data_path_from_md5_path(const char *md5_path, char *out, size_t out_size)
+{
+    static const char prefix[] = "/sd/gcodes/.md5/";
+    static const size_t prefix_len = sizeof(prefix) - 1;
+    if (strncmp(md5_path, prefix, prefix_len) != 0) {
+        return false;
+    }
+    const char *rel = md5_path + prefix_len;
+    // "/sd/gcodes/" + rel + NUL
+    if (11 + strlen(rel) + 1 > out_size) {
+        return false;
+    }
+    strcpy(out, "/sd/gcodes/");
+    strcat(out, rel);
+    return true;
+}
+
+// FatFs open() builds paths in a 64-byte stack buffer ("0:/" + path-relative-to-mount).
+// Opening a longer path overruns that buffer and crashes. Detect and skip safely.
+static bool fatfs_path_too_long(const char *abspath)
+{
+    const char *rel = abspath;
+    if (strncmp(abspath, "/sd/", 4) == 0) {
+        rel = abspath + 4;
+    } else if (abspath[0] == '/') {
+        rel = abspath + 1;
+    }
+    // "0:/" (3) + rel + NUL (1) must fit in 64
+    return (3 + strlen(rel) + 1) > 64;
+}
+
+// Stream file through MD5 in small chunks. Uses a small stack buffer because
+// FatFs fopen() already puts a ~512-byte FIL on the stack (copied by value).
+// Writes 32 hex chars + NUL into hex_out. Returns false on failure/halt.
+static bool compute_file_md5(const char *filepath, char *hex_out)
+{
+    hex_out[0] = '\0';
+    if (fatfs_path_too_long(filepath)) {
+        return false;
+    }
+
+    FILE *lp = fwfs::fopen(filepath, "r");
+    if (lp == NULL) {
+        return false;
+    }
+
+    MD5 md5;
+    uint8_t buf[64];
+    size_t n;
+    while ((n = fwfs::fread(buf, 1, sizeof(buf), lp)) > 0) {
+        md5.update(buf, static_cast<MD5::size_type>(n));
+        THEKERNEL->call_event(ON_IDLE);
+        if (THEKERNEL->is_halted()) {
+            fwfs::fclose(lp);
+            return false;
+        }
+    }
+    fwfs::fclose(lp);
+
+    string hex = md5.finalize().hexdigest();
+    if (hex.size() < 32) {
+        return false;
+    }
+    memcpy(hex_out, hex.c_str(), 32);
+    hex_out[32] = '\0';
+    return true;
+}
+
+// Read the 32-char stored MD5 from a sidecar file into hex_out (33 bytes).
+static bool read_stored_md5(const char *md5_path, char *hex_out)
+{
+    hex_out[0] = '\0';
+    if (fatfs_path_too_long(md5_path)) {
+        return false;
+    }
+
+    FILE *fp = fwfs::fopen(md5_path, "r");
+    if (fp == NULL) {
+        return false;
+    }
+
+    memset(hex_out, 0, 33);
+    size_t n = fwfs::fread(hex_out, 1, 32, fp);
+    fwfs::fclose(fp);
+    if (n < 32) {
+        hex_out[0] = '\0';
+        return false;
+    }
+    hex_out[32] = '\0';
+    return true;
+}
+
+// Compare data file against an already-known MD5 sidecar path (no mkdir/opendir).
+static bool file_matches_md5_sidecar(const char *md5_path, const char *data_path)
+{
+    char stored[33];
+    char computed[33];
+    if (!read_stored_md5(md5_path, stored)) {
+        return false;
+    }
+    if (!compute_file_md5(data_path, computed)) {
+        return false;
+    }
+    return strncasecmp(computed, stored, 32) == 0;
+}
+
+// Working path buffer for the directory walk (absolute paths under /sd/...).
+// FatFs open() separately limits relative paths to fit in 64 bytes; we check that too.
+static const size_t MD5_CHECK_PATH_MAX = 96;
+
+// Recursively count MD5 sidecar files. Mutates `path` in place (must be writable).
+// Only stores short basenames of subdirs -- not full path lists -- to limit heap use.
+static unsigned int count_md5_sidecars(char *path)
+{
+    DIR *d = fwfs::opendir(path);
+    if (d == NULL) {
+        return 0;
+    }
+
+    unsigned int count = 0;
+    std::vector<string> subdirs;
+    struct dirent *p;
+    while ((p = readdir(d)) != NULL) {
+        if (p->d_name[0] == '.') {
+            continue;
+        }
+        if (p->d_isdir) {
+            subdirs.push_back(p->d_name);
+        } else {
+            count++;
+        }
+    }
+    closedir(d);
+
+    size_t baselen = strlen(path);
+    for (size_t i = 0; i < subdirs.size(); i++) {
+        if (baselen + 1 + subdirs[i].size() + 1 > MD5_CHECK_PATH_MAX) {
+            continue;
+        }
+        path[baselen] = '/';
+        strcpy(path + baselen + 1, subdirs[i].c_str());
+        count += count_md5_sidecars(path);
+        path[baselen] = '\0';
+        THEKERNEL->call_event(ON_IDLE);
+        if (THEKERNEL->is_halted()) {
+            break;
+        }
+    }
+    return count;
+}
+
+// Recursively verify files. Mutates `md5_path` in place. Checks each file as it is
+// found (no list of full paths held across hashing).
+static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned int total, StreamOutput *stream, bool& aborted)
+{
+    if (aborted || THEKERNEL->is_halted()) {
+        aborted = true;
+        return;
+    }
+
+    DIR *d = fwfs::opendir(md5_path);
+    if (d == NULL) {
+        return;
+    }
+
+    std::vector<string> files;
+    std::vector<string> subdirs;
+    struct dirent *p;
+    while ((p = readdir(d)) != NULL) {
+        if (p->d_name[0] == '.') {
+            continue;
+        }
+        if (p->d_isdir) {
+            subdirs.push_back(p->d_name);
+        } else {
+            files.push_back(p->d_name);
+        }
+    }
+    closedir(d);
+
+    size_t baselen = strlen(md5_path);
+    char data_path[MD5_CHECK_PATH_MAX];
+
+    for (size_t i = 0; i < files.size(); i++) {
+        if (THEKERNEL->is_halted()) {
+            aborted = true;
+            return;
+        }
+
+        if (baselen + 1 + files[i].size() + 1 > MD5_CHECK_PATH_MAX) {
+            current++;
+            stream->printf("[%u/%u] - (path too long)\n", current, total);
+            stream->printf("Corrupt\n");
+            continue;
+        }
+
+        md5_path[baselen] = '/';
+        strcpy(md5_path + baselen + 1, files[i].c_str());
+
+        current++;
+        if (!data_path_from_md5_path(md5_path, data_path, sizeof(data_path))) {
+            stream->printf("[%u/%u] - %s\n", current, total, md5_path);
+            stream->printf("Corrupt\n");
+            md5_path[baselen] = '\0';
+            continue;
+        }
+
+        stream->printf("[%u/%u] - %s\n", current, total, data_path);
+
+        if (fatfs_path_too_long(md5_path) || fatfs_path_too_long(data_path)) {
+            stream->printf("Corrupt\n");
+        } else {
+            bool intact = file_matches_md5_sidecar(md5_path, data_path);
+            stream->printf("%s\n", intact ? "Intact" : "Corrupt");
+        }
+
+        md5_path[baselen] = '\0';
+        THEKERNEL->call_event(ON_IDLE);
+    }
+
+    for (size_t i = 0; i < subdirs.size(); i++) {
+        if (aborted || THEKERNEL->is_halted()) {
+            aborted = true;
+            return;
+        }
+        if (baselen + 1 + subdirs[i].size() + 1 > MD5_CHECK_PATH_MAX) {
+            continue;
+        }
+        md5_path[baselen] = '/';
+        strcpy(md5_path + baselen + 1, subdirs[i].c_str());
+        verify_md5_sidecars(md5_path, current, total, stream, aborted);
+        md5_path[baselen] = '\0';
+    }
+}
+
+// Run count + verify walk starting at an MD5 sidecar directory root.
+static void run_md5_check_walk(const char *md5_root, StreamOutput *stream)
+{
+    if (strlen(md5_root) >= MD5_CHECK_PATH_MAX) {
+        stream->printf("ERROR: Path too long\n");
+        return;
+    }
+
+    char md5_path[MD5_CHECK_PATH_MAX];
+    strncpy(md5_path, md5_root, sizeof(md5_path) - 1);
+    md5_path[sizeof(md5_path) - 1] = '\0';
+
+    unsigned int total = count_md5_sidecars(md5_path);
+
+    // Restore root after count walk
+    strncpy(md5_path, md5_root, sizeof(md5_path) - 1);
+    md5_path[sizeof(md5_path) - 1] = '\0';
+
+    if (THEKERNEL->is_halted()) {
+        stream->printf("ERROR: File integrity check aborted\n");
+        return;
+    }
+
+    if (total == 0) {
+        stream->printf("No files with stored MD5 hashes found\n");
+        return;
+    }
+
+    unsigned int current = 0;
+    bool aborted = false;
+    verify_md5_sidecars(md5_path, current, total, stream, aborted);
+
+    if (aborted || THEKERNEL->is_halted()) {
+        stream->printf("ERROR: File integrity check aborted\n");
+    }
+}
+
+static bool path_is_directory(const char *path)
+{
+    DIR *d = fwfs::opendir(path);
+    if (d == NULL) {
+        return false;
+    }
+    closedir(d);
+    return true;
+}
+
+// Strip trailing slashes (except root "/")
+static void strip_trailing_slashes(string& path)
+{
+    while (path.size() > 1 && path[path.size() - 1] == '/') {
+        path.erase(path.size() - 1);
+    }
+}
+
+// M576 / M576.1 -- walk all gcode files that have a stored MD5 and verify them
+void SimpleShell::md5check_command( string parameters, StreamOutput *stream )
+{
+    (void)parameters;
+
+    if (THEKERNEL->is_halted()) {
+        stream->printf("ERROR: Cannot check file integrity while halted\n");
+        return;
+    }
+
+    run_md5_check_walk("/sd/gcodes/.md5", stream);
+}
+
+// M576.2 -- check a single file, or recursively check a directory
+void SimpleShell::md5check_file_command( string parameters, StreamOutput *stream )
+{
+    if (parameters.empty()) {
+        stream->printf("ERROR: M576.2 requires a file or directory path\n");
+        return;
+    }
+
+    if (THEKERNEL->is_halted()) {
+        stream->printf("ERROR: Cannot check file integrity while halted\n");
+        return;
+    }
+
+    string filename = absolute_from_relative(parameters);
+    strip_trailing_slashes(filename);
+
+    // Normalize relative gcode paths to /sd/gcodes/... when needed
+    if (filename.find("gcodes/") == string::npos && filename != "/sd/gcodes") {
+        if (!parameters.empty() && parameters[0] != '/') {
+            filename = "/sd/gcodes/" + parameters;
+            strip_trailing_slashes(filename);
+        }
+    }
+
+    if (filename.find("gcodes/") == string::npos && filename != "/sd/gcodes") {
+        stream->printf("ERROR: Path must be under /sd/gcodes/\n");
+        return;
+    }
+
+    // Directory: walk the matching MD5 sidecar tree for this folder and children
+    if (path_is_directory(filename.c_str())) {
+        string md5_root;
+        if (filename == "/sd/gcodes") {
+            md5_root = "/sd/gcodes/.md5";
+        } else {
+            md5_root = change_to_md5_path(filename);
+        }
+
+        // change_to_md5_path may leave a trailing slash-less path; ensure it exists as a dir
+        if (!path_is_directory(md5_root.c_str())) {
+            stream->printf("No files with stored MD5 hashes found\n");
+            return;
+        }
+
+        run_md5_check_walk(md5_root.c_str(), stream);
+        return;
+    }
+
+    // Single file
+    if (fatfs_path_too_long(filename.c_str())) {
+        stream->printf("ERROR: Path too long for SD open: %s\n", filename.c_str());
+        return;
+    }
+
+    string md5_path = change_to_md5_path(filename);
+    char stored[33];
+    if (!read_stored_md5(md5_path.c_str(), stored)) {
+        stream->printf("ERROR: No MD5 hash found for %s\n", filename.c_str());
+        return;
+    }
+
+    stream->printf("[1/1] - %s\n", filename.c_str());
+    bool intact = file_matches_md5_sidecar(md5_path.c_str(), filename.c_str());
+    stream->printf("%s\n", intact ? "Intact" : "Corrupt");
 }
 
 // runs several types of test on the mechanisms

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -46,6 +46,7 @@
 #include "platform_memory.h"
 #include "SwitchPublicAccess.h"
 #include "SDFAT.h"
+#include "FATFileSystem.h"
 #include "Thermistor.h"
 #include "md5.h"
 #include "utils.h"
@@ -2093,28 +2094,7 @@ void SimpleShell::md5sum_command( string parameters, StreamOutput *stream )
 
 }
 
-// Map an MD5 sidecar path back to the data file path (in-place into out buffer).
-// md5_path: /sd/gcodes/.md5/...  ->  out: /sd/gcodes/...
-// Returns false if the path is not under the MD5 tree or will not fit.
-static bool data_path_from_md5_path(const char *md5_path, char *out, size_t out_size)
-{
-    static const char prefix[] = "/sd/gcodes/.md5/";
-    static const size_t prefix_len = sizeof(prefix) - 1;
-    if (strncmp(md5_path, prefix, prefix_len) != 0) {
-        return false;
-    }
-    const char *rel = md5_path + prefix_len;
-    // "/sd/gcodes/" + rel + NUL
-    if (11 + strlen(rel) + 1 > out_size) {
-        return false;
-    }
-    strcpy(out, "/sd/gcodes/");
-    strcat(out, rel);
-    return true;
-}
-
-// FatFs open() builds paths in a 64-byte stack buffer ("0:/" + path-relative-to-mount).
-// Opening a longer path overruns that buffer and crashes. Detect and skip safely.
+// FatFs open/opendir build paths in a FATFS_PATH_MAX buffer ("0:/" + path-relative-to-mount).
 static bool fatfs_path_too_long(const char *abspath)
 {
     const char *rel = abspath;
@@ -2123,13 +2103,39 @@ static bool fatfs_path_too_long(const char *abspath)
     } else if (abspath[0] == '/') {
         rel = abspath + 1;
     }
-    // "0:/" (3) + rel + NUL (1) must fit in 64
-    return (3 + strlen(rel) + 1) > 64;
+    return (3 + strlen(rel) + 1) > FATFS_PATH_MAX;
 }
 
-// Stream file through MD5 in small chunks. Uses a small stack buffer because
-// FatFs fopen() already puts a ~512-byte FIL on the stack (copied by value).
-// Writes 32 hex chars + NUL into hex_out. Returns false on failure/halt.
+// Build MD5 sidecar path from a data file path without mkdir/opendir side effects.
+static bool md5_path_from_data_path(const char *data_path, char *out, size_t out_size)
+{
+    static const char prefix[] = "/sd/gcodes/";
+    static const size_t prefix_len = sizeof(prefix) - 1;
+    if (strncmp(data_path, prefix, prefix_len) != 0) {
+        return false;
+    }
+    const char *rel = data_path + prefix_len;
+    if (17 + strlen(rel) + 1 > out_size) {
+        return false;
+    }
+    strcpy(out, "/sd/gcodes/.md5/");
+    strcat(out, rel);
+    return true;
+}
+
+static void md5_hex_from_digest(const MD5& md5, char *hex_out)
+{
+    uint8_t digest[16];
+    md5.bindigest(digest, 16);
+    for (int i = 0; i < 16; i++) {
+        static const char hexdigits[] = "0123456789abcdef";
+        hex_out[i * 2] = hexdigits[digest[i] >> 4];
+        hex_out[i * 2 + 1] = hexdigits[digest[i] & 0x0f];
+    }
+    hex_out[32] = '\0';
+}
+
+// Stream file through MD5 using stdio fopen (FIL_t is heap-allocated in FatFs open).
 static bool compute_file_md5(const char *filepath, char *hex_out)
 {
     hex_out[0] = '\0';
@@ -2143,24 +2149,24 @@ static bool compute_file_md5(const char *filepath, char *hex_out)
     }
 
     MD5 md5;
-    uint8_t buf[64];
+    uint8_t buf[128];
     size_t n;
+    unsigned idle_ctr = 0;
     while ((n = fwfs::fread(buf, 1, sizeof(buf), lp)) > 0) {
         md5.update(buf, static_cast<MD5::size_type>(n));
-        THEKERNEL->call_event(ON_IDLE);
-        if (THEKERNEL->is_halted()) {
-            fwfs::fclose(lp);
-            return false;
+        // ~every 4KB; never call ON_IDLE while a DIR is open
+        if ((++idle_ctr & 0x1f) == 0) {
+            THEKERNEL->call_event(ON_IDLE);
+            if (THEKERNEL->is_halted()) {
+                fwfs::fclose(lp);
+                return false;
+            }
         }
     }
     fwfs::fclose(lp);
 
-    string hex = md5.finalize().hexdigest();
-    if (hex.size() < 32) {
-        return false;
-    }
-    memcpy(hex_out, hex.c_str(), 32);
-    hex_out[32] = '\0';
+    md5.finalize();
+    md5_hex_from_digest(md5, hex_out);
     return true;
 }
 
@@ -2188,7 +2194,6 @@ static bool read_stored_md5(const char *md5_path, char *hex_out)
     return true;
 }
 
-// Compare data file against an already-known MD5 sidecar path (no mkdir/opendir).
 static bool file_matches_md5_sidecar(const char *md5_path, const char *data_path)
 {
     char stored[33];
@@ -2202,61 +2207,102 @@ static bool file_matches_md5_sidecar(const char *md5_path, const char *data_path
     return strncasecmp(computed, stored, 32) == 0;
 }
 
-// Working path buffer for the directory walk (absolute paths under /sd/...).
-// FatFs open() separately limits relative paths to fit in 64 bytes; we check that too.
-static const size_t MD5_CHECK_PATH_MAX = 96;
+// Working path buffer size for the directory walk (absolute paths under /sd/...).
+static const size_t MD5_CHECK_PATH_MAX = FATFS_PATH_MAX;
 
-// Recursively count MD5 sidecar files. Mutates `path` in place (must be writable).
-// Only stores short basenames of subdirs -- not full path lists -- to limit heap use.
-static unsigned int count_md5_sidecars(char *path)
+static bool path_is_directory(const char *path)
 {
     DIR *d = fwfs::opendir(path);
+    if (d == NULL) {
+        return false;
+    }
+    closedir(d);
+    return true;
+}
+
+// True if this gcodes data file has a matching MD5 sidecar.
+static bool sidecar_exists_for_data(const char *data_path, char *md5_path)
+{
+    if (!md5_path_from_data_path(data_path, md5_path, MD5_CHECK_PATH_MAX)) {
+        return false;
+    }
+    if (fatfs_path_too_long(md5_path)) {
+        return false;
+    }
+    return file_exists(md5_path);
+}
+
+// Count data files that have a matching MD5 sidecar (same criteria as verify).
+// Do NOT call ON_IDLE while a DIR is open (_USE_LFN == 1 is not reentrant).
+static unsigned int count_hashed_data_files(char *data_path, char *md5_path)
+{
+    DIR *d = fwfs::opendir(data_path);
     if (d == NULL) {
         return 0;
     }
 
     unsigned int count = 0;
     std::vector<string> subdirs;
+    std::vector<string> files;
     struct dirent *p;
     while ((p = readdir(d)) != NULL) {
         if (p->d_name[0] == '.') {
             continue;
         }
+        if (p->d_isdir && (strcmp(p->d_name, ".md5") == 0 || strcmp(p->d_name, ".lz") == 0)) {
+            continue;
+        }
         if (p->d_isdir) {
             subdirs.push_back(p->d_name);
         } else {
-            count++;
+            files.push_back(p->d_name);
         }
     }
     closedir(d);
 
-    size_t baselen = strlen(path);
-    for (size_t i = 0; i < subdirs.size(); i++) {
-        if (baselen + 1 + subdirs[i].size() + 1 > MD5_CHECK_PATH_MAX) {
+    size_t baselen = strlen(data_path);
+    for (size_t i = 0; i < files.size(); i++) {
+        if (baselen + 1 + files[i].size() + 1 > MD5_CHECK_PATH_MAX) {
             continue;
         }
-        path[baselen] = '/';
-        strcpy(path + baselen + 1, subdirs[i].c_str());
-        count += count_md5_sidecars(path);
-        path[baselen] = '\0';
-        THEKERNEL->call_event(ON_IDLE);
+        data_path[baselen] = '/';
+        strcpy(data_path + baselen + 1, files[i].c_str());
+        if (sidecar_exists_for_data(data_path, md5_path)) {
+            count++;
+        }
+        data_path[baselen] = '\0';
+    }
+    files.clear();
+
+    for (size_t i = 0; i < subdirs.size(); i++) {
         if (THEKERNEL->is_halted()) {
             break;
         }
+        if (baselen + 1 + subdirs[i].size() + 1 > MD5_CHECK_PATH_MAX) {
+            continue;
+        }
+        data_path[baselen] = '/';
+        strcpy(data_path + baselen + 1, subdirs[i].c_str());
+        count += count_hashed_data_files(data_path, md5_path);
+        data_path[baselen] = '\0';
+        THEKERNEL->call_event(ON_IDLE);
     }
     return count;
 }
 
-// Recursively verify files. Mutates `md5_path` in place. Checks each file as it is
-// found (no list of full paths held across hashing).
-static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned int total, StreamOutput *stream, bool& aborted)
+// Verify by walking data LFNs (full names). Skip files with no sidecar.
+// Do NOT call ON_IDLE while a DIR is open.
+static void verify_hashed_data_files(char *data_path, char *md5_path,
+                                     unsigned int& current, unsigned int total,
+                                     unsigned int& intact_count, unsigned int& corrupt_count,
+                                     StreamOutput *stream, bool& aborted)
 {
     if (aborted || THEKERNEL->is_halted()) {
         aborted = true;
         return;
     }
 
-    DIR *d = fwfs::opendir(md5_path);
+    DIR *d = fwfs::opendir(data_path);
     if (d == NULL) {
         return;
     }
@@ -2268,6 +2314,9 @@ static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned 
         if (p->d_name[0] == '.') {
             continue;
         }
+        if (p->d_isdir && (strcmp(p->d_name, ".md5") == 0 || strcmp(p->d_name, ".lz") == 0)) {
+            continue;
+        }
         if (p->d_isdir) {
             subdirs.push_back(p->d_name);
         } else {
@@ -2276,8 +2325,7 @@ static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned 
     }
     closedir(d);
 
-    size_t baselen = strlen(md5_path);
-    char data_path[MD5_CHECK_PATH_MAX];
+    size_t baselen = strlen(data_path);
 
     for (size_t i = 0; i < files.size(); i++) {
         if (THEKERNEL->is_halted()) {
@@ -2286,35 +2334,37 @@ static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned 
         }
 
         if (baselen + 1 + files[i].size() + 1 > MD5_CHECK_PATH_MAX) {
-            current++;
-            stream->printf("[%u/%u] - (path too long)\n", current, total);
-            stream->printf("Corrupt\n");
             continue;
         }
 
-        md5_path[baselen] = '/';
-        strcpy(md5_path + baselen + 1, files[i].c_str());
+        data_path[baselen] = '/';
+        strcpy(data_path + baselen + 1, files[i].c_str());
+
+        if (!sidecar_exists_for_data(data_path, md5_path)) {
+            data_path[baselen] = '\0';
+            continue;
+        }
 
         current++;
-        if (!data_path_from_md5_path(md5_path, data_path, sizeof(data_path))) {
-            stream->printf("[%u/%u] - %s\n", current, total, md5_path);
-            stream->printf("Corrupt\n");
-            md5_path[baselen] = '\0';
-            continue;
-        }
-
         stream->printf("[%u/%u] - %s\n", current, total, data_path);
 
-        if (fatfs_path_too_long(md5_path) || fatfs_path_too_long(data_path)) {
-            stream->printf("Corrupt\n");
+        bool intact = false;
+        if (!fatfs_path_too_long(data_path) && !fatfs_path_too_long(md5_path)) {
+            intact = file_matches_md5_sidecar(md5_path, data_path);
+        }
+        if (intact) {
+            intact_count++;
+            stream->printf("Intact\n");
         } else {
-            bool intact = file_matches_md5_sidecar(md5_path, data_path);
-            stream->printf("%s\n", intact ? "Intact" : "Corrupt");
+            corrupt_count++;
+            stream->printf("Corrupt\n");
         }
 
-        md5_path[baselen] = '\0';
+        data_path[baselen] = '\0';
         THEKERNEL->call_event(ON_IDLE);
     }
+
+    files.clear();
 
     for (size_t i = 0; i < subdirs.size(); i++) {
         if (aborted || THEKERNEL->is_halted()) {
@@ -2324,58 +2374,76 @@ static void verify_md5_sidecars(char *md5_path, unsigned int& current, unsigned 
         if (baselen + 1 + subdirs[i].size() + 1 > MD5_CHECK_PATH_MAX) {
             continue;
         }
-        md5_path[baselen] = '/';
-        strcpy(md5_path + baselen + 1, subdirs[i].c_str());
-        verify_md5_sidecars(md5_path, current, total, stream, aborted);
-        md5_path[baselen] = '\0';
+        data_path[baselen] = '/';
+        strcpy(data_path + baselen + 1, subdirs[i].c_str());
+        verify_hashed_data_files(data_path, md5_path, current, total,
+                                 intact_count, corrupt_count, stream, aborted);
+        data_path[baselen] = '\0';
+        THEKERNEL->call_event(ON_IDLE);
     }
 }
 
-// Run count + verify walk starting at an MD5 sidecar directory root.
-static void run_md5_check_walk(const char *md5_root, StreamOutput *stream)
+// Run count + verify. data_root is a /sd/gcodes/... directory.
+static void run_md5_check_walk(const char *data_root, StreamOutput *stream)
 {
-    if (strlen(md5_root) >= MD5_CHECK_PATH_MAX) {
-        stream->printf("ERROR: Path too long\n");
+    // Heap-allocate walk buffers (not BSS -- LPC main RAM is tight).
+    char *data_path = new char[MD5_CHECK_PATH_MAX];
+    char *md5_path = new char[MD5_CHECK_PATH_MAX];
+    if (data_path == NULL || md5_path == NULL) {
+        delete[] data_path;
+        delete[] md5_path;
+        stream->printf("ERROR: Out of memory\n");
         return;
     }
 
-    char md5_path[MD5_CHECK_PATH_MAX];
-    strncpy(md5_path, md5_root, sizeof(md5_path) - 1);
-    md5_path[sizeof(md5_path) - 1] = '\0';
+    if (strlen(data_root) >= MD5_CHECK_PATH_MAX) {
+        stream->printf("ERROR: Path too long\n");
+        delete[] data_path;
+        delete[] md5_path;
+        return;
+    }
+    strcpy(data_path, data_root);
 
-    unsigned int total = count_md5_sidecars(md5_path);
+    stream->printf("Scanning for files with MD5 hashes...\n");
 
-    // Restore root after count walk
-    strncpy(md5_path, md5_root, sizeof(md5_path) - 1);
-    md5_path[sizeof(md5_path) - 1] = '\0';
+    // Same walk criteria as verify: data LFN + matching sidecar (not raw .md5
+    // entries — those can include orphan truncated names from older firmware).
+    unsigned int total = count_hashed_data_files(data_path, md5_path);
+
+    strcpy(data_path, data_root);
 
     if (THEKERNEL->is_halted()) {
         stream->printf("ERROR: File integrity check aborted\n");
+        delete[] data_path;
+        delete[] md5_path;
         return;
     }
 
     if (total == 0) {
         stream->printf("No files with stored MD5 hashes found\n");
+        delete[] data_path;
+        delete[] md5_path;
         return;
     }
 
+    stream->printf("Checking %u file(s)...\n", total);
+
     unsigned int current = 0;
+    unsigned int intact_count = 0;
+    unsigned int corrupt_count = 0;
     bool aborted = false;
-    verify_md5_sidecars(md5_path, current, total, stream, aborted);
+    verify_hashed_data_files(data_path, md5_path, current, total,
+                             intact_count, corrupt_count, stream, aborted);
 
     if (aborted || THEKERNEL->is_halted()) {
         stream->printf("ERROR: File integrity check aborted\n");
+    } else {
+        stream->printf("File integrity check complete: %u intact, %u corrupt\n",
+                       intact_count, corrupt_count);
     }
-}
 
-static bool path_is_directory(const char *path)
-{
-    DIR *d = fwfs::opendir(path);
-    if (d == NULL) {
-        return false;
-    }
-    closedir(d);
-    return true;
+    delete[] data_path;
+    delete[] md5_path;
 }
 
 // Strip trailing slashes (except root "/")
@@ -2396,7 +2464,7 @@ void SimpleShell::md5check_command( string parameters, StreamOutput *stream )
         return;
     }
 
-    run_md5_check_walk("/sd/gcodes/.md5", stream);
+    run_md5_check_walk("/sd/gcodes", stream);
 }
 
 // M576.2 -- check a single file, or recursively check a directory
@@ -2428,41 +2496,36 @@ void SimpleShell::md5check_file_command( string parameters, StreamOutput *stream
         return;
     }
 
-    // Directory: walk the matching MD5 sidecar tree for this folder and children
+    // Directory: recursively check this folder and children
     if (path_is_directory(filename.c_str())) {
-        string md5_root;
-        if (filename == "/sd/gcodes") {
-            md5_root = "/sd/gcodes/.md5";
-        } else {
-            md5_root = change_to_md5_path(filename);
-        }
-
-        // change_to_md5_path may leave a trailing slash-less path; ensure it exists as a dir
-        if (!path_is_directory(md5_root.c_str())) {
-            stream->printf("No files with stored MD5 hashes found\n");
-            return;
-        }
-
-        run_md5_check_walk(md5_root.c_str(), stream);
+        run_md5_check_walk(filename.c_str(), stream);
         return;
     }
 
     // Single file
     if (fatfs_path_too_long(filename.c_str())) {
-        stream->printf("ERROR: Path too long for SD open: %s\n", filename.c_str());
+        stream->printf("ERROR: Path too long for SD open\n");
         return;
     }
 
-    string md5_path = change_to_md5_path(filename);
+    char md5_path[MD5_CHECK_PATH_MAX];
+    if (!md5_path_from_data_path(filename.c_str(), md5_path, sizeof(md5_path))) {
+        stream->printf("ERROR: Path must be under /sd/gcodes/\n");
+        return;
+    }
+
     char stored[33];
-    if (!read_stored_md5(md5_path.c_str(), stored)) {
-        stream->printf("ERROR: No MD5 hash found for %s\n", filename.c_str());
+    if (!read_stored_md5(md5_path, stored)) {
+        stream->printf("ERROR: No MD5 hash found for ");
+        stream->printf("%s\n", filename.c_str());
         return;
     }
 
     stream->printf("[1/1] - %s\n", filename.c_str());
-    bool intact = file_matches_md5_sidecar(md5_path.c_str(), filename.c_str());
+    bool intact = file_matches_md5_sidecar(md5_path, filename.c_str());
     stream->printf("%s\n", intact ? "Intact" : "Corrupt");
+    stream->printf("File integrity check complete: %u intact, %u corrupt\n",
+                   intact ? 1u : 0u, intact ? 0u : 1u);
 }
 
 // runs several types of test on the mechanisms

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -55,6 +55,8 @@ private:
     static void calc_thermistor_command( string parameters, StreamOutput *stream);
     static void print_thermistors_command( string parameters, StreamOutput *stream);
     static void md5sum_command( string parameters, StreamOutput *stream);
+    static void md5check_command( string parameters, StreamOutput *stream );
+    static void md5check_file_command( string parameters, StreamOutput *stream );
     static void grblDP_command( string parameters, StreamOutput *stream);
 
     static void switch_command(string parameters, StreamOutput *stream );

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -7,6 +7,7 @@
 
 #include "WifiProvider.h"
 
+#include <cstdarg>
 #include "brd_cfg.h"
 #include "M8266HostIf.h"
 
@@ -711,65 +712,76 @@ void WifiProvider::PacketMessage(char cmd, const char* s, int size)
 
 int WifiProvider::printfcmd(const char cmd, const char *format, ...)
 {
-	char b[64];
+	char b[256];
     char *buffer;
-    // Make the message
     va_list args;
     va_start(args, format);
+    va_list args_copy;
+    va_copy(args_copy, args);
 
-    int size = vsnprintf(b, 64, format, args) + 1; // we add one to take into account space for the terminating \0
+    int len = vsnprintf(b, sizeof(b), format, args);
+    va_end(args);
 
-    if (size < 64) {
+    if (len < 0) {
+        va_end(args_copy);
+        return -1;
+    } else if ((size_t)len < sizeof(b)) {
+        va_end(args_copy);
         buffer = b;
     } else {
-        buffer = new char[size];
-        vsnprintf(buffer, size, format, args);
+        buffer = new char[len + 1];
+        vsnprintf(buffer, len + 1, format, args_copy);
+        va_end(args_copy);
     }
-    va_end(args);
 
 	if (communication_protocol == PROTOCOL_SMOOTHIE) {
 		puts(buffer, strlen(buffer));
 	} else {
-		PacketMessage(PTYPE_DIAG_RES, buffer, strlen(buffer));
+		PacketMessage(cmd, buffer, strlen(buffer));
 	}
-//    puts(buffer, strlen(buffer));
-	
 
     if (buffer != b)
         delete[] buffer;
 
-    return size - 1;
+    return len;
 }
 
 int WifiProvider::printf(const char *format, ...)
 {
-	char b[64];
+	char b[256];
     char *buffer;
-    // Make the message
     va_list args;
     va_start(args, format);
+    va_list args_copy;
+    va_copy(args_copy, args);
 
-    int size = vsnprintf(b, 64, format, args) + 1; // we add one to take into account space for the terminating \0
-
-    if (size < 64) {
-        buffer = b;
-    } else {
-        buffer = new char[size];
-        vsnprintf(buffer, size, format, args);
-    }
+    int len = vsnprintf(b, sizeof(b), format, args);
     va_end(args);
 
+    if (len < 0) {
+        va_end(args_copy);
+        return -1;
+    } else if ((size_t)len < sizeof(b)) {
+        va_end(args_copy);
+        buffer = b;
+    } else {
+        buffer = new char[len + 1];
+        vsnprintf(buffer, len + 1, format, args_copy);
+        va_end(args_copy);
+    }
 
 	if (communication_protocol == PROTOCOL_SMOOTHIE) {
 		puts(buffer, strlen(buffer));
 	} else {
-		PacketMessage(PTYPE_DIAG_RES, buffer, strlen(buffer));
+		// Match StreamOutput: NORMAL_INFO (not DIAG_RES). Controllers treat
+		// console/info lines as NORMAL_INFO; DIAG_RES is for diagnose payloads.
+		PacketMessage(PTYPE_NORMAL_INFO, buffer, strlen(buffer));
 	}
 
     if (buffer != b)
         delete[] buffer;
 
-    return size - 1;
+    return len;
 }
 
 int WifiProvider::puts(const char* s, int size)

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,5 @@
 [unreleased]
+- Enhancement: Add SD card file integrity check. M576/M576.1 walks all files with stored MD5 hashes. M576.2 checks a single file or recursively checks a directory
 - Enhancement: AnalogSpindleControl now supports optional RPM feedback and Alarm pin functionality, same as PWMSpindleControl. Same configuration keys (spindle.feedback_pin, spindle.pulses_per_rev, spindle.acc_ratio, and spindle.control_smoothing, spindle.alarm_pin)
 - Enhancement: Suspend/resume saves spindle state, stops the spindle on pause, and restores speed only if it was running. This functionality is enabled by default, but can be disabled via config key spindle_suspend_restore_enable.
 - Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,4 @@
 [unreleased]
-- Enhancement: Add SD card file integrity check. M576/M576.1 walks all files with stored MD5 hashes. M576.2 checks a single file or recursively checks a directory
 - Enhancement: AnalogSpindleControl now supports optional RPM feedback and Alarm pin functionality, same as PWMSpindleControl. Same configuration keys (spindle.feedback_pin, spindle.pulses_per_rev, spindle.acc_ratio, and spindle.control_smoothing, spindle.alarm_pin)
 - Enhancement: Suspend/resume saves spindle state, stops the spindle on pause, and restores speed only if it was running. This functionality is enabled by default, but can be disabled via config key spindle_suspend_restore_enable.
 - Enhancement: `debugmode` shell command to turn on/off firmware diagnostic tools that are continiously running 
@@ -9,6 +8,7 @@
 - Enhancement: Added a new 4th axis self-calibration routine M469.6. This routine calibrates the 4th axis centreline in both Y and Z axis by probing a round object (such as chuck body) from multiple directions. This routine find the true zero point without being affected by runout or surface imperfections.
 - Enhancement: Added improved PID Spindle control that increases performance of carvera C1 spindles. Setup requires following the guide on the documentation page
 - Enhancement: Add endstops repeatability test (M575)
+- Enhancement: Add SD card file integrity check. M576/M576.1 walks all files with stored MD5 hashes. M576.2 checks a single file or recursively checks a directory
 - Fixed: Corrected the Shrink A command G92.4 A0 S0. Now instead of compressing machine coordinates it compresses work coordinates. Backported from Makera firmware
 - Enhancement: Add option to auto-disable on-board wifi AP once machine is connected to external wifi (STA). By default this is turned on, to turn off type config-set sd wifi.ap_auto_disable false into the MDI
 - Fixed: Prevent incorrect current line reporting after a tool change


### PR DESCRIPTION
Based on the discovery that the machine stores MD5 hashes of files received that means we can validate files later. Something that might be quite useful in identifying dying SD cards.

This PR adds:
* M576/M576.1 - Walks the entire SD card for files that both have a MD5 hash stored as well as exist on the SD card. Then check file is checked to see if the hash matches
* M576.2 - Same thing but takes a file or directory path as a parameter for what specifically to check. If a directory is provided it walks it

It also importantly fixes the max filepath and printf lengths.

The "under the covers" changes:
- Raised FatFs open/opendir path limit from 64 → 260 and reject paths that don’t fit. 
- Heap-allocate FatFs FIL_t (no more ~512B stack copy on every open)
- Fix readdir LFN copy to use strlen and always NUL-terminate
- Fix file_exists so it doesn’t fclose(NULL) on missing files
- Fix StreamOutput / WifiProvider printf: larger buffer, proper va_copy, grow for long lines
- Send WiFi console printf as NORMAL_INFO (not DIAG_RES)

Raising the filepath limit to 260 characters(e.g. /sd/ + up to 256 chars after the mount) even though the real FAT32 limit is a total path lengths of up to 32,760 Unicode characters (with individual path components (folder or file names) of 255 characters each) because on Windows the default [MAX_PATH is 260 chars](https://stackoverflow.com/questions/1880321/why-does-the-260-character-path-length-limit-exist-in-windows).


Here is an example of what it looks like, amusingly it looks like the examples provided by Makera have a corrupt MD5 hash for AudreyHepburn.nc and PirateShip.nc
```
M576.2 /sd/gcodes/examples/

Scanning for files with MD5 hashes...
Checking 19 file(s)...
[1/19] - /sd/gcodes/examples/Laser/AudreyHepburn.nc
Corrupt
[2/19] - /sd/gcodes/examples/Laser/AudreyHepburnSmall.nc
Intact
[3/19] - /sd/gcodes/examples/LED/ABS-Base.nc
Intact
[4/19] - /sd/gcodes/examples/LED/ACRYLIC-Balloon.nc
Intact
[5/19] - /sd/gcodes/examples/LED/ACRYLIC-Carvera.nc
Intact
[6/19] - /sd/gcodes/examples/LED/ACRYLIC-Face.nc
Intact
[7/19] - /sd/gcodes/examples/LED/ACRYLIC-R2D2.nc
Intact
[8/19] - /sd/gcodes/examples/LED/ACRYLIC-SpiderMan.nc
Intact
[9/19] - /sd/gcodes/examples/LED/ALUMINUM-Button.nc
Intact
[10/19] - /sd/gcodes/examples/LED/PCB-NO-UV-MASK.nc
Intact
[11/19] - /sd/gcodes/examples/LED/PCB-UV-MASK(PART1).nc
Intact
[12/19] - /sd/gcodes/examples/LED/PCB-UV-MASK(PART2).nc
Intact
[13/19] - /sd/gcodes/examples/Relief/PirateShip.nc
Corrupt
[14/19] - /sd/gcodes/examples/Rotation/NefertitiFinish.nc
Intact
[15/19] - /sd/gcodes/examples/Rotation/NefertitiRough.nc
Intact
[16/19] - /sd/gcodes/examples/Tests/atc-fatigue-test.nc
Intact
[17/19] - /sd/gcodes/examples/Tests/atc-test.nc
Intact
[18/19] - /sd/gcodes/examples/Tests/board-test.nc
Intact
[19/19] - /sd/gcodes/examples/Tests/fatigue-test.nc
Intact
File integrity check complete: 17 intact, 2 corrupt
ok
```