### PR TITLE
Make AHB placement new safe on pool exhaustion

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -666,6 +666,12 @@ std::string Kernel::get_diagnose_string()
 // Add a module to Kernel. We don't actually hold a list of modules we just call its on_module_loaded
 void Kernel::add_module(Module* module)
 {
+    if(module == nullptr) {
+        // new(AHB) yields nullptr when the pool is exhausted (see MemoryPool.h);
+        // report loudly and skip instead of faulting on the call below.
+        this->streams->printf("FATAL: add_module(nullptr) - module allocation failed, AHB pool exhausted?\n");
+        return;
+    }
     module->on_module_loaded();
 }
 

--- a/src/libs/MemoryPool.h
+++ b/src/libs/MemoryPool.h
@@ -50,13 +50,18 @@ private:
 };
 
 // this overloads "placement new"
-inline void* operator new(size_t nbytes, MemoryPool& pool)
+// noexcept matters here: alloc() returns NULL when the pool is exhausted, and
+// the compiler only emits the null check that skips construction when the
+// allocation function is declared non-throwing (building with -fno-exceptions
+// does not change that rule). Without it, `new(AHB) Foo()` on an exhausted
+// pool would run Foo's constructor at address 0.
+inline void* operator new(size_t nbytes, MemoryPool& pool) noexcept
 {
     return pool.alloc(nbytes);
 }
 
 // this allows placement new to free memory if the constructor fails
-inline void  operator delete(void* p, MemoryPool& pool)
+inline void  operator delete(void* p, MemoryPool& pool) noexcept
 {
     pool.dealloc(p);
 }


### PR DESCRIPTION
`MemoryPool::alloc()` returns NULL when the pool has no suitable block, but the placement `operator new` wrapping it was not declared `noexcept`. The compiler only emits the null check that skips construction when the allocation function is declared non-throwing — building with `-fno-exceptions` does not change that rule — so `new(AHB) Foo()` on an exhausted pool would run the constructor at address 0, undefined behaviour with no diagnostic on this target.

Declares the operator and its matching `delete` `noexcept` so a failed pool allocation yields `nullptr` without constructing anything, and teaches `Kernel::add_module()` to report and skip a `nullptr` module instead of calling `on_module_loaded()` through it.

The AHB pool has headroom at boot today, but its dynamic area is shared with config-driven consumers (leveling grid size, planner queue length, wifi buffers), so exhaustion is one config change away from reachable.

---

**Risk: low.** Defensive bounding. Behaviour is unchanged for input that was already valid; it changes only for input that previously overran a buffer.

**Testing.** Verified analytically only: clean build with arm-none-eabi-gcc 14.2 at `AXIS=5 PAXIS=3 CNC=1`, plus the specific evidence noted above. **Not tested on physical hardware** — I have no machine access at present, so no bench or cutting validation has been done. Testing that still needs doing: confirm on a Carvera and/or Carvera Air that boot completes normally and that the affected subsystem behaves as described. Stating this explicitly as the guidelines ask.