### PR TITLE
Report planner queue allocation failures instead of degrading silently

### DIFF
--- a/src/modules/robot/BlockQueue.cpp
+++ b/src/modules/robot/BlockQueue.cpp
@@ -1,6 +1,9 @@
 #include "BlockQueue.h"
 #include "Block.h"
 
+#include "libs/Kernel.h"
+#include "libs/StreamOutputPool.h"
+
 #include <cstdlib>
 #include "cmsis.h"
 #include "platform_memory.h"
@@ -23,11 +26,12 @@ BlockQueue::BlockQueue(unsigned int length)
     isr_tail_i = tail_i;
     void *v= AHB.alloc(sizeof(Block) * length);
     if (v == nullptr) {
-        // TODO: Optionally add error reporting here (e.g., THEKERNEL->streams->printf("FATAL: BlockQueue alloc failed!\n");)
-        // For now, just ensure the queue is unusable
+        // A zero-length queue means no motion can ever be queued; that must
+        // never happen silently.
+        THEKERNEL->streams->printf("FATAL: BlockQueue allocation failed (%u bytes) - AHB pool exhausted, motion queue disabled\n",
+            (unsigned int)(sizeof(Block) * length));
         this->length = 0;
         this->ring = nullptr;
-        // Consider adding __disable_irq(); while(1); or similar if this is truly fatal
         return;
     }
     ring = new(v) Block[length];
@@ -192,7 +196,8 @@ bool BlockQueue::resize(unsigned int length)
         // Note: we don't use realloc so we can fall back to the existing ring if allocation fails
         void *v= AHB.alloc(sizeof(Block) * length);
         if (v == nullptr) {
-            // Allocation failed, cannot resize
+            THEKERNEL->streams->printf("ERROR: BlockQueue resize to %u blocks failed (%u bytes) - AHB pool exhausted, keeping previous queue\n",
+                length, (unsigned int)(sizeof(Block) * length));
             return false;
         }
         Block* newring = new(v) Block[length];

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -82,7 +82,12 @@ void Conveyor::on_module_loaded()
 void Conveyor::start(uint8_t n)
 {
     Block::init(n); // set the number of motors which determines how big the tick info vector is
-    queue.resize(queue_size);
+    if(!queue.resize(queue_size)) {
+        // Without a planner queue no move can ever be queued. Say so instead
+        // of booting into a machine that silently refuses to move.
+        THEKERNEL->streams->printf("FATAL: planner queue allocation failed (%u blocks) - machine cannot queue motion, check planner_queue_size\n",
+            (unsigned int)queue_size);
+    }
     running = true;
 }
 


### PR DESCRIPTION
`BlockQueue` left a TODO where the error reporting should be: on AHB pool exhaustion the constructor and `resize()` would leave or keep the queue unusable without a word, and `Conveyor::start()` ignored the `resize()` return value and set `running = true` regardless. The result was a machine that boots normally and then silently refuses to queue motion.

Prints a message in all three paths: constructor failure (queue disabled), resize failure (previous queue kept — that fallback already existed and is correct), and `Conveyor::start()` failure (naming `planner_queue_size`, the config value that sizes the allocation).

The parameterized `BlockQueue` constructor is currently unused, since `Conveyor` default-constructs and resizes, so LTO drops that path from the binary today; the report is there for any future caller.

---

**Risk: low.** Adds diagnostic output on an existing failure path. No functional or motion behaviour changes.

**Testing.** Verified analytically only: clean build with arm-none-eabi-gcc 14.2 at `AXIS=5 PAXIS=3 CNC=1`, plus the specific evidence noted above. **Not tested on physical hardware** — I have no machine access at present, so no bench or cutting validation has been done. Testing that still needs doing: confirm on a Carvera and/or Carvera Air that boot completes normally and that the affected subsystem behaves as described. Stating this explicitly as the guidelines ask.