### PR TITLE
Remove non-ascii chars from config.defaults

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -66,7 +66,7 @@ delta_step_pin								1.18			# Pin for delta stepper step signal
 delta_dir_pin								1.20!			# Pin for delta stepper direction
 delta_en_pin								3.26			# Pin for delta enable
 #delta_max_rate								10800.0			# mm/min transform from degree/min
-#delta_acceleration							360			    # degree/secÂ²
+#delta_acceleration							360			    # degree/sec^2
 delta_steps_per_mm							26.666667			# may be steps per degree for example (26.67)
 #delta_steps_per_mm							44.444444			# may be steps per degree for example (26.67)
 
@@ -75,7 +75,7 @@ epsilon_step_pin							1.21			# Pin for delta stepper step signal
 epsilon_dir_pin								1.23			# Pin for delta stepper direction
 epsilon_en_pin								1.30			# Pin for delta enable
 #epsilon_max_rate							100.0			# mm/min
-#epsilon_acceleration						10.0			# mm/secÂ²
+#epsilon_acceleration						10.0			# mm/sec^2
 epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for example (43200)
 
 # WIFI

--- a/src/config2.default
+++ b/src/config2.default
@@ -66,7 +66,7 @@ delta_step_pin								1.21			# Pin for delta stepper step signal
 delta_dir_pin								1.23!			# Pin for delta stepper direction
 delta_en_pin								1.30			# Pin for delta enable
 #delta_max_rate								10800.0			# mm/min transform from degree/min
-#delta_acceleration							360			    # degree/secÂ²
+#delta_acceleration							360			    # degree/sec^2
 #delta_steps_per_mm							26.666667		# may be steps per degree for example (26.67)
 delta_steps_per_mm							888.888889		# may be steps per degree for example (26.67)
 
@@ -75,7 +75,7 @@ epsilon_step_pin							1.22			# Pin for delta stepper step signal
 epsilon_dir_pin								1.0			# Pin for delta stepper direction
 epsilon_en_pin								1.10			# Pin for delta enable
 epsilon_max_rate							3600.0			# mm/min
-#epsilon_acceleration						360.0			# mm/secÂ²
+#epsilon_acceleration						360.0			# mm/sec^2
 epsilon_steps_per_mm						888.88888		# may be steps per degree for example (26.67)
 
 #communication protocol


### PR DESCRIPTION
The machine only supports ASCII, so on the Controller we have bare open() with no encoding specified. However these config.defaults have non-ascii chars in comments which fail to decode if the Controller is on Windows (due to defaulting to cp1252)