### PR TITLE
Add ON_CONFIG_CACHE_CLEARED kernel event for deferred boot work

### DIFF
--- a/src/libs/Module.cpp
+++ b/src/libs/Module.cpp
@@ -22,7 +22,8 @@ const ModuleCallback kernel_callback_functions[NUMBER_OF_DEFINED_EVENTS] = {
     &Module::on_get_public_data,
     &Module::on_set_public_data,
     &Module::on_halt,
-    &Module::on_enable
+    &Module::on_enable,
+    &Module::on_config_cache_cleared
 
 };
 

--- a/src/libs/Module.h
+++ b/src/libs/Module.h
@@ -21,6 +21,7 @@ enum _EVENT_ENUM {
     ON_SET_PUBLIC_DATA,
     ON_HALT,
     ON_ENABLE,
+    ON_CONFIG_CACHE_CLEARED,
     NUMBER_OF_DEFINED_EVENTS
 };
 
@@ -50,6 +51,11 @@ public:
     virtual void on_set_public_data(void *) {};
     virtual void on_halt(void *) {};
     virtual void on_enable(void *) {};
+    // Fired once at boot, right after Config::config_cache_clear() has released
+    // the fixed cache region below __StackLimit. Boot work that allocates on the
+    // main heap (file autoloads, large buffers) must be deferred to this event —
+    // never done in on_module_loaded()/on_config_reload() while the cache is live.
+    virtual void on_config_cache_cleared(void *) {};
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,8 +225,7 @@ void init() {
     // kernel->add_module( new(AHB) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    ZProbe *zprobe = new ZProbe();
-    kernel->add_module( zprobe );
+    kernel->add_module( new ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
     kernel->add_module( new SCARAcal() );
@@ -291,11 +290,11 @@ void init() {
     // clear up the config cache to save some memory
     kernel->config->config_cache_clear();
 
-    #ifndef NO_TOOLS_ZPROBE
-    // Flex compensation autoload (and anything else that needs main-heap room)
-    // must run only after the config cache is released.
-    zprobe->after_config_cache_clear();
-    #endif
+    // The config cache region is free again: broadcast to every registered
+    // module that deferred boot work needing main-heap room (file autoloads
+    // etc.) may now run. Such work must never happen in on_module_loaded() or
+    // on_config_reload() while the cache is live — register for this event.
+    kernel->call_event(ON_CONFIG_CACHE_CLEARED, nullptr);
 
     if(kernel->is_using_leds()) {
         // set some leds to indicate status... led0 init done, led1 mainloop running, led2 idle loop running, led3 sdcard ok

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1695,6 +1695,7 @@ void ATCHandler::on_module_loaded()
     this->register_for_event(ON_SET_PUBLIC_DATA);
     this->register_for_event(ON_MAIN_LOOP);
     this->register_for_event(ON_HALT);
+    this->register_for_event(ON_CONFIG_CACHE_CLEARED);
 
     this->on_config_reload(this);
 
@@ -1722,6 +1723,14 @@ void ATCHandler::on_module_loaded()
 	this->beep_state = BP_SLEEP;
 	this->beep_count = 0;
 	
+}
+
+void ATCHandler::on_config_cache_cleared(void *argument)
+{
+    // File autoloads allocate on the main heap (stdio buffers, string/vector
+    // growth) and must therefore wait until the config cache region has been
+    // released — see the ON_CONFIG_CACHE_CLEARED broadcast in main.cpp.
+    this->load_custom_tool_slots();
 }
 
 void ATCHandler::on_config_reload(void *argument)
@@ -1787,9 +1796,9 @@ void ATCHandler::on_config_reload(void *argument)
 	this->probe_mcs_z = THEKERNEL->config->value(coordinate_checksum, probe_mcs_z_checksum)->as_number(NAN);
 	this->probe_position_configured = !isnan(this->probe_mcs_x) || !isnan(this->probe_mcs_y) || !isnan(this->probe_mcs_z);
 	
-	// Load custom tool slots configuration
-	// Delay loading to ensure system is fully initialized
-	this->load_custom_tool_slots();
+	// Custom tool slots are loaded in on_config_cache_cleared(): the file read
+	// allocates on the main heap, which must not grow while the config cache
+	// region is still live during init.
 
 	// Calculate probe position - use configured absolute MCS coordinates if available, otherwise use hardcoded values
 	if(CARVERA == THEKERNEL->factory_set->MachineModel){

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -23,6 +23,7 @@ public:
     void on_halt(void *argument);
     int get_active_tool() const { return active_tool; }
     void on_config_reload(void *argument);
+    void on_config_cache_cleared(void *argument);
 
 
 private:

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -94,6 +94,7 @@ void ZProbe::on_module_loaded()
     register_for_event(ON_GET_PUBLIC_DATA);
     register_for_event(ON_SET_PUBLIC_DATA);
     register_for_event(ON_MAIN_LOOP);
+    register_for_event(ON_CONFIG_CACHE_CLEARED);
 
     this->probing_cycle = NONE;
 
@@ -191,7 +192,7 @@ void ZProbe::config_load()
 
 }
 
-void ZProbe::after_config_cache_clear()
+void ZProbe::on_config_cache_cleared(void *argument)
 {
     for(auto ls : strategies) {
         ls->after_config_cache_clear();

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -103,7 +103,7 @@ public:
     void on_module_loaded();
     void on_gcode_received(void *argument);
     void on_main_loop(void *argument);
-    void after_config_cache_clear();
+    void on_config_cache_cleared(void *argument);
 
     bool check_last_probe_ok();
     bool run_probe(float& mm, float feedrate, float max_dist= -1, bool reverse= false);


### PR DESCRIPTION
573ef33 deferred the flex compensation autoload until after `config_cache_clear()` because boot-time file loads allocate on the main heap, which must not grow into the live config cache region. That fix wired a one-off method call from `main()` to a single `ZProbe` pointer, so the next module needing a boot-time file load has no pattern to follow and would naturally put it back in `on_module_loaded()`, reintroducing the same failure class.

Promotes the mechanism to a proper kernel event: `ON_CONFIG_CACHE_CLEARED` is broadcast from `main()` once the cache region has been released, and any module can register for it like any other event. `ZProbe` now receives the event instead of being special-cased in `main()`.

Also moves `ATCHandler`'s `custom_tool_slots.txt` load out of `on_module_loaded()` and into the new event: it was doing `fopen` and vector growth inside the cache-alive window, and its "delay loading" comment described a delay that did not exist.

**Tradeoff to weigh.** No change to *what* gets loaded at boot, only to *when* — both loads still complete before the main loop starts. But it does reorder boot-time work, and the ATC tool-slot load now happens later than before, which is the part most worth checking on hardware.

**Merge order:** touches the same ZProbe method as `boot-attempt-counter`; taking this one first is easier.

---

**Risk: moderate — this deliberately changes behaviour.** Please read the tradeoff below before merging; this is the group most in need of hardware validation.

**Testing.** Verified analytically only: clean build with arm-none-eabi-gcc 14.2 at `AXIS=5 PAXIS=3 CNC=1`, plus the specific evidence noted above. **Not tested on physical hardware** — I have no machine access at present, so no bench or cutting validation has been done. Testing that still needs doing: confirm on a Carvera and/or Carvera Air that boot completes normally and that the affected subsystem behaves as described. Stating this explicitly as the guidelines ask.