### PR TITLE
Arm the watchdog at the end of init instead of the middle

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,18 +270,14 @@ void init() {
     //     kernel->add_module( new(AHB) DFU(&u));
     // }
 
-    // 10 second watchdog timeout (or config as seconds)
-
-    // LUKE : DISABLED
-
-    float t= kernel->config->value( watchdog_timeout_checksum )->as_number(10.0F);
-    if(t > 0.1F) {
-        // NOTE setting WDT_RESET with the current bootloader would leave it in DFU mode which would be suboptimal
-        kernel->add_module( new Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
-        kernel->streams->printf("Watchdog enabled for %1.3f seconds\n", t);
-    }else{
-        kernel->streams->printf("WARNING Watchdog is disabled\n");
-    }
+    // 10 second watchdog timeout (or config as seconds). Only read the value
+    // here, while the config cache is still loaded; arming is deferred to the
+    // end of init() so that slow boot work (SD autoloads after the cache
+    // release, config override execution) cannot trip a watchdog that nothing
+    // is feeding yet - it is only fed from ON_IDLE, which does not run during
+    // init. NOTE a watchdog reset with the current bootloader would leave the
+    // machine in DFU mode, so tripping it during a slow boot must not happen.
+    float watchdog_timeout= kernel->config->value( watchdog_timeout_checksum )->as_number(10.0F);
 
     // kernel->add_module( &u );
 
@@ -325,6 +321,16 @@ void init() {
     THEKERNEL->conveyor->start(THEROBOT->get_number_registered_motors());
     THEKERNEL->step_ticker->start();
     THEKERNEL->slow_ticker->start();
+
+    // Arm the watchdog last, when no boot work remains that could starve it.
+    // From here on the main loop's ON_IDLE keeps it fed.
+    if(watchdog_timeout > 0.1F) {
+        // NOTE setting WDT_RESET with the current bootloader would leave it in DFU mode which would be suboptimal
+        kernel->add_module( new Watchdog(watchdog_timeout * 1000000, WDT_RESET ));
+        kernel->streams->printf("Watchdog enabled for %1.3f seconds\n", watchdog_timeout);
+    }else{
+        kernel->streams->printf("WARNING Watchdog is disabled\n");
+    }
 }
 
 int main()


### PR DESCRIPTION
The `Watchdog` constructor starts the hardware timer immediately, but the module is only fed from `ON_IDLE`, which does not run until the main loop starts. It was armed in the middle of `init()`, leaving the config cache release, SD autoloads (flex compensation, custom tool slots), config override execution and conveyor/ticker startup all running against an armed watchdog that nothing feeds. A slow SD card during those steps — read retries on a marginal card, large data files — could trip it, and per the existing NOTE in `main.cpp`, a watchdog reset with the current bootloader leaves the machine in DFU mode, i.e. apparently dead until power cycled.

Keeps reading `watchdog_timeout` where it was (the config cache must still be loaded), but arms the watchdog as the last step of `init()` when no boot work remains that could starve it.

**Tradeoff to weigh, and it is a real one.** A hang during `init()` is no longer caught by the watchdog. That is deliberate — a frozen boot with serial output is diagnosable, a machine that silently enters DFU is not — but it does reduce coverage in one scenario, and maintainers may reasonably prefer a different balance. Cost: +8 bytes text.

---

**Risk: moderate — this deliberately changes behaviour.** Please read the tradeoff below before merging; this is the group most in need of hardware validation.

**Testing.** Verified analytically only: clean build with arm-none-eabi-gcc 14.2 at `AXIS=5 PAXIS=3 CNC=1`, plus the specific evidence noted above. **Not tested on physical hardware** — I have no machine access at present, so no bench or cutting validation has been done. Testing that still needs doing: confirm on a Carvera and/or Carvera Air that boot completes normally and that the affected subsystem behaves as described. Stating this explicitly as the guidelines ask.