### PR TITLE
Add read-only HTTP status API (GET /status) for network integrations

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -87,6 +87,8 @@ epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for exampl
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
 # wifi.ap_auto_disable							true			# false to keep AP enabled even when STA is connected
+# wifi.http_enable							false			# enable the read-only HTTP status API (GET /status)
+# wifi.http_port								8080			# TCP port for the HTTP status API
 
 # ATC
 # atc.enable									true

--- a/src/config2.default
+++ b/src/config2.default
@@ -90,6 +90,8 @@ protocol 					makera 	#makera for the stock configuration, smoothie for default 
 # wifi.tcp_timeout_s							10
 # wifi.machine_name							CARVERA_01001
 # wifi.ap_auto_disable							true			# false to keep AP enabled even when STA is connected
+# wifi.http_enable							false			# enable the read-only HTTP status API (GET /status)
+# wifi.http_port								8080			# TCP port for the HTTP status API
 
 # ATC
 # atc.enable									true

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -82,7 +82,13 @@ void Conveyor::on_module_loaded()
 void Conveyor::start(uint8_t n)
 {
     Block::init(n); // set the number of motors which determines how big the tick info vector is
-    queue.resize(queue_size);
+    if(!queue.resize(queue_size)) {
+        // without this halt the first append_block() would dereference the
+        // null ring and hard-fault the machine into a watchdog reboot loop
+        THEKERNEL->streams->printf("FATAL: block queue allocation failed (%d blocks), out of AHB memory - motion disabled, machine halted\n", queue_size);
+        THEKERNEL->call_event(ON_HALT, nullptr);
+        return;
+    }
     running = true;
 }
 

--- a/src/modules/utils/wifi/StatusJson.cpp
+++ b/src/modules/utils/wifi/StatusJson.cpp
@@ -1,0 +1,236 @@
+/*
+ * StatusJson.cpp
+ *
+ * JSON status document for the read-only HTTP status API.
+ * Mirrors the field sources of Kernel::get_query_string() (the `?` report),
+ * but emits a stable, self-describing JSON schema for consumers like
+ * Home Assistant's rest: integration.
+ */
+
+#include "StatusJson.h"
+
+#include "libs/Kernel.h"
+#include "libs/PublicData.h"
+#include "libs/nuts_bolts.h"
+#include "modules/robot/Robot.h"
+#include "modules/robot/Conveyor.h"
+#include "StepperMotor.h"
+#include "checksumm.h"
+#include "SpindlePublicAccess.h"
+#include "TemperatureControlPublicAccess.h"
+#include "ATCHandlerPublicAccess.h"
+#include "LaserPublicAccess.h"
+#include "PlayerPublicAccess.h"
+#include "version.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cstdarg>
+
+// append with a running cursor; always NUL-safe, returns the new cursor.
+// Once the buffer is full further calls are no-ops, yielding truncated
+// (possibly invalid) JSON rather than a buffer overrun.
+static size_t jput(char *buf, size_t size, size_t pos, const char *fmt, ...)
+{
+	if (pos + 1 >= size) return size - 1;
+	va_list ap;
+	va_start(ap, fmt);
+	int n = vsnprintf(buf + pos, size - pos, fmt, ap);
+	va_end(ap);
+	if (n < 0) return pos;
+	pos += (size_t)n;
+	return pos >= size ? size - 1 : pos;
+}
+
+// copy src into dst replacing characters that would need JSON escaping
+// ('"', '\\', control and non-ASCII bytes) with '_' so the output size
+// stays deterministic.
+static void json_sanitize(char *dst, size_t dst_size, const char *src)
+{
+	size_t i;
+	// dst_size also bounds how far src is read: callers pass fixed-size
+	// firmware buffers that are not guaranteed to be terminated.
+	for (i = 0; i + 1 < dst_size && src[i] != '\0'; i++) {
+		char c = src[i];
+		dst[i] = (c == '"' || c == '\\' || c < 0x20 || c > 0x7E) ? '_' : c;
+	}
+	dst[i] = '\0';
+}
+
+static const char *jbool(bool b)
+{
+	return b ? "true" : "false";
+}
+
+size_t build_status_json(char *buf, size_t buf_size,
+                         const char *machine_name,
+                         const char *sta_ip,
+                         int console_clients)
+{
+	size_t pos = 0;
+
+	uint8_t state = THEKERNEL->get_state();
+	bool running = (state == RUN || state == HOME);
+
+	const char *state_str;
+	switch (state) {
+		case SLEEP:   state_str = "Sleep"; break;
+		case SUSPEND: state_str = "Pause"; break;
+		case WAIT:    state_str = "Wait"; break;
+		case TOOL:    state_str = "Tool"; break;
+		case ALARM:   state_str = "Alarm"; break;
+		case HOME:    state_str = "Home"; break;
+		case HOLD:    state_str = "Hold"; break;
+		case RUN:     state_str = "Run"; break;
+		case IDLE:
+		default:      state_str = "Idle"; break;
+	}
+
+	const char *model_str;
+	switch (THEKERNEL->factory_set->MachineModel) {
+		case CARVERA:     model_str = "C1"; break;
+		case CARVERA_AIR: model_str = "CA1"; break;
+		default:          model_str = "unknown"; break;
+	}
+
+	// Never format these straight into the document: they are fixed-size
+	// firmware buffers that may not be terminated yet (the machine's IP is
+	// only filled in once the wifi module reports an association), and a
+	// stray %s would read past the end of one.
+	char name_s[36], ip_s[16];
+	json_sanitize(name_s, sizeof(name_s), machine_name);
+	json_sanitize(ip_s, sizeof(ip_s), sta_ip);
+
+	pos = jput(buf, buf_size, pos,
+	           "{\"name\":\"%s\",\"model\":\"%s\",\"fw\":\"%s\",\"ip\":\"%s\",\"state\":\"%s\"",
+	           name_s, model_str, Version().get_build(), ip_s, state_str);
+
+	pos = jput(buf, buf_size, pos, ",\"alarm\":%s,\"halt_reason\":%d",
+	           jbool(THEKERNEL->is_halted()),
+	           THEKERNEL->is_halted() ? THEKERNEL->get_halt_reason() : 0);
+
+	// machine and work positions, mirroring Kernel::get_query_string()
+	float mpos[5] = {0, 0, 0, 0, 0};
+	float wpos[5];
+	if (running) {
+		THEROBOT->get_current_machine_position(mpos);
+		// current_position includes the compensation transform, get the inverse for the actual position
+		if (THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false);
+#if MAX_ROBOT_ACTUATORS > 3
+		mpos[A_AXIS] = THEROBOT->actuators[A_AXIS]->get_current_position();
+		mpos[B_AXIS] = THEROBOT->actuators[B_AXIS]->get_current_position();
+#else
+		mpos[A_AXIS] = 0;
+		mpos[B_AXIS] = 0;
+#endif
+	} else {
+		// last milestone when idle
+		Robot::wcs_t mp = THEROBOT->get_axis_position();
+		mpos[X_AXIS] = std::get<X_AXIS>(mp);
+		mpos[Y_AXIS] = std::get<Y_AXIS>(mp);
+		mpos[Z_AXIS] = std::get<Z_AXIS>(mp);
+		mpos[A_AXIS] = std::get<A_AXIS>(mp);
+		mpos[B_AXIS] = std::get<B_AXIS>(mp);
+	}
+	Robot::wcs_t wp = THEROBOT->mcs2wcs(mpos);
+	wpos[X_AXIS] = std::get<X_AXIS>(wp);
+	wpos[Y_AXIS] = std::get<Y_AXIS>(wp);
+	wpos[Z_AXIS] = std::get<Z_AXIS>(wp);
+	wpos[A_AXIS] = std::get<A_AXIS>(wp);
+	wpos[B_AXIS] = std::get<B_AXIS>(wp);
+
+	pos = jput(buf, buf_size, pos, ",\"mpos\":[%1.4f,%1.4f,%1.4f,%1.4f,%1.4f]",
+	           THEROBOT->from_millimeters(mpos[X_AXIS]),
+	           THEROBOT->from_millimeters(mpos[Y_AXIS]),
+	           THEROBOT->from_millimeters(mpos[Z_AXIS]),
+	           mpos[A_AXIS], mpos[B_AXIS]);
+	pos = jput(buf, buf_size, pos, ",\"wpos\":[%1.4f,%1.4f,%1.4f,%1.4f,%1.4f]",
+	           THEROBOT->from_millimeters(wpos[X_AXIS]),
+	           THEROBOT->from_millimeters(wpos[Y_AXIS]),
+	           THEROBOT->from_millimeters(wpos[Z_AXIS]),
+	           wpos[A_AXIS], wpos[B_AXIS]);
+
+	static const char *const wcs_names[] = {"G54", "G55", "G56", "G57", "G58", "G59", "G59.1", "G59.2", "G59.3"};
+	uint8_t wcs = THEROBOT->get_current_wcs();
+	pos = jput(buf, buf_size, pos, ",\"wcs\":\"%s\",\"wcs_rotation\":%1.4f,\"inch\":%s,\"absolute\":%s",
+	           wcs < (sizeof(wcs_names) / sizeof(wcs_names[0])) ? wcs_names[wcs] : "?",
+	           THEROBOT->r[wcs],
+	           jbool(THEROBOT->inch_mode), jbool(THEROBOT->absolute_mode));
+
+	pos = jput(buf, buf_size, pos, ",\"feed\":{\"current\":%1.1f,\"target\":%1.1f,\"override\":%1.1f}",
+	           running ? THEROBOT->from_millimeters(THECONVEYOR->get_current_feedrate() * 60.0F) : 0.0F,
+	           THEROBOT->from_millimeters(THEROBOT->get_feed_rate()),
+	           6000.0F / THEROBOT->get_seconds_per_minute());
+
+	struct spindle_status ss;
+	if (PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss)) {
+		pos = jput(buf, buf_size, pos,
+		           ",\"spindle\":{\"on\":%s,\"rpm\":%1.1f,\"target_rpm\":%1.1f,\"override\":%1.1f,\"vacuum\":%s",
+		           jbool(ss.state), ss.current_rpm, ss.target_rpm, ss.factor,
+		           jbool(THEKERNEL->get_vacuum_mode()));
+		struct pad_temperature temp;
+		if (PublicData::get_value(temperature_control_checksum, current_temperature_checksum, spindle_temperature_checksum, &temp)) {
+			pos = jput(buf, buf_size, pos, ",\"temp\":%1.1f", temp.current_temperature);
+		}
+		pos = jput(buf, buf_size, pos, "}");
+	}
+
+	// power supply temperature (Carvera Air only, self-gating)
+	struct pad_temperature ptemp;
+	if (PublicData::get_value(temperature_control_checksum, current_temperature_checksum, power_temperature_checksum, &ptemp)) {
+		pos = jput(buf, buf_size, pos, ",\"power_temp\":%1.1f", ptemp.current_temperature);
+	}
+
+	struct tool_status tool;
+	if (PublicData::get_value(atc_handler_checksum, get_tool_status_checksum, &tool)) {
+		pos = jput(buf, buf_size, pos, ",\"tool\":{\"number\":%d,\"target\":%d,\"offset\":%1.3f}",
+		           tool.active_tool, tool.target_tool, tool.tool_offset);
+	}
+
+	float wp_voltage;
+	if (PublicData::get_value(atc_handler_checksum, get_wp_voltage_checksum, &wp_voltage)) {
+		pos = jput(buf, buf_size, pos, ",\"probe_voltage\":%1.2f", wp_voltage);
+	}
+
+	struct laser_status ls;
+	if (PublicData::get_value(laser_checksum, get_laser_status_checksum, &ls)) {
+		pos = jput(buf, buf_size, pos, ",\"laser\":{\"mode\":%s,\"on\":%s,\"power\":%1.1f,\"scale\":%1.1f}",
+		           jbool(ls.mode), jbool(ls.state), ls.power, ls.scale);
+	}
+
+	// job progress; Player returns a pointer to its own static pad_progress,
+	// read it in place (single-threaded main-loop context) to avoid copying
+	// the std::string filename
+	void *returned_data;
+	if (PublicData::get_value(player_checksum, get_progress_checksum, &returned_data)) {
+		struct pad_progress *p = static_cast<struct pad_progress *>(returned_data);
+		if (!p->is_playing && p->filename.empty()) {
+			// nothing has played since boot, Player's last-progress fields are unset
+			pos = jput(buf, buf_size, pos, ",\"job\":{\"playing\":false}");
+		} else {
+			char fname[100];
+			json_sanitize(fname, sizeof(fname), p->filename.c_str());
+			pos = jput(buf, buf_size, pos,
+			           ",\"job\":{\"playing\":%s,\"file\":\"%s\",\"percent\":%u,\"played_lines\":%lu,\"parsed_lines\":%lu,\"elapsed_secs\":%lu}",
+			           jbool(p->is_playing), fname, p->percent_complete,
+			           p->played_lines, p->parsed_lines, p->elapsed_secs);
+		}
+	} else {
+		pos = jput(buf, buf_size, pos, ",\"job\":{\"playing\":false}");
+	}
+
+	if (THEROBOT->compensationTransform != nullptr) {
+		pos = jput(buf, buf_size, pos, ",\"leveling\":{\"active\":true,\"max_delta\":%1.3f}", THEROBOT->get_max_delta());
+	} else {
+		pos = jput(buf, buf_size, pos, ",\"leveling\":{\"active\":false}");
+	}
+
+	if (THEKERNEL->factory_set->FuncSetting & (1 << 2)) { // ATC present
+		pos = jput(buf, buf_size, pos, ",\"atc_state\":%d", THEKERNEL->get_atc_state());
+	}
+
+	pos = jput(buf, buf_size, pos, ",\"clients\":%d,\"controller_connected\":%s}",
+	           console_clients, jbool(console_clients > 0));
+
+	return pos;
+}

--- a/src/modules/utils/wifi/StatusJson.h
+++ b/src/modules/utils/wifi/StatusJson.h
@@ -1,0 +1,22 @@
+/*
+ * StatusJson.h
+ *
+ * Builds the JSON document served by the read-only HTTP status API (GET /status).
+ */
+
+#ifndef STATUSJSON_H_
+#define STATUSJSON_H_
+
+#include <cstddef>
+
+// Builds the /status JSON document into buf (always NUL-terminated).
+// Returns the body length (excluding the NUL); output is truncated safely
+// if buf_size is too small.
+// Must only be called from main-loop context (ON_IDLE / ON_MAIN_LOOP),
+// it performs PublicData reads.
+size_t build_status_json(char *buf, size_t buf_size,
+                         const char *machine_name,
+                         const char *sta_ip,
+                         int console_clients);
+
+#endif /* STATUSJSON_H_ */

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -43,6 +43,8 @@
 
 #include "gpio.h"
 
+#include "StatusJson.h"
+
 #include <math.h>
 
 #define wifi_checksum                     CHECKSUM("wifi")
@@ -54,6 +56,26 @@
 #define udp_recv_port_checksum		      CHECKSUM("udp_recv_port")
 #define tcp_timeout_s_checksum			  CHECKSUM("tcp_timeout_s")
 #define ap_auto_disable_checksum          CHECKSUM("ap_auto_disable")
+#define http_enable_checksum              CHECKSUM("http_enable")
+#define http_port_checksum                CHECKSUM("http_port")
+
+// Read-only HTTP status API (GET /status). The response is built in place in
+// the shared WifiData buffer once the request has been parsed out of it, so
+// the feature costs no RAM: the AHB pool has almost no headroom left and
+// allocating from it at boot starves the motion block queue.
+#define HTTP_HDR_RESERVE   192
+#define HTTP_BODY_MAX_SIZE (WIFI_DATA_MAX_SIZE - HTTP_HDR_RESERVE)
+#define HTTP_TIMEOUT_S     5
+
+// request parser states / matched route
+#define HTTP_ST_METHOD     0
+#define HTTP_ST_PATH       1
+#define HTTP_ST_HEADERS    2
+#define HTTP_RT_NOT_FOUND  0
+#define HTTP_RT_STATUS     1
+#define HTTP_RT_ROOT       2
+#define HTTP_RT_BAD_METHOD 3
+#define HTTP_STATUS_PATH   "/status"   /* the only route with a payload */
 
 #define WIFI_AP_ON_DELAY_S           5
 #define WIFI_STA_FLAP_WINDOW_S       (5 * 60)   // count reconnect cycles in this window
@@ -73,6 +95,24 @@ WifiProvider::WifiProvider()
 {
 	tcp_link_no = 0;
 	udp_link_no = 1;
+	http_link_no = 2;
+	http_enable = false;
+	http_port = 8080;
+	tcp_client_num = 0;
+	http_parse_state = HTTP_ST_METHOD;
+	http_match_pos = 0;
+	http_route = HTTP_RT_NOT_FOUND;
+	http_eoh_run = 0;
+	http_client_port = 0;
+	http_pending = false;
+	// Only filled once the module reports an association. Anything that
+	// formats them before that (the status API answers from the first second
+	// of uptime) would otherwise run off the end of the buffer.
+	sta_address[0] = '\0';
+	sta_netmask[0] = '\0';
+	ap_address[0] = '\0';
+	ap_netmask[0] = '\0';
+	machine_name[0] = '\0';
 	wifi_init_ok = false;
 	has_data_flag = false;
 	makera_file_cancel = false;
@@ -109,6 +149,12 @@ void WifiProvider::on_module_loaded()
 	this->tcp_timeout_s = THEKERNEL->config->value(wifi_checksum, tcp_timeout_s_checksum)->as_int(10);
 	std::string config_name = THEKERNEL->config->value(wifi_checksum, machine_name_checksum)->as_string("CARVERA");
 	this->ap_auto_disable = THEKERNEL->config->value(wifi_checksum, ap_auto_disable_checksum)->as_bool(true);
+	this->http_enable = THEKERNEL->config->value(wifi_checksum, http_enable_checksum)->as_bool(false);
+	this->http_port = THEKERNEL->config->value(wifi_checksum, http_port_checksum)->as_int(8080);
+	if (this->http_enable && this->http_port == this->tcp_port) {
+		THEKERNEL->streams->printf("WARNING: wifi.http_port equals wifi.tcp_port, HTTP status API disabled\n");
+		this->http_enable = false;
+	}
     strncpy(this->machine_name, config_name.c_str(), sizeof(this->machine_name) - 1);
     this->machine_name[sizeof(this->machine_name) - 1] = '\0'; // Ensure null termination
 
@@ -184,9 +230,25 @@ void WifiProvider::receive_wifi_data() {
 	if (communication_protocol == PROTOCOL_SMOOTHIE) {
 		while (true)
 		{
-			received = M8266WIFI_SPI_RecvData(WifiData, WIFI_DATA_MAX_SIZE, WIFI_DATA_TIMEOUT_MS, &link_no, &status);
+			u8 remote_ip[4];
+			u16 remote_port = 0;
+			received = M8266WIFI_SPI_RecvData_ex(WifiData, WIFI_DATA_MAX_SIZE, WIFI_DATA_TIMEOUT_MS, &link_no, remote_ip, &remote_port, &status);
+			if (received == 0) {
+				// nothing read, link_no would be stale, never dispatch on it
+				return;
+			}
 			if (link_no == udp_link_no) {
 				return;
+			}
+			if (http_enable && link_no == http_link_no) {
+				// parse only; the answer is sent from on_idle
+				for (uint32_t i = 0; i < received && !http_pending; i++) {
+					http_feed(WifiData[i], remote_ip, remote_port);
+				}
+				if (received < WIFI_DATA_MAX_SIZE) {
+					return;
+				}
+				continue;
 			}
 			for (uint32_t i = 0; i < received; i ++) {
 				if(THEKERNEL->is_cachewait()) {
@@ -273,6 +335,14 @@ void WifiProvider::receive_wifi_data() {
 		if (count == 0) return;
 		if (count > wanted) count = wanted;
 		if (link_no == udp_link_no) return;
+		if (http_enable && link_no == http_link_no) {
+			// status poll: parse it, never let its bytes reach the frame decoder
+			for (uint16_t i = 0; i < count && !http_pending; i++) {
+				http_feed(WifiData[i], remote_ip, remote_port);
+			}
+			if (http_pending) return;   // answer it from on_idle, then come back
+			continue;
+		}
 		if (!makera_remote_known || remote_port != makera_remote_port ||
 			memcmp(remote_ip, makera_remote_ip, sizeof(makera_remote_ip)) != 0) {
 			makera_frame_decoder.reset();
@@ -386,6 +456,7 @@ void WifiProvider::on_second_tick(void *)
 		if (!wifi_init_ok || THEKERNEL->is_uploading()) return;
 
 		M8266WIFI_SPI_List_Clients_On_A_TCP_Server(tcp_link_no, &client_num, RemoteClients, &status);
+		this->tcp_client_num = client_num;
 
 		M8266WIFI_SPI_Get_STA_Connection_Status(&connection_status, &status);
 		// THEKERNEL->streams->printf("M8266WIFI_SPI_Get_STA_Connection_Status: [%d]!\n", connection_status);
@@ -538,6 +609,12 @@ void WifiProvider::on_idle(void *argument)
 	if (!command_waiting && (has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
 		has_data_flag = false;
 		receive_wifi_data();
+	}
+
+	// answer a parsed status request outside the receive loops, so building a
+	// response can never stall a console frame mid-read
+	if (http_pending) {
+		serve_http();
 	}
 
 	if (makera_file_cancel) {
@@ -767,12 +844,177 @@ int WifiProvider::_putc(int c)
 	}
 }
 
+// Feed one received byte of an HTTP request through the parser. Nothing is
+// buffered: the method and the route are matched incrementally, so a request
+// may arrive in any number of TCP segments and the whole parser costs ~10
+// bytes of state. Sets http_pending when a complete request has been seen;
+// serve_http() answers it later, from on_idle.
+void WifiProvider::http_feed(u8 c, const u8 remote_ip[4], u16 remote_port)
+{
+	if (http_pending) return;   // previous answer not sent yet, ignore extra bytes
+
+	// A different client (or the first byte of a new request) restarts the parse:
+	// a client that opened a connection and never finished its request cannot
+	// then block the next one.
+	bool new_client = (remote_port != http_client_port) || memcmp(remote_ip, http_ip, 4) != 0;
+	if (new_client || (http_parse_state == HTTP_ST_METHOD && http_match_pos == 0)) {
+		memcpy(http_ip, remote_ip, 4);
+		http_client_port = remote_port;
+		http_parse_state = HTTP_ST_METHOD;
+		http_match_pos = 0;
+		http_route = HTTP_RT_STATUS;   // still on track to match "/status"
+		http_eoh_run = 0;
+	}
+
+	switch (http_parse_state) {
+	case HTTP_ST_METHOD: {
+		static const char method[] = "GET ";
+		if (c == method[http_match_pos]) {
+			if (++http_match_pos == 4) {
+				http_parse_state = HTTP_ST_PATH;
+				http_match_pos = 0;
+			}
+		} else {
+			http_route = HTTP_RT_BAD_METHOD;
+			http_parse_state = HTTP_ST_HEADERS;
+		}
+		break;
+	}
+	case HTTP_ST_PATH: {
+		static const char status_path[] = HTTP_STATUS_PATH;   // "/status"
+		const u8 status_len = sizeof(status_path) - 1;
+		// '?' ends the path too (a future ?token= check would hook in here)
+		if (c == ' ' || c == '\r' || c == '\n' || c == '?') {
+			if (http_route == HTTP_RT_STATUS && http_match_pos == status_len) {
+				/* exactly "/status" */
+			} else if (http_route == HTTP_RT_STATUS && http_match_pos == 1) {
+				http_route = HTTP_RT_ROOT;                    // just "/"
+			} else {
+				http_route = HTTP_RT_NOT_FOUND;
+			}
+			http_parse_state = HTTP_ST_HEADERS;
+			if (c == '\n') http_eoh_run = 1;
+		} else if (http_route == HTTP_RT_STATUS
+		           && (http_match_pos >= status_len || c != status_path[http_match_pos])) {
+			http_route = HTTP_RT_NOT_FOUND;                   // diverged from the only route
+		} else if (http_route == HTTP_RT_STATUS) {
+			http_match_pos++;
+		}
+		break;
+	}
+	case HTTP_ST_HEADERS:
+		// end of the header block: "\r\n\r\n" (a bare "\n\n" counts too)
+		if (c == '\n') {
+			if (++http_eoh_run >= 2) http_pending = true;
+		} else if (c != '\r') {
+			http_eoh_run = 0;
+		}
+		break;
+	default:
+		http_parse_state = HTTP_ST_METHOD;
+		break;
+	}
+}
+
+// Answer the parsed request. Called from on_idle, never from inside a receive
+// loop: the response is built in place in WifiData, so nothing here may call
+// puts()/printf-to-streams or pump events (they all reuse WifiData).
+void WifiProvider::serve_http()
+{
+	u16 status = 0;
+	char client_ip[16];
+	snprintf(client_ip, sizeof(client_ip), "%u.%u.%u.%u", http_ip[0], http_ip[1], http_ip[2], http_ip[3]);
+
+	const char *code = "200 OK";
+	const char *ctype = "application/json";
+	char *body = (char *)WifiData + HTTP_HDR_RESERVE;
+	size_t body_len = 0;
+
+	switch (http_route) {
+	case HTTP_RT_STATUS:
+		body_len = build_status_json(body, HTTP_BODY_MAX_SIZE, machine_name, sta_address, tcp_client_num);
+		break;
+	case HTTP_RT_ROOT:
+		ctype = "text/plain";
+		body_len = snprintf(body, HTTP_BODY_MAX_SIZE, "Carvera status API\nGET /status -> machine state as JSON\n");
+		break;
+	case HTTP_RT_BAD_METHOD:
+		code = "405 Method Not Allowed";
+		ctype = "text/plain";
+		body_len = snprintf(body, HTTP_BODY_MAX_SIZE, "GET only\n");
+		break;
+	default:
+		code = "404 Not Found";
+		ctype = "text/plain";
+		body_len = snprintf(body, HTTP_BODY_MAX_SIZE, "not found\n");
+		break;
+	}
+
+	// write the headers directly in front of the body so headers+body go out
+	// as one contiguous buffer without copying the body
+	char hdr[HTTP_HDR_RESERVE];
+	int hdr_len = snprintf(hdr, sizeof(hdr),
+			"HTTP/1.0 %s\r\nContent-Type: %s\r\nContent-Length: %u\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
+			code, ctype, (unsigned)body_len);
+	if (hdr_len >= (int)sizeof(hdr)) hdr_len = sizeof(hdr) - 1; // never copy past the reserve
+	char *frame = body - hdr_len;
+	memcpy(frame, hdr, hdr_len);
+	send_http_response(frame, hdr_len + body_len, client_ip, http_client_port);
+
+	// actively close the connection; if the client is already gone this is a no-op
+	u8 client_num = 0;
+	ClientInfo RemoteClients[15];
+	if (M8266WIFI_SPI_List_Clients_On_A_TCP_Server(http_link_no, &client_num, RemoteClients, &status) != 0) {
+		for (u8 i = 0; i < client_num; i++) {
+			if (memcmp(RemoteClients[i].remote_ip, http_ip, 4) == 0 && RemoteClients[i].remote_port == http_client_port) {
+				M8266WIFI_SPI_Disconnect_TcpClient(http_link_no, &RemoteClients[i], &status);
+				break;
+			}
+		}
+	}
+
+	// ready for the next request
+	http_pending = false;
+	http_parse_state = HTTP_ST_METHOD;
+	http_match_pos = 0;
+	http_client_port = 0;
+}
+
+void WifiProvider::send_http_response(const char *data, size_t total_len, char *client_ip, u16 client_port)
+{
+	u16 status = 0;
+	size_t sent_index = 0;
+	int guard = 0;
+	while (sent_index < total_len && guard++ < 8) {
+		u16 to_send = (total_len - sent_index) > WIFI_DATA_MAX_SIZE ? WIFI_DATA_MAX_SIZE : (total_len - sent_index);
+		u16 sent = M8266WIFI_SPI_Send_Data_to_TcpClient(reinterpret_cast<u8 *>(const_cast<char *>(data + sent_index)), to_send, http_link_no, client_ip, client_port, &status);
+		if (sent == 0) {
+			// client gone or module TX error, give up
+			return;
+		}
+		sent_index += sent;
+	}
+}
+
 int WifiProvider::_getc()
 {
+	// XMODEM reads its ACK/NAK/'C' handshake bytes through here one at a time.
+	// UDP or HTTP bytes must never leak into that stream: a status poll
+	// arriving mid-download would corrupt the handshake and its remnants would
+	// later be parsed as console commands.
 	u16 status;
-	u8 to_recv = 0, link_no;
-	M8266WIFI_SPI_RecvData(&to_recv, 1, WIFI_DATA_TIMEOUT_MS, &link_no, &status);
-	return to_recv;
+	u8 link_no;
+	while (true) {
+		u8 to_recv = 0;
+		u16 received = M8266WIFI_SPI_RecvData(&to_recv, 1, WIFI_DATA_TIMEOUT_MS, &link_no, &status);
+		if (received == 0) {
+			return 0;
+		}
+		if (link_no == udp_link_no || (http_enable && link_no == http_link_no)) {
+			continue;
+		}
+		return to_recv;
+	}
 }
 
 int WifiProvider::gets(char** buf, int size)
@@ -782,7 +1024,7 @@ int WifiProvider::gets(char** buf, int size)
 		u8 link_no;
 		u16 received = M8266WIFI_SPI_RecvData(WifiData,
 				(size == 0 || size > WIFI_DATA_MAX_SIZE) ? WIFI_DATA_MAX_SIZE : size, WIFI_DATA_TIMEOUT_MS, &link_no, &status);
-		if (link_no == udp_link_no) {
+		if (link_no == udp_link_no || (http_enable && link_no == http_link_no)) {
 			// THEKERNEL->streams->printf("gets, data from udp");
 			return 0;
 		}
@@ -805,7 +1047,7 @@ int WifiProvider::gets(char** buf, int size)
 		{
 			received = M8266WIFI_SPI_RecvData(WifiData,
 					(size == 0 || size > WIFI_DATA_MAX_SIZE) ? WIFI_DATA_MAX_SIZE : size, WIFI_DATA_TIMEOUT_MS, &link_no, &status);
-			if (link_no == udp_link_no) {
+			if (link_no == udp_link_no || (http_enable && link_no == http_link_no)) {
 				// THEKERNEL->streams->printf("gets, data from udp");
 				return 0;
 			}
@@ -1624,6 +1866,10 @@ void WifiProvider::init_wifi_module(bool reset) {
 		if (M8266WIFI_SPI_Delete_Connection( udp_link_no, &status) == 0){
 			THEKERNEL->streams->printf("M8266WIFI_SPI_Delete_Connection ERROR, status:%d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
 		}
+		if (http_enable) {
+			u16 http_status = 0;
+			M8266WIFI_SPI_Delete_Connection( http_link_no, &http_status);
+		}
 		if (M8266WIFI_SPI_Delete_Connection( tcp_link_no, &status) == 0){
 			THEKERNEL->streams->printf("M8266WIFI_SPI_Delete_Connection ERROR, status:%d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
 		}
@@ -1649,6 +1895,23 @@ void WifiProvider::init_wifi_module(bool reset) {
 	snprintf(address, sizeof(address), "192.168.4.255");
 	if (M8266WIFI_SPI_Setup_Connection(0, this->udp_recv_port, address, 0, udp_link_no, 3, &status) == 0) {
 		THEKERNEL->streams->printf("M8266WIFI_SPI_Setup_Connection ERROR, status:%d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
+	}
+
+	// setup TCP server for the read-only HTTP status API
+	if (http_enable) {
+		snprintf(address, sizeof(address), "0.0.0.0");
+		if (M8266WIFI_SPI_Setup_Connection(2, this->http_port, address, 0, http_link_no, 3, &status) == 0) {
+			THEKERNEL->streams->printf("HTTP M8266WIFI_SPI_Setup_Connection ERROR, status:%d, high: %d, low: %d!\n", status, int(status >> 8), int(status & 0xff));
+			// fail safe: never dispatch to a dead link
+			http_enable = false;
+		} else {
+			if (M8266WIFI_SPI_Config_Max_Clients_Allowed_To_A_Tcp_Server(http_link_no, 2, &status) == 0) {
+				THEKERNEL->streams->printf("HTTP M8266WIFI_SPI_Config_Max_Clients ERROR, status:%d\n", status);
+			}
+			if (M8266WIFI_SPI_Set_TcpServer_Auto_Discon_Timeout(http_link_no, HTTP_TIMEOUT_S, &status) == 0) {
+				THEKERNEL->streams->printf("HTTP M8266WIFI_SPI_Set_TcpServer_Auto_Discon_Timeout ERROR, status:%d\n", status);
+			}
+		}
 	}
 
 	// set timeout

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -70,6 +70,9 @@ private:
 
     void on_pin_rise();
     void receive_wifi_data();
+    void http_feed(u8 c, const u8 remote_ip[4], u16 remote_port);
+    void serve_http();
+    void send_http_response(const char *data, size_t total_len, char *client_ip, u16 client_port);
     int CheckFilePacket(char** buf);
 
     void PacketMessage(char cmd, const char* s, int size);
@@ -84,6 +87,17 @@ private:
 	int udp_send_port;
 	int udp_recv_port;
 	int tcp_timeout_s;
+	int http_port;
+	u8  tcp_client_num;     // clients on the console TCP server, refreshed each second
+	// HTTP request parser state. Requests are matched incrementally as bytes
+	// arrive - nothing is buffered, so this costs ~10 bytes instead of a
+	// request buffer, and a request may span any number of TCP segments.
+	u8  http_ip[4];
+	u16 http_client_port;
+	u8  http_parse_state;
+	u8  http_match_pos;
+	u8  http_route;
+	u8  http_eoh_run;       // consecutive newlines, for end-of-headers
 	int connection_fail_count;
 	int sta_down_seconds;
 	uint32_t wifi_seconds;
@@ -101,7 +115,10 @@ private:
     struct {
     	u8  tcp_link_no;
     	u8  udp_link_no;
+    	u8  http_link_no;
     	bool wifi_init_ok:1;
+    	bool http_enable:1;
+    	bool http_pending:1;   // a parsed request is waiting to be answered
     	bool ap_auto_disable:1;
     	bool ap_currently_on:1;
     	bool ap_manually_disabled:1; // sticky from `ap disable` until `ap enable`

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
 [unreleased]
+- Enhancement: Optional read-only HTTP status API (GET /status) on a spare Wi-Fi link, off by default via wifi.http_enable / wifi.http_port
+- Fixed: Conveyor halts with a clear error instead of hard-faulting when the block queue cannot be allocated
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration


### PR DESCRIPTION
# Add a read-only HTTP status API (GET /status) for network integrations

## What & why

This adds an opt-in, read-only HTTP endpoint to the WiFi module so anything on the local network can poll the machine's live state as JSON — without touching the Controller connection. The console port stays single-client for the one operator; observers (Home Assistant, dashboards, scripts) use HTTP.

```
$ curl http://<machine>:8080/status
{"name":"CARVERA_AIR_05214","model":"CA1","fw":"...","state":"Idle","alarm":false,
 "mpos":[...],"wpos":[...],"wcs":"G54","feed":{...},"spindle":{"rpm":0,"temp":29.3,...},
 "power_temp":29.9,"tool":{"number":1,...},"laser":{...},"job":{"playing":false},...}
```

Use case that drove it: Home Assistant integration (tool-change / job-done / alarm notifications, spindle temperature history). A ready-made HA integration ([MakerHA](https://github.com/BellionBastien/MakerHA)) and a dependency-free local HTML dashboard (kept out of this PR to stay minimal; available on the reference branch) consume it; plain `curl`/scripts work too. On Dev this also restores a simple machine-readable interface for scripting, now that the console defaults to the framed Makera protocol.

## Design

- **Off by default.** Enable with `config-set sd wifi.http_enable true` + reboot (`wifi.http_port`, default 8080). Disabled = zero behavior change, zero RAM cost.
- **Read-only, GET only** — `/status` (JSON), `/` (help), 404/405/400 otherwise. Nothing on the network can control the machine through it. (A `?token=` hook location is marked in the code if auth is ever wanted.)
- **Zero RAM cost.** Requests are matched incrementally as bytes arrive (~10 bytes of parser state, nothing buffered) and the response is built in place in the existing `WifiData` buffer. `WifiProvider` grows by 20 bytes versus baseline; `mem` shows identical heap/AHB numbers with the feature on and off (verified on hardware, see below).
- **Uses the module's spare TCP link 2** (console=0, UDP beacon=1), with `Config_Max_Clients(2)` and a 5 s idle auto-disconnect. Responses are addressed per-client (`Send_Data_to_TcpClient`), so concurrent pollers can't steal each other's replies.
- **Both console protocols served:** packet-wise dispatch on the legacy Smoothie path, and byte-wise parsing inside the framed Makera reader, so an HTTP poll arriving mid-frame can neither corrupt the frame nor starve. Responses are sent from `on_idle`, never from inside a receive loop, so serving one cannot delay a console frame.
- **Foreign-link byte guards on `_getc()`/`gets()`:** HTTP (and UDP) bytes can never leak into XMODEM or framed transfers. Without this, a status poll landing mid-download corrupts the handshake and its remnants get parsed as console commands (`error:Unsupported command - ...`) — this exact failure was hit by the community Controller during on-machine testing and is fixed here. The pre-existing UDP variant of the hole is closed by the same guards.

The branch contains a second, separable commit: **`Conveyor::start()` halts with a clear FATAL message when the block queue cannot allocate** instead of null-deref'ing into a watchdog reboot loop. It was discovered while sizing this feature's memory use (an earlier prototype allocated 1.6 KB from AHB at boot and chain-rebooted a Carvera Air whose pool had ~150 B of headroom on master). It's included because the discovery story belongs to this PR, but it's an independent commit that can be cherry-picked or dropped without affecting the feature. Happy to split it into its own PR if preferred.

## Testing done

All on a **Carvera Air (CA1)** — the numbers below are from the transcripts collected during testing.

**Master-based branch first** (reference: [`http-status-api`](https://github.com/BellionBastien/Carvera_Community_Firmware/tree/http-status-api)):
- AHB pool free identical (148 B) with feature on/off; main heap within noise
- 30-minute poll soak @2 s: 884 polls, **99.32 % success, median 19 ms, p95 36 ms**, longest failure streak = 1 — *through jogging, a real hard-limit alarm, a machine reboot, a full cutting job with two manual tool changes, and Controller sessions*
- XMODEM upload **and** download bit-identical (MD5) under active polling, before/after the `_getc` fix; the Controller's config-download flapping reproduced pre-fix and gone post-fix
- 3 soft reboots + 3 cold power cycles, clean boots, API up within seconds
- Full job lifecycle + 9 manual tool-change waits (`M6T0/T1/T7 H-100/T8 C0/T-1`) with correct target-tool reporting; a genuine HARD_LIMIT alarm captured with reason code
- `TEST_M118_PrintToConsole.cnc` output exactly as specified; beacon cadence unchanged at 1 Hz

**Review round (boot-memory budget + a crash it uncovered):**
- `build/check-ahb-budget.py` reproduced on each tree — `origin/Dev` 656 B free (PASS), `1f1d7a2` as first posted 376 B (FAIL), current head 632 B (PASS); also checked against a real machine's `config.txt`: 1528 B free
- **Flex compensation live on a Carvera Air**: 30-point profile with `flex_compensation_always_active true` boots clean, profile loads and interpolates, AHB free unchanged at 3136 B, `mem` reports 7940 B above the heap high-water mark (profile synthesised — see *Tests still needed*)
- **Crash fixed**: the status API formatted `sta_address` before the wifi module had filled it, over-reading an unterminated buffer — hard fault, watchdog, reboot loop under a 5 s poller. Buffers are initialised at construction and sanitised before formatting. Verified on hardware: API answers 4.9 s after reset inside the window that used to crash it, 284 responses / 0 invalid, `ip` reported as `""` until association completes
- 5-minute soak at 2 s on the fixed build: 147/148, 21 ms median

**This Dev-based branch, re-verified on hardware:**
- heap/AHB identical with feature on/off (3136 B AHB free both ways)
- HTTP battery: correct 200/404/405, malformed handled, 5.6 s idle disconnect, 20/20 poll burst, concurrent clients OK
- Framed (Makera-protocol) console commands answered correctly **while polling at 2 Hz** (26/27 concurrent polls OK) — exercises the new byte-wise accumulator
- XMODEM upload + download (smoothie path) under polling, byte-identical MD5 round-trip
- 8-minute soak on the Dev build: 233/233 polls, 100.00 % success, median 52 ms, zero failures
- Boot stability across multiple reboots

## Tests still needed

- Carvera **C1** owners: same feature, same WiFi hardware — confirmation welcome
- Flex compensation with a **real probed profile**: the live test below used a synthesised profile because I have no 3D touch probe and `G33` requires one. The load path and allocations are identical, but a flex-comp owner confirming the real-world case would be worth having.

## Known behaviors (documented, not bugs of this PR)

- During XMODEM/file transfers the WiFi receive path is dedicated to the transfer: HTTP requests go unanswered for the duration (seconds). Home Assistant shows sensors unavailable briefly; they recover on their own.
- The console port's module-level single-client enforcement is unchanged; the beacon busy flag is unchanged.
- Release binaries should be **clean builds**: `SimpleShell`'s `version` prints a compile-time `VERSION` macro per object file, so incremental builds can report different version strings from different subsystems (pre-existing; bit us during testing).

## Issues found in Dev while testing (filed separately, not addressed here)

1. `FileConfigSource::write()` in-place overwrite mangles the line on Dev (splits it, leaving an orphan fragment; subsequent writes then genuinely fail for space). Master's writer with the same algorithm behaves correctly — suspect the fwfs position accounting.
2. Console file operations (`ls`, `cat`, `config-get/set/delete`) driven as plain command lines over the **Makera protocol** return errors or nothing (`ls` → `Could not open directory` via LOAD_ERROR, `cat` silent); the same commands work over the Smoothie protocol (`M485.1`). Affects scripting/carvera-cli against Dev defaults.
3. `Configurator::config_set_command` reports every write failure as "not enough space to overwrite existing key/value", which misleads diagnosis.

## Credits

- **tcatm**'s 2024 webserver exploration on the `tcatmDev` branch pioneered the multi-link driver usage this builds on.
- The `_getc` transfer-corruption bug was found by a **Carvera Community Controller** session during testing — community tooling catching real bugs.

## Example: Home Assistant

Works out of the box with the `rest:` integration, or the dedicated [MakerHA](https://github.com/BellionBastien/MakerHA) integration (device auto-discovery via the existing UDP beacon, tool-change/job/alarm device triggers):

```yaml
rest:
  - resource: "http://<machine-ip>:8080/status"
    scan_interval: 15
    sensor:
      - name: "Carvera state"
        value_template: "{{ value_json.state }}"
    binary_sensor:
      - name: "Carvera alarm"
        value_template: "{{ value_json.alarm }}"
        device_class: problem
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

