### PR TITLE
Disable the AP before STA connect

### DIFF
--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -54,7 +54,7 @@
 #define tcp_timeout_s_checksum			  CHECKSUM("tcp_timeout_s")
 #define ap_auto_disable_checksum          CHECKSUM("ap_auto_disable")
 
-#define WIFI_AP_OFF_DELAY_S          3
+#define WIFI_AP_ON_DELAY_S           5
 
 #define XBUFF_LENGTH	8208
 extern unsigned char xbuff[XBUFF_LENGTH];
@@ -107,7 +107,7 @@ WifiProvider::WifiProvider()
 	makera_command_pending = false;
 	makera_pending_payload_len = 0;
 	connection_fail_count = 0;
-	sta_stable_seconds = 0;
+	sta_down_seconds = 0;
 	ap_auto_disable = true;
 	ap_currently_on = true;
 	ap_off_by_auto_toggle = false;
@@ -139,6 +139,16 @@ void WifiProvider::on_module_loaded()
         u16 op_status = 0;
         M8266WIFI_SPI_Get_Opmode(&boot_op_mode, &op_status);
         this->ap_currently_on = (boot_op_mode != 1);
+    }
+
+    // Disable AP before STA auto-reconnect to avoid address conflicts with the onboard AP
+    if (this->ap_auto_disable && this->ap_currently_on) {
+        u16 op_status = 0;
+        if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
+            this->ap_currently_on = false;
+            this->ap_off_by_auto_toggle = true;
+            this->sta_down_seconds = 0;
+        }
     }
 
     // Add interrupt for WIFI data receving
@@ -509,13 +519,12 @@ void WifiProvider::on_second_tick(void *)
 			connection_fail_count = 0;
 		}
 
-		// AP off when STA is up, AP back on when STA drops. saved=0 to avoid flash wear.
+		// Keep AP off while STA is connecting/connected; restore AP after STA is down
+		// for WIFI_AP_ON_DELAY_S to avoid address conflicts. saved=0 to avoid flash wear.
 		if (this->ap_auto_disable) {
-			if (connection_status == 5) {
-				if (this->sta_stable_seconds < WIFI_AP_OFF_DELAY_S) {
-					this->sta_stable_seconds++;
-				}
-				if (this->sta_stable_seconds >= WIFI_AP_OFF_DELAY_S && this->ap_currently_on) {
+			if (connection_status == 1 || connection_status == 5) {
+				this->sta_down_seconds = 0;
+				if (this->ap_currently_on) {
 					u16 op_status = 0;
 					if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
 						this->ap_currently_on = false;
@@ -523,9 +532,11 @@ void WifiProvider::on_second_tick(void *)
 					}
 				}
 			} else {
-				this->sta_stable_seconds = 0;
+				if (this->sta_down_seconds < WIFI_AP_ON_DELAY_S) {
+					this->sta_down_seconds++;
+				}
 				// only re-enable if we were the ones who turned it off; ap disable stays off
-				if (!this->ap_currently_on && this->ap_off_by_auto_toggle) {
+				if (this->sta_down_seconds >= WIFI_AP_ON_DELAY_S && !this->ap_currently_on && this->ap_off_by_auto_toggle) {
 					u16 op_status = 0;
 					if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
 						this->ap_currently_on = true;
@@ -1399,6 +1410,16 @@ void WifiProvider::on_set_public_data(void *argument)
     			snprintf(s->error_info, sizeof(s->error_info), "Disconnect error!");
     		}
     	} else {
+    	    // Disable AP before STA connect to avoid network address conflicts
+    	    if (this->ap_auto_disable && this->ap_currently_on) {
+    	        u16 op_status = 0;
+    	        if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
+    	            this->ap_currently_on = false;
+    	            this->ap_off_by_auto_toggle = true;
+    	        }
+    	    }
+    	    this->sta_down_seconds = 0;
+
     	    // u8 M8266WIFI_SPI_STA_Connect_Ap(u8 ssid[32], u8 password[64], u8 saved, u8 timeout_in_s, u16* status);
     	    M8266WIFI_SPI_STA_Connect_Ap((u8 *)s->ssid, (u8 *)s->password, 1, 0, &status);
 
@@ -1516,7 +1537,7 @@ void WifiProvider::on_set_public_data(void *argument)
     	if (*enable_op) {
         	set_wifi_op_mode(3);
         	this->ap_currently_on = true;
-        	this->sta_stable_seconds = 0;
+        	this->sta_down_seconds = 0;
         	this->ap_off_by_auto_toggle = false;
     	} else {
         	set_wifi_op_mode(1);

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -55,6 +55,9 @@
 #define ap_auto_disable_checksum          CHECKSUM("ap_auto_disable")
 
 #define WIFI_AP_ON_DELAY_S           5
+#define WIFI_STA_FLAP_WINDOW_S       (5 * 60)   // count reconnect cycles in this window
+#define WIFI_STA_FLAP_LIMIT          3          // cycles that trigger AP hold
+#define WIFI_AP_FLAP_HOLD_S          (30 * 60)  // keep AP up this long after flapping
 
 #define XBUFF_LENGTH	8208
 extern unsigned char xbuff[XBUFF_LENGTH];
@@ -109,9 +112,17 @@ WifiProvider::WifiProvider()
 	connection_fail_count = 0;
 	sta_down_seconds = 0;
 	last_sta_connection_status = 0xff;
+	wifi_seconds = 0;
+	sta_flap_count = 0;
+	ap_hold_remaining_s = 0;
 	ap_auto_disable = true;
 	ap_currently_on = true;
 	ap_manually_disabled = false;
+	sta_was_connected = false;
+	sta_down_since_connected = false;
+	for (uint8_t i = 0; i < WIFI_STA_FLAP_LIMIT; i++) {
+		sta_flap_times[i] = 0;
+	}
 }
 
 void WifiProvider::on_module_loaded()
@@ -1185,23 +1196,94 @@ void WifiProvider::set_wifi_op_mode(u8 op_mode) {
 // Keep AP off while STA has an IP; restore AP after WIFI_AP_ON_DELAY_S of not being
 // connected. Status 1 (connecting/reconnecting) counts as down so a dead router that
 // leaves the module in a reconnect loop still brings the onboard AP back.
+// If STA completes WIFI_STA_FLAP_LIMIT reconnect cycles within WIFI_STA_FLAP_WINDOW_S,
+// leave AP up for WIFI_AP_FLAP_HOLD_S to avoid opmode thrashing on a flaky link.
 // saved=0 to avoid flash wear. Manual `ap disable` sets ap_manually_disabled and blocks restore.
 void WifiProvider::update_ap_auto_disable(u8 connection_status)
 {
 	if (!this->ap_auto_disable || this->ap_manually_disabled) return;
 
+	this->wifi_seconds++;
+	if (this->ap_hold_remaining_s > 0) {
+		this->ap_hold_remaining_s--;
+		if (this->ap_hold_remaining_s == 0) {
+			THEKERNEL->streams->printf("WIFI: AP flap-hold expired\n");
+		}
+	}
+
 	if (connection_status != this->last_sta_connection_status) {
 		THEKERNEL->streams->printf(
-			"WIFI: STA status %u -> %u (down=%d AP=%s)\n",
+			"WIFI: STA status %u -> %u (down=%d AP=%s hold=%lu)\n",
 			this->last_sta_connection_status,
 			connection_status,
 			this->sta_down_seconds,
-			this->ap_currently_on ? "on" : "off");
+			this->ap_currently_on ? "on" : "off",
+			(unsigned long)this->ap_hold_remaining_s);
 		this->last_sta_connection_status = connection_status;
 	}
 
 	if (connection_status == 5) {
+		// Count a flap cycle when STA returns after previously being up then down
+		if (this->sta_down_since_connected) {
+			this->sta_down_since_connected = false;
+
+			// drop flap timestamps outside the window
+			uint8_t kept = 0;
+			for (uint8_t i = 0; i < this->sta_flap_count; i++) {
+				if ((this->wifi_seconds - this->sta_flap_times[i]) <= WIFI_STA_FLAP_WINDOW_S) {
+					this->sta_flap_times[kept++] = this->sta_flap_times[i];
+				}
+			}
+			this->sta_flap_count = kept;
+
+			if (this->sta_flap_count < WIFI_STA_FLAP_LIMIT) {
+				this->sta_flap_times[this->sta_flap_count++] = this->wifi_seconds;
+			} else {
+				// shift and append
+				for (uint8_t i = 1; i < WIFI_STA_FLAP_LIMIT; i++) {
+					this->sta_flap_times[i - 1] = this->sta_flap_times[i];
+				}
+				this->sta_flap_times[WIFI_STA_FLAP_LIMIT - 1] = this->wifi_seconds;
+			}
+
+			uint8_t flaps_in_window = 0;
+			for (uint8_t i = 0; i < this->sta_flap_count; i++) {
+				if ((this->wifi_seconds - this->sta_flap_times[i]) <= WIFI_STA_FLAP_WINDOW_S) {
+					flaps_in_window++;
+				}
+			}
+
+			THEKERNEL->streams->printf(
+				"WIFI: STA reconnect cycle (%u in %ds)\n",
+				flaps_in_window, WIFI_STA_FLAP_WINDOW_S);
+
+			if (flaps_in_window >= WIFI_STA_FLAP_LIMIT) {
+				this->ap_hold_remaining_s = WIFI_AP_FLAP_HOLD_S;
+				THEKERNEL->streams->printf(
+					"WIFI: STA flapping — holding AP up for %ds\n", WIFI_AP_FLAP_HOLD_S);
+			}
+		}
+		this->sta_was_connected = true;
 		this->sta_down_seconds = 0;
+
+		// During flap-hold, keep AP up even while STA is connected
+		if (this->ap_hold_remaining_s > 0) {
+			if (!this->ap_currently_on) {
+				u16 op_status = 0;
+				if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
+					this->ap_currently_on = true;
+					u8 param_len = 0;
+					u16 qstatus = 0;
+					M8266WIFI_SPI_Query_AP_Param(AP_PARAM_TYPE_IP_ADDR, (u8 *)this->ap_address, &param_len, &qstatus);
+					M8266WIFI_SPI_Query_AP_Param(AP_PARAM_TYPE_NETMASK_ADDR, (u8 *)this->ap_netmask, &param_len, &qstatus);
+					THEKERNEL->streams->printf("WIFI: AP held on during flap-hold ip=%s\n", this->ap_address);
+				} else {
+					THEKERNEL->streams->printf("WIFI: AP hold-enable FAILED, status:%u\n", op_status);
+				}
+			}
+			return;
+		}
+
 		if (this->ap_currently_on) {
 			u16 op_status = 0;
 			if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
@@ -1212,6 +1294,10 @@ void WifiProvider::update_ap_auto_disable(u8 connection_status)
 			}
 		}
 		return;
+	}
+
+	if (this->sta_was_connected) {
+		this->sta_down_since_connected = true;
 	}
 
 	if (this->sta_down_seconds < WIFI_AP_ON_DELAY_S) {

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -108,9 +108,10 @@ WifiProvider::WifiProvider()
 	makera_pending_payload_len = 0;
 	connection_fail_count = 0;
 	sta_down_seconds = 0;
+	last_sta_connection_status = 0xff;
 	ap_auto_disable = true;
 	ap_currently_on = true;
-	ap_off_by_auto_toggle = false;
+	ap_manually_disabled = false;
 }
 
 void WifiProvider::on_module_loaded()
@@ -142,12 +143,18 @@ void WifiProvider::on_module_loaded()
     }
 
     // Disable AP before STA auto-reconnect to avoid address conflicts with the onboard AP
-    if (this->ap_auto_disable && this->ap_currently_on) {
-        u16 op_status = 0;
-        if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
-            this->ap_currently_on = false;
-            this->ap_off_by_auto_toggle = true;
-            this->sta_down_seconds = 0;
+    if (this->ap_auto_disable && !this->ap_manually_disabled) {
+        if (this->ap_currently_on) {
+            u16 op_status = 0;
+            if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
+                this->ap_currently_on = false;
+                this->sta_down_seconds = 0;
+                THEKERNEL->streams->printf("WIFI: AP auto-disabled at boot (opmode STA-only)\n");
+            } else {
+                THEKERNEL->streams->printf("WIFI: AP auto-disable at boot FAILED, status:%u\n", op_status);
+            }
+        } else {
+            THEKERNEL->streams->printf("WIFI: AP already off at boot (will restore if STA stays down)\n");
         }
     }
 
@@ -519,32 +526,7 @@ void WifiProvider::on_second_tick(void *)
 			connection_fail_count = 0;
 		}
 
-		// Keep AP off while STA is connecting/connected; restore AP after STA is down
-		// for WIFI_AP_ON_DELAY_S to avoid address conflicts. saved=0 to avoid flash wear.
-		if (this->ap_auto_disable) {
-			if (connection_status == 1 || connection_status == 5) {
-				this->sta_down_seconds = 0;
-				if (this->ap_currently_on) {
-					u16 op_status = 0;
-					if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
-						this->ap_currently_on = false;
-						this->ap_off_by_auto_toggle = true;
-					}
-				}
-			} else {
-				if (this->sta_down_seconds < WIFI_AP_ON_DELAY_S) {
-					this->sta_down_seconds++;
-				}
-				// only re-enable if we were the ones who turned it off; ap disable stays off
-				if (this->sta_down_seconds >= WIFI_AP_ON_DELAY_S && !this->ap_currently_on && this->ap_off_by_auto_toggle) {
-					u16 op_status = 0;
-					if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
-						this->ap_currently_on = true;
-						this->ap_off_by_auto_toggle = false;
-					}
-				}
-			}
-		}
+		update_ap_auto_disable(connection_status);
 
 		// send ap info through UDP
 		if (!this->ap_currently_on) return;
@@ -578,43 +560,45 @@ void WifiProvider::on_second_tick(void *)
 
 		if (!wifi_init_ok || THEKERNEL->is_uploading()) return;
 
-		if (M8266WIFI_SPI_List_Clients_On_A_TCP_Server(tcp_link_no, &client_num, RemoteClients, &status)) {
+		M8266WIFI_SPI_List_Clients_On_A_TCP_Server(tcp_link_no, &client_num, RemoteClients, &status);
 
-			if (M8266WIFI_SPI_Get_STA_Connection_Status(&connection_status, &status)) {
-				if (connection_status == 5) {
-					// get ip and netmask
-					M8266WIFI_SPI_Query_STA_Param(STA_PARAM_TYPE_IP_ADDR, (u8 *)this->sta_address, &param_len, &status);
-					M8266WIFI_SPI_Query_STA_Param(STA_PARAM_TYPE_NETMASK_ADDR, (u8 *)this->sta_netmask, &param_len, &status);
-					// send data to sta broadcast address
-					get_broadcast_from_ip_and_netmask(address, this->sta_address, this->sta_netmask);
-					snprintf(udp_buff, sizeof(udp_buff), "%s,%s,%d,%d", this->machine_name, this->sta_address, this->tcp_port, client_num > 0 ? 1 : 0);
-					if (M8266WIFI_SPI_Send_Udp_Data((u8 *)udp_buff, strlen(udp_buff), udp_link_no, address, this->udp_send_port, &status) < strlen(udp_buff)) {
-						// THEKERNEL->streams->printf("Send UDP through STA ERROR, status: %d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
-					} else {
-						// THEKERNEL->streams->printf("Send UDP through STA Success!\n");
-					}
-					connection_fail_count = 0;
-				} else if (connection_status == 2 || connection_status == 3 || connection_status == 4) {
-					// wrong password or can not find STA or fail to connect
-					connection_fail_count ++;
-					if (connection_fail_count > 30) {
-						// disconnect Wifi
-						if (M8266WIFI_SPI_STA_DisConnect_Ap(&status)) {
-							THEKERNEL->streams->printf("STA connection timeout, disconnected!\n");
-						}
-						connection_fail_count = 0;
-					}
-				} else {
-					connection_fail_count = 0;
-				}
-			
-				// send ap info through UDP
-				memset(udp_buff, 0, sizeof(udp_buff));
-				get_broadcast_from_ip_and_netmask(address, this->ap_address, this->ap_netmask);
-				snprintf(udp_buff, sizeof(udp_buff), "%s,%s,%d,%d", this->machine_name, this->ap_address, this->tcp_port, client_num > 0 ? 1 : 0);
+		if (M8266WIFI_SPI_Get_STA_Connection_Status(&connection_status, &status)) {
+			if (connection_status == 5) {
+				// get ip and netmask
+				M8266WIFI_SPI_Query_STA_Param(STA_PARAM_TYPE_IP_ADDR, (u8 *)this->sta_address, &param_len, &status);
+				M8266WIFI_SPI_Query_STA_Param(STA_PARAM_TYPE_NETMASK_ADDR, (u8 *)this->sta_netmask, &param_len, &status);
+				// send data to sta broadcast address
+				get_broadcast_from_ip_and_netmask(address, this->sta_address, this->sta_netmask);
+				snprintf(udp_buff, sizeof(udp_buff), "%s,%s,%d,%d", this->machine_name, this->sta_address, this->tcp_port, client_num > 0 ? 1 : 0);
 				if (M8266WIFI_SPI_Send_Udp_Data((u8 *)udp_buff, strlen(udp_buff), udp_link_no, address, this->udp_send_port, &status) < strlen(udp_buff)) {
-					// THEKERNEL->streams->printf("Send UDP through AP ERROR, status: %d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
+					// THEKERNEL->streams->printf("Send UDP through STA ERROR, status: %d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
+				} else {
+					// THEKERNEL->streams->printf("Send UDP through STA Success!\n");
 				}
+				connection_fail_count = 0;
+			} else if (connection_status == 2 || connection_status == 3 || connection_status == 4) {
+				// wrong password or can not find STA or fail to connect
+				connection_fail_count ++;
+				if (connection_fail_count > 30) {
+					// disconnect Wifi
+					if (M8266WIFI_SPI_STA_DisConnect_Ap(&status)) {
+						THEKERNEL->streams->printf("STA connection timeout, disconnected!\n");
+					}
+					connection_fail_count = 0;
+				}
+			} else {
+				connection_fail_count = 0;
+			}
+
+			update_ap_auto_disable(connection_status);
+
+			// send ap info through UDP
+			if (!this->ap_currently_on) return;
+			memset(udp_buff, 0, sizeof(udp_buff));
+			get_broadcast_from_ip_and_netmask(address, this->ap_address, this->ap_netmask);
+			snprintf(udp_buff, sizeof(udp_buff), "%s,%s,%d,%d", this->machine_name, this->ap_address, this->tcp_port, client_num > 0 ? 1 : 0);
+			if (M8266WIFI_SPI_Send_Udp_Data((u8 *)udp_buff, strlen(udp_buff), udp_link_no, address, this->udp_send_port, &status) < strlen(udp_buff)) {
+				// THEKERNEL->streams->printf("Send UDP through AP ERROR, status: %d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
 			}
 		}
 	}
@@ -1198,6 +1182,60 @@ void WifiProvider::set_wifi_op_mode(u8 op_mode) {
 	}
 }
 
+// Keep AP off while STA has an IP; restore AP after WIFI_AP_ON_DELAY_S of not being
+// connected. Status 1 (connecting/reconnecting) counts as down so a dead router that
+// leaves the module in a reconnect loop still brings the onboard AP back.
+// saved=0 to avoid flash wear. Manual `ap disable` sets ap_manually_disabled and blocks restore.
+void WifiProvider::update_ap_auto_disable(u8 connection_status)
+{
+	if (!this->ap_auto_disable || this->ap_manually_disabled) return;
+
+	if (connection_status != this->last_sta_connection_status) {
+		THEKERNEL->streams->printf(
+			"WIFI: STA status %u -> %u (down=%d AP=%s)\n",
+			this->last_sta_connection_status,
+			connection_status,
+			this->sta_down_seconds,
+			this->ap_currently_on ? "on" : "off");
+		this->last_sta_connection_status = connection_status;
+	}
+
+	if (connection_status == 5) {
+		this->sta_down_seconds = 0;
+		if (this->ap_currently_on) {
+			u16 op_status = 0;
+			if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
+				this->ap_currently_on = false;
+				THEKERNEL->streams->printf("WIFI: AP auto-disabled (STA connected)\n");
+			} else {
+				THEKERNEL->streams->printf("WIFI: AP auto-disable FAILED, status:%u\n", op_status);
+			}
+		}
+		return;
+	}
+
+	if (this->sta_down_seconds < WIFI_AP_ON_DELAY_S) {
+		this->sta_down_seconds++;
+	}
+
+	if (this->sta_down_seconds >= WIFI_AP_ON_DELAY_S && !this->ap_currently_on) {
+		u16 op_status = 0;
+		if (M8266WIFI_SPI_Set_Opmode(3, 0, &op_status)) {
+			this->ap_currently_on = true;
+			// SoftAP just came back; refresh cached AP addressing used for UDP beacon
+			u8 param_len = 0;
+			u16 qstatus = 0;
+			M8266WIFI_SPI_Query_AP_Param(AP_PARAM_TYPE_IP_ADDR, (u8 *)this->ap_address, &param_len, &qstatus);
+			M8266WIFI_SPI_Query_AP_Param(AP_PARAM_TYPE_NETMASK_ADDR, (u8 *)this->ap_netmask, &param_len, &qstatus);
+			THEKERNEL->streams->printf(
+				"WIFI: AP auto-enabled (STA down >= %ds) ip=%s\n",
+				WIFI_AP_ON_DELAY_S, this->ap_address);
+		} else {
+			THEKERNEL->streams->printf("WIFI: AP auto-enable FAILED, status:%u\n", op_status);
+		}
+	}
+}
+
 void WifiProvider::on_get_public_data(void* argument) {
 	if (communication_protocol == PROTOCOL_SMOOTHIE) { //smoothie can be cleaned up and merged
 		PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
@@ -1411,11 +1449,13 @@ void WifiProvider::on_set_public_data(void *argument)
     		}
     	} else {
     	    // Disable AP before STA connect to avoid network address conflicts
-    	    if (this->ap_auto_disable && this->ap_currently_on) {
+    	    if (this->ap_auto_disable && !this->ap_manually_disabled && this->ap_currently_on) {
     	        u16 op_status = 0;
     	        if (M8266WIFI_SPI_Set_Opmode(1, 0, &op_status)) {
     	            this->ap_currently_on = false;
-    	            this->ap_off_by_auto_toggle = true;
+    	            THEKERNEL->streams->printf("WIFI: AP auto-disabled before STA connect\n");
+    	        } else {
+    	            THEKERNEL->streams->printf("WIFI: AP auto-disable before STA connect FAILED, status:%u\n", op_status);
     	        }
     	    }
     	    this->sta_down_seconds = 0;
@@ -1538,11 +1578,11 @@ void WifiProvider::on_set_public_data(void *argument)
         	set_wifi_op_mode(3);
         	this->ap_currently_on = true;
         	this->sta_down_seconds = 0;
-        	this->ap_off_by_auto_toggle = false;
+        	this->ap_manually_disabled = false;
     	} else {
         	set_wifi_op_mode(1);
         	this->ap_currently_on = false;
-        	this->ap_off_by_auto_toggle = false;
+        	this->ap_manually_disabled = true;
     	}
     }
 	pdr->set_taken();

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -85,7 +85,7 @@ private:
 	int udp_recv_port;
 	int tcp_timeout_s;
 	int connection_fail_count;
-	int sta_stable_seconds;
+	int sta_down_seconds;
 	char machine_name[64]; // Fixed-size buffer to avoid std::string heap allocation
 	char ap_address[16];
 	char ap_netmask[16];

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -88,6 +88,10 @@ private:
 	int connection_fail_count;
 	int sta_down_seconds;
 	u8 last_sta_connection_status;
+	uint32_t wifi_seconds;
+	uint32_t sta_flap_times[3]; // timestamps of recent STA reconnect cycles (WIFI_STA_FLAP_LIMIT)
+	uint8_t sta_flap_count;
+	uint32_t ap_hold_remaining_s; // keep AP up while > 0 after STA flapping
 	char machine_name[64]; // Fixed-size buffer to avoid std::string heap allocation
 	char ap_address[16];
 	char ap_netmask[16];
@@ -101,6 +105,8 @@ private:
     	bool ap_auto_disable:1;
     	bool ap_currently_on:1;
     	bool ap_manually_disabled:1; // sticky from `ap disable` until `ap enable`
+    	bool sta_was_connected:1;
+    	bool sta_down_since_connected:1;
     	volatile bool halt_flag:1;
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -60,6 +60,7 @@ private:
 
     void init_wifi_module(bool reset);
     void query_wifi_status();
+    void update_ap_auto_disable(u8 connection_status);
 
     uint32_t ip_to_int(const char* ip_addr);
     void int_to_ip(uint32_t i_ip, char *ip_addr);
@@ -86,6 +87,7 @@ private:
 	int tcp_timeout_s;
 	int connection_fail_count;
 	int sta_down_seconds;
+	u8 last_sta_connection_status;
 	char machine_name[64]; // Fixed-size buffer to avoid std::string heap allocation
 	char ap_address[16];
 	char ap_netmask[16];
@@ -98,7 +100,7 @@ private:
     	bool wifi_init_ok:1;
     	bool ap_auto_disable:1;
     	bool ap_currently_on:1;
-    	bool ap_off_by_auto_toggle:1;
+    	bool ap_manually_disabled:1; // sticky from `ap disable` until `ap enable`
     	volatile bool halt_flag:1;
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;


### PR DESCRIPTION
Resolves #384 

This PR changes the auto_disable_ap feature logic to disable the AP mode before connecting STA, and re-enable AP only after 5s of STA disconnect.