### PR TITLE
Fix flex_comp OOM

### DIFF
--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -13,7 +13,6 @@
 
 #include <stdio.h>
 #include <string>
-#include <map>
 #include <vector>
 #include <queue>
 #include <cstdint>
@@ -117,7 +116,6 @@ class Player : public Module {
         bool saved_spindle_on;
         bool last_spindle_on;
         bool last_spindle_ccw;
-        std::map<uint16_t, float> saved_temperatures;
         bool skip_ocodes_prescan = false;
 
         struct {

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -36,6 +36,7 @@
 #include "libs/StreamOutput.h"
 
 #include "platform_memory.h" // Needed for AHB allocator
+#include "libs/compiler.h"
 
 #include "port_api.h"
 #include "InterruptIn.h"
@@ -59,7 +60,7 @@
 #define XBUFF_LENGTH	8208
 extern unsigned char xbuff[XBUFF_LENGTH];
 extern unsigned char fbuff[4096];
-__attribute__((section("AHBSRAM1"), aligned(4))) char WifiSerialbuff[544];
+char WifiSerialbuff[544] LOCATED_IN_AHBSRAM;
 
 
 
@@ -1059,9 +1060,6 @@ void WifiProvider::on_gcode_received(void *argument)
 				gcode->stream->printf("broadcast: %s\n", broadcast);
 			} else if (gcode->subcode == 7) {
 				gcode->stream->printf("aaaaaaa\n");
-				if (communication_protocol == PROTOCOL_SMOOTHIE) {
-					gcode->stream->printf("test buffer: %s\n", test_buffer.c_str());
-				}
 			}
 
 		} else if (gcode->m == 482) {

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -73,10 +73,8 @@ private:
     void PacketMessage(char cmd, const char* s, int size);
 
     mbed::InterruptIn *wifi_interrupt_pin; // Interrupt pin for measuring speed
-    float probe_slow_rate;
 
     RingBuffer<char, 256> buffer; // Receive buffer
-    string test_buffer;
 
 	u8 WifiData[WIFI_DATA_MAX_SIZE];
 


### PR DESCRIPTION
Take #2 at #353

This PR free up memory by:
1. Removing unused includes/variables from Player and Wifi Provider
2. Place WifiSerialbuff properly into the AHB pool. It was silently failing to go into `AHBSRAM1` resulting it being allocated into SRAM. This is a regression we seem to have inherited from https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/343

This gives us back 656 bytes in SRAM which based on the test in https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/385 is enough to load flex_comp again.