### PR TITLE
Fix Makera command queuing

### DIFF
--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <string>
+#include <string.h>
 #include <stdarg.h>
 using std::string;
 #include "mbed.h" // for us_ticker_read()
@@ -30,6 +31,13 @@ using std::string;
 extern unsigned char xbuff[XBUFF_LENGTH];
 alignas(4) static unsigned char serial_protocol_buffer[544];
 
+// Queue lives in main RAM (SerialConsole itself is AHB-allocated)
+enum { MAKERA_CMD_QUEUE_DEPTH = 4, MAKERA_CMD_MAX_LEN = 256 };
+static char makera_cmd_payloads[MAKERA_CMD_QUEUE_DEPTH][MAKERA_CMD_MAX_LEN];
+static uint16_t makera_cmd_lengths[MAKERA_CMD_QUEUE_DEPTH];
+static volatile uint8_t makera_cmd_head;
+static volatile uint8_t makera_cmd_tail;
+
 // Serial reading module
 // Treats every received line as a command and passes it ( via event call ) to the command dispatcher.
 // The command dispatcher will then ask other modules if they can do something with it
@@ -41,7 +49,7 @@ SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate ){
     this->default_baud_rate = baud_rate;
     this->temp_baud_rate = 0;
     this->last_activity_ms = 0;
-    this->makera_command_pending = false;
+    this->makera_cmd_queue_clear();
     this->reset_makera_command_parser();
     this->reset_file_parser();
 }
@@ -113,11 +121,9 @@ void SerialConsole::on_serial_char_received() {
 		}
 
         if (communication_protocol == PROTOCOL_MAKERA) {
+            // Keep RX IRQ enabled and queue completed commands. Disabling IRQ while a
+            // command is pending drops back-to-back host traffic (e.g. buffer then play).
             process_makera_byte(static_cast<uint8_t>(received));
-            if (makera_command_pending) {
-                attach_irq(false);
-                return;
-            }
             continue;
         }
 		
@@ -223,25 +229,16 @@ void SerialConsole::on_idle(void * argument)
 // Actual event calling must happen in the main loop because if it happens in the interrupt we will loose data
 void SerialConsole::on_main_loop(void * argument){
     if (communication_protocol == PROTOCOL_MAKERA) {
-        if (makera_command_pending) {
-            if (makera_data_length < 3) {
-                makera_command_pending = false;
-                reset_makera_command_parser();
-                attach_irq(true);
-                return;
-            }
-
-            uint16_t payload_length = makera_data_length - 3;
+        if (!makera_cmd_queue_empty()) {
+            uint8_t idx = makera_cmd_head;
+            uint16_t payload_length = makera_cmd_lengths[idx];
             struct SerialMessage message;
-            message.message.assign(reinterpret_cast<char *>(&serial_protocol_buffer[5]), payload_length);
+            message.message.assign(makera_cmd_payloads[idx], payload_length);
             message.stream = this;
             message.line = 0;
 
-            makera_command_pending = false;
-            reset_makera_command_parser();
+            makera_cmd_head = (idx + 1) % MAKERA_CMD_QUEUE_DEPTH;
             THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
-            attach_irq(false);
-            if (!makera_command_pending) attach_irq(true);
         }
         return;
     }
@@ -342,6 +339,34 @@ void SerialConsole::reset_makera_command_parser()
     makera_data_length = 0;
 }
 
+bool SerialConsole::makera_cmd_queue_empty() const
+{
+    return makera_cmd_head == makera_cmd_tail;
+}
+
+void SerialConsole::makera_cmd_queue_clear()
+{
+    makera_cmd_head = 0;
+    makera_cmd_tail = 0;
+}
+
+bool SerialConsole::makera_cmd_queue_push(const char *data, uint16_t len)
+{
+    if (data == nullptr || len == 0 || len > MAKERA_CMD_MAX_LEN) {
+        return false;
+    }
+
+    uint8_t next = (makera_cmd_tail + 1) % MAKERA_CMD_QUEUE_DEPTH;
+    if (next == makera_cmd_head) {
+        return false; // queue full — drop
+    }
+
+    memcpy(makera_cmd_payloads[makera_cmd_tail], data, len);
+    makera_cmd_lengths[makera_cmd_tail] = len;
+    makera_cmd_tail = next;
+    return true;
+}
+
 void SerialConsole::process_makera_byte(uint8_t received)
 {
     if (makera_received < 2) {
@@ -401,7 +426,10 @@ void SerialConsole::process_makera_byte(uint8_t received)
             }
         }
     } else if (command == PTYPE_CTRL_MULTI || command == PTYPE_FILE_START) {
-        makera_command_pending = true;
+        // Copy payload now so the parser can accept the next frame immediately
+        uint16_t payload_len = makera_data_length - 3;
+        makera_cmd_queue_push(reinterpret_cast<char *>(&serial_protocol_buffer[5]), payload_len);
+        reset_makera_command_parser();
         return;
     }
 
@@ -455,7 +483,7 @@ void SerialConsole::on_protocol_changed()
     query_flag = false;
     halt_flag = false;
     diagnose_flag = false;
-    makera_command_pending = false;
+    makera_cmd_queue_clear();
     reset_makera_command_parser();
     reset_file_parser();
 }

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -55,10 +55,13 @@ class SerialConsole : public Module, public StreamOutput {
         int default_baud_rate;
         int temp_baud_rate;                       // non-zero = temporary baud active
         uint32_t last_activity_ms;                // for 15s timeout revert
-        volatile bool makera_command_pending;
         uint16_t makera_header;
         uint16_t makera_received;
         uint16_t makera_data_length;
+
+        bool makera_cmd_queue_push(const char *data, uint16_t len);
+        void makera_cmd_queue_clear();
+        bool makera_cmd_queue_empty() const;
 
         enum FileParseState {
             FILE_WAIT_HEADER,

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -103,6 +103,8 @@ WifiProvider::WifiProvider()
 	udp_link_no = 1;
 	wifi_init_ok = false;
 	has_data_flag = false;
+	makera_command_pending = false;
+	makera_pending_payload_len = 0;
 	connection_fail_count = 0;
 	sta_stable_seconds = 0;
 	ap_auto_disable = true;
@@ -370,20 +372,17 @@ void WifiProvider::receive_wifi_data() {
 				}
 				break;
 			}
-			case PTYPE_CTRL_MULTI: {
-				struct SerialMessage message;
-				message.message.assign(WifiSerialbuff+5, data_len-3);
-				message.stream = this;
-				THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
+			case PTYPE_CTRL_MULTI:
+			case PTYPE_FILE_START:
+				// Defer to on_main_loop — same as SerialConsole. Commands like
+				// suspend/abort call wait_for_idle(), which re-enters ON_IDLE; handling
+				// them here would nest receive_wifi_data/puts on shared SPI buffers and
+				// drop the controller connection.
+				if (data_len >= 3) {
+					makera_pending_payload_len = data_len - 3;
+					makera_command_pending = true;
+				}
 				break;
-			}
-			case PTYPE_FILE_START: {
-				struct SerialMessage message;
-				message.message.assign(WifiSerialbuff+5,data_len-3);
-				message.stream = this;
-				THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
-				break;
-			}
 				
 			default:
 				break;
@@ -626,7 +625,8 @@ void WifiProvider::on_idle(void *argument)
  {
 	if (THEKERNEL->is_uploading()) return;
 
-	if (has_data_flag || M8266WIFI_SPI_Has_DataReceived()) {
+	// Do not receive another Makera frame while a deferred command still owns WifiSerialbuff
+	if (!makera_command_pending && (has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
 		has_data_flag = false;
 		receive_wifi_data();
 	}
@@ -665,22 +665,35 @@ void WifiProvider::on_idle(void *argument)
 
 void WifiProvider::on_main_loop(void *argument)
 {
-    if (communication_protocol == PROTOCOL_SMOOTHIE) {
-		if( this->has_char('\n') ){
-			string received;
-			received.reserve(20);
-			while(1){
-			char c;
-			this->buffer.pop_front(c);
-			if( c == '\n' ){
-					struct SerialMessage message;
-					message.message = received;
-					message.stream = this;
-					THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
-					return;
-				}else{
-					received += c;
-				}
+	if (communication_protocol == PROTOCOL_MAKERA) {
+		if (makera_command_pending) {
+			struct SerialMessage message;
+			message.message.assign(WifiSerialbuff + 5, makera_pending_payload_len);
+			message.stream = this;
+			message.line = 0;
+
+			makera_command_pending = false;
+			makera_pending_payload_len = 0;
+			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+		}
+		return;
+	}
+
+	if ( this->has_char('\n') ){
+		string received;
+		received.reserve(20);
+		while(1){
+		char c;
+		this->buffer.pop_front(c);
+		if( c == '\n' ){
+				struct SerialMessage message;
+				message.message = received;
+				message.stream = this;
+				message.line = 0;
+				THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
+				return;
+			}else{
+				received += c;
 			}
 		}
 	}

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -103,7 +103,10 @@ private:
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;
     	volatile bool has_data_flag:1;
+    	volatile bool makera_command_pending:1;
     };
+    // Payload length for deferred Makera CTRL_MULTI / FILE_START (bytes at WifiSerialbuff+5)
+    uint16_t makera_pending_payload_len;
     ParseState currentState = WAIT_HEADER;    
     int ptrData;
     int ptr_xbuff;


### PR DESCRIPTION
This resolves two related bugs when in Makera protocol mode:

1. On USB-Serial, sending a play command is ignored because Serial RX IRQ was disabled while a prior command (e.g. buffer) was still pending, so a back-to-back play frame was dropped on the Serial FIFO before it could be parsed.

2. On Wifi, sending a stop/pause causes the machine to crash because suspend/abort were handled inside on_idle → receive_wifi_data, then blocked in wait_for_idle() which re-entered that same path and nested WiFi SPI RX/TX on shared buffers, dropping the controller connection.