### PR TITLE
Make _sbrk respect the config cache region; report boot heap margin

### DIFF
--- a/build/mbed_custom.cpp
+++ b/build/mbed_custom.cpp
@@ -220,6 +220,32 @@ extern int errno;
 
 static int doesHeapCollideWithStack(unsigned int newHeap);
 
+/* Optional extra heap ceiling below the stack guard.
+   The config cache occupies a fixed region just below __StackLimit while the
+   machine boots (see ConfigCache.h). Config lowers this ceiling to the cache
+   base for that window so an over-allocating boot fails cleanly with ENOMEM
+   instead of malloc handing out memory inside the live cache. 0 = inactive. */
+static unsigned int g_heapCeilingAddress = 0;
+
+/* Highest heap address ever handed out by _sbrk. Lets us report the real boot
+   heap margin instead of guessing at it. */
+static unsigned int g_heapHighWaterMark = 0;
+
+extern "C" void setHeapCeiling(unsigned int ceiling)
+{
+    g_heapCeilingAddress = ceiling;
+}
+
+extern "C" void clearHeapCeiling(void)
+{
+    g_heapCeilingAddress = 0;
+}
+
+extern "C" unsigned int getHeapHighWaterMark(void)
+{
+    return g_heapHighWaterMark;
+}
+
 /* Dynamic memory allocation related syscalls. */
 extern "C" caddr_t _sbrk(int incr)
 {
@@ -233,13 +259,16 @@ extern "C" caddr_t _sbrk(int incr)
     }
 
     heap = new_heap;
+    if ((unsigned int)new_heap > g_heapHighWaterMark)
+        g_heapHighWaterMark = (unsigned int)new_heap;
     return (caddr_t) prev_heap;
 }
 
 static int doesHeapCollideWithStack(unsigned int newHeap)
 {
     return ((newHeap >= __get_MSP()) ||
-            (STACK_SIZE && newHeap >= g_maximumHeapAddress));
+            (STACK_SIZE && newHeap >= g_maximumHeapAddress) ||
+            (g_heapCeilingAddress && newHeap > g_heapCeilingAddress));
 }
 
 

--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -20,6 +20,9 @@ using namespace std;
 #include "libs/ConfigSources/FileConfigSource.h"
 
 extern "C" caddr_t _sbrk(int);
+extern "C" void setHeapCeiling(unsigned int);
+extern "C" void clearHeapCeiling(void);
+extern "C" unsigned int getHeapHighWaterMark(void);
 #include "libs/ConfigSources/FirmConfigSource.h"
 #include "StreamOutputPool.h"
 
@@ -92,6 +95,11 @@ void Config::config_cache_load(bool parse)
         return;
     }
 
+    // Cap the malloc heap at the cache base while the cache is live, so an
+    // over-allocating boot fails with ENOMEM instead of _sbrk handing out
+    // memory inside the cache (which the stack-based guard alone permits).
+    setHeapCeiling(cache_start);
+
     if(parse) {
         // For each ConfigSource in our stack
         for( ConfigSource *source : this->config_sources ) {
@@ -116,6 +124,16 @@ void Config::config_cache_clear()
         this->config_cache->clear();
         delete this->config_cache;  // frees the small ConfigCache object itself
         this->config_cache = NULL;
+
+        // The cache region is free again; let the heap use it.
+        clearHeapCeiling();
+
+        // Report the boot heap high-water mark against the cache base. This is
+        // the margin that, when exhausted, used to corrupt the cache silently —
+        // now it is measured on every boot instead of guessed at.
+        const auto high_water = getHeapHighWaterMark();
+        THEKERNEL->streams->printf("Config cache released, heap high water 0x%08lX, boot margin %ld bytes\n",
+            (unsigned long)high_water, (long)cache_start - (long)high_water);
     }
 }
 


### PR DESCRIPTION
The config cache lives in a fixed region below `__StackLimit` while the machine boots (`ConfigCache.h`). The heap guard in `_sbrk` only knew about the stack, so `g_maximumHeapAddress` allowed the heap to grow roughly 9 KB past the cache base, and `malloc` would hand out memory inside the live cache. The two spot-checks in `Config.cpp` could only detect the collision after the fact, and the one in `config_cache_clear()` responds with `system_reset()`, which turns any overallocation into a deterministic boot loop — the failure mode behind the flex compensation incident fixed in 573ef33.

Adds an optional heap ceiling to `_sbrk`'s collision check. `Config` lowers it to the cache base while the cache is live and lifts it on release, so an over-allocating boot fails the offending allocation with `ENOMEM` at the moment it happens instead of corrupting live config data. The existing spot-checks remain as a second line of defence.

Also tracks the heap high-water mark in `_sbrk` and prints it with the remaining margin to the cache base when the cache is released, so every boot reports how close it came instead of leaving the margin unmeasured.

**Tradeoff to weigh.** This makes a previously-silent overallocation into a hard `ENOMEM` at the allocation site. On a configuration that was already overallocating and getting away with it, that turns undefined behaviour into a visible failure — which is the intent, but it is a behaviour change. It also adds one line of boot output. Cost: +160 bytes text, +8 bytes bss.

---

**Risk: moderate — this deliberately changes behaviour.** Please read the tradeoff below before merging; this is the group most in need of hardware validation.

**Testing.** Verified analytically only: clean build with arm-none-eabi-gcc 14.2 at `AXIS=5 PAXIS=3 CNC=1`, plus the specific evidence noted above. **Not tested on physical hardware** — I have no machine access at present, so no bench or cutting validation has been done. Testing that still needs doing: confirm on a Carvera and/or Carvera Air that boot completes normally and that the affected subsystem behaves as described. Stating this explicitly as the guidelines ask.