### PR TITLE
3dtoolsetter m3 m4 merge candidate

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -10,7 +10,7 @@
 ### Carvera settings which are fixed ###
 new_status_format							true
 
-wsd_ok										true
+sd_ok											true
 
 #dfu_enable									false
 #msd_disable								true			# Disable the MSD (USB SDCARD)
@@ -97,7 +97,7 @@ epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for exampl
 # atc.homing_rate_mm_s						0.4
 #atc.action_mm								2.0
 # atc.action_rate_mm_s						0.25
-#atc.3dtoolsetter						false			# opt-in: enable 3D toolsetter diameter touch-off script extensions
+# atc.3dtoolsetter						false			# opt-in: enable 3D toolsetter diameter touch-off script extensions
 
 # atc.detector.detect_pin						0.20^
 # atc.detector.detect_rate_mm_s				20				# Tool detect speed (mm / second)	
@@ -269,9 +269,9 @@ zprobe.debounce_ms							1				# Set if noisy
 # zprobe.calibrate_pin						0.5^			# calibrate_pin
 zprobe.probe_tip_diameter					1.6				#3 axis probe tip diamter
 # zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
-zprobe.3dtoolsetter                           false           # opt-in: for 3D probe tools, probe trigger alone completes tool calibration
+# zprobe.3dtoolsetter                           false           # opt-in: for 3D probe tools, probe trigger alone completes tool calibration
 # zprobe.three_axis_probe_tdo_correction        0.0             # additive correction (mm) applied to 3-axis diameter touch-off measurement
-zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
+# zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true

--- a/src/config.default
+++ b/src/config.default
@@ -10,7 +10,7 @@
 ### Carvera settings which are fixed ###
 new_status_format							true
 
-#sd_ok										false
+wsd_ok										true
 
 #dfu_enable									false
 #msd_disable								true			# Disable the MSD (USB SDCARD)
@@ -170,12 +170,11 @@ switch.probecharger.ignore_on_halt			true			# ignore on halt
 switch.probecharger.startup_state			true			# wireless probe startup state
 
 
-switch.extend.enable							true			# Enable this module
-# switch.extend.input_pin						0.21			# Pin this module controls
-switch.extend.output_pin						2.2			# Pin this module controls
-switch.extend.output_type					hwpwm			# Digital means this is just an on or off pin
-switch.extend.input_on_command				M851			# Command that will turn this switch on
-switch.extend.input_off_command				M852			# Command that will turn this switch off
+switch.extendout.enable						true			# Enable this module
+switch.extendout.output_pin					2.2				# Pin this module controls
+switch.extendout.output_type				swpwm			# Digital means this is just an on or off pin
+switch.extendout.input_on_command			M851			# Command that will turn this switch on
+switch.extendout.input_off_command			M852			# Command that will turn this switch off
 
 switch.air.enable							true			# Enable this module
 switch.air.output_pin						0.11				# Pin this module controls
@@ -366,7 +365,7 @@ spindle.alarm_pin							0.19^			# spindle alarm trigger pin
 user_setting_start true				# Indicate user settings start
 
 ## fixed Settings ##
-# sd_ok false								# Indicate SD card is corrected read
+sd_ok true								# Indicate SD card is corrected read
 
 ## Basic Settings ##
 # Vacuum

--- a/src/config.default
+++ b/src/config.default
@@ -97,6 +97,7 @@ epsilon_steps_per_mm						43200			# 1:27 rate may be steps per degree for exampl
 # atc.homing_rate_mm_s						0.4
 #atc.action_mm								2.0
 # atc.action_rate_mm_s						0.25
+#atc.3dtoolsetter						false			# opt-in: enable 3D toolsetter diameter touch-off script extensions
 
 # atc.detector.detect_pin						0.20^
 # atc.detector.detect_rate_mm_s				20				# Tool detect speed (mm / second)	
@@ -268,6 +269,7 @@ zprobe.debounce_ms							1				# Set if noisy
 # zprobe.calibrate_pin						0.5^			# calibrate_pin
 zprobe.probe_tip_diameter					1.6				#3 axis probe tip diamter
 # zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
+zprobe.3dtoolsetter                           false           # opt-in: for 3D probe tools, probe trigger alone completes tool calibration
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true
@@ -326,7 +328,8 @@ e_stop_pin									0.26!^			# Emergency stop pin
 # Spindle configuration
 #spindle.enable								true			# set this to false to disable the spindle module
 #spindle.type								pwm				# sets the spindle module to PWM mode
-# spindle_suspend_restore_enable              true            # On suspend: if spindle is running, stop it and remember RPM. On resume: restore only if it was running.
+spindle.3dtoolsetter					false			# opt-in: enable M4 handling and EXT direction mapping for 3D toolsetter workflow
+spindle_suspend_restore_enable              true            # On suspend: if spindle is running, stop it and remember RPM. On resume: restore only if it was running.
 spindle.pwm_pin								2.5				# Big Mosfet Q7. Pin must be hardware PWM capable.
 # spindle.pwm_period							1000			# default 1000, sets the PWM frequency
 spindle.feedback_pin						2.7				# Pin must be interrupt capable. 

--- a/src/config.default
+++ b/src/config.default
@@ -270,6 +270,8 @@ zprobe.debounce_ms							1				# Set if noisy
 zprobe.probe_tip_diameter					1.6				#3 axis probe tip diamter
 # zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
 zprobe.3dtoolsetter                           false           # opt-in: for 3D probe tools, probe trigger alone completes tool calibration
+# zprobe.three_axis_probe_tdo_correction        0.0             # additive correction (mm) applied to 3-axis diameter touch-off measurement
+zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true

--- a/src/config.default
+++ b/src/config.default
@@ -170,11 +170,12 @@ switch.probecharger.ignore_on_halt			true			# ignore on halt
 switch.probecharger.startup_state			true			# wireless probe startup state
 
 
-switch.extendout.enable						true			# Enable this module
-switch.extendout.output_pin					0.29			# Pin this module controls
-switch.extendout.output_type				swpwm			# Digital means this is just an on or off pin
-switch.extendout.input_on_command			M851			# Command that will turn this switch on
-switch.extendout.input_off_command			M852			# Command that will turn this switch off
+switch.extend.enable							true			# Enable this module
+# switch.extend.input_pin						0.21			# Pin this module controls
+switch.extend.output_pin						2.2			# Pin this module controls
+switch.extend.output_type					hwpwm			# Digital means this is just an on or off pin
+switch.extend.input_on_command				M851			# Command that will turn this switch on
+switch.extend.input_off_command				M852			# Command that will turn this switch off
 
 switch.air.enable							true			# Enable this module
 switch.air.output_pin						0.11				# Pin this module controls

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -862,11 +862,21 @@ void Kernel::check_eeprom_data()
 		this->eeprom_data->TOOLMZ = 0;
 		needrewtite = true;
 	}
-	if(isnan(this->eeprom_data->reserve))
+    if(isnan(this->eeprom_data->reserve))
+    {
+        this->eeprom_data->reserve = 0;
+        needrewtite = true;
+    }
+    if(isnan(this->eeprom_data->TOOL_DIA_WEAR))
 	{
-		this->eeprom_data->reserve = 0;
+        this->eeprom_data->TOOL_DIA_WEAR = 0;
 		needrewtite = true;
 	}
+    if(isnan(this->eeprom_data->TOOL_DIA))
+    {
+        this->eeprom_data->TOOL_DIA = 0;
+        needrewtite = true;
+    }
 	if(isnan(this->eeprom_data->TOOL))
 	{
 		this->eeprom_data->TOOL = 0;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -98,14 +98,20 @@ typedef struct {
 //	float G54[5*MAX_WCS];
 	float REFMZ;
 	float TOOLMZ;
-	float reserve;
+    float reserve;
+    // TEMPORARY: TOOL_DIA_WEAR is EEPROM-backed in this PR cycle and will be replaced by SD tool-table storage.
+    float TOOL_DIA_WEAR;
 	int TOOL;
     float perm_vars[20];
     bool tool_not_calibrated;
     int current_wcs;
     float WCScoord[6][4];
     float WCSrotation[6];
+    // TEMPORARY: TOOL_DIA is EEPROM-backed in this PR cycle and will be replaced by SD tool-table storage.
+    float TOOL_DIA;
 } EEPROM_data;
+
+static_assert(sizeof(EEPROM_data) <= 480, "EEPROM_data exceeds 480-byte EEPROM page budget");
 
 typedef struct {
 	char  MachineModel;

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -135,6 +135,7 @@ ATCHandler::ATCHandler()
     probe_oneoff_z = 0.0;
     probe_oneoff_configured = false;
 	enable_3dtoolsetter = false;
+	enable_zprobe_3dtoolsetter = false;
 	target_collet_type = UNDEFINED;
 	a_axis_cor.phase = 0;
 	a_axis_cor.pass = 0;
@@ -1409,7 +1410,7 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z, int repeat_count
 			snprintf(buff, sizeof(buff), "M493.1 R%d", i);
 			this->script_queue.push(buff);
 
-			if(this->enable_3dtoolsetter && !is_probe) {
+			if(this->enable_zprobe_3dtoolsetter && !is_probe) {
 				// Diameter touch-off sequence for non-probe tools uses reverse spindle direction.
 				snprintf(buff, sizeof(buff), "G91 G0 Z2");
 				this->script_queue.push(buff);
@@ -1424,8 +1425,6 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z, int repeat_count
 				snprintf(buff, sizeof(buff), "G91 G0 X-0.5");
 				this->script_queue.push(buff);
 				snprintf(buff, sizeof(buff), "M5");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "M491.4");
 				this->script_queue.push(buff);
 			}
 
@@ -1785,6 +1784,7 @@ void ATCHandler::on_config_reload(void *argument)
 	this->probe_retract_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, retract_mm_checksum)->as_number(2   );
 	this->probe_height_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, probe_height_mm_checksum)->as_number(0   );
 	this->enable_3dtoolsetter = THEKERNEL->config->value(atc_checksum, three_d_toolsetter_checksum)->as_bool(false);
+	this->enable_zprobe_3dtoolsetter = THEKERNEL->config->value(zprobe_checksum, three_d_toolsetter_checksum)->as_bool(false);
 	
 	this->anchor_width = THEKERNEL->config->value(coordinate_checksum, anchor_width_checksum)->as_number(15  );
 	this->anchor1_x = THEKERNEL->config->value(coordinate_checksum, anchor1_x_checksum)->as_number(-359  );
@@ -2755,7 +2755,7 @@ void ATCHandler::on_gcode_received(void *argument)
 					return;
 				}
 
-			} else {
+			} else if (gcode->subcode == 0) {
 				
 				// Handle one-off probe position offsets
 
@@ -2794,6 +2794,10 @@ void ATCHandler::on_gcode_received(void *argument)
 				bool tlo_calibrating = true;
 				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
 				this->fill_cali_scripts(active_tool == 0 || active_tool >= 999990 || active_tool == 9999, true, repeat_count);
+
+			} else {
+				THEKERNEL->streams->printf("ERROR: Unsupported M491.%d subcode\n", static_cast<int>(gcode->subcode));
+				return;
 
 			}
 		} else if (gcode->m == 492) {

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -97,6 +97,7 @@
 #define probe_mcs_z_checksum		CHECKSUM("probe_mcs_z")
 #define reference_tool_mz_checksum	CHECKSUM("reference_tool_mz")
 #define three_axis_probe_tlo_correction_checksum CHECKSUM("three_axis_probe_tlo_correction")
+#define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
 
 ATCHandler::ATCHandler()
 {
@@ -133,6 +134,7 @@ ATCHandler::ATCHandler()
     probe_oneoff_y = 0.0;
     probe_oneoff_z = 0.0;
     probe_oneoff_configured = false;
+	enable_3dtoolsetter = false;
 	target_collet_type = UNDEFINED;
 	a_axis_cor.phase = 0;
 	a_axis_cor.pass = 0;
@@ -1406,6 +1408,25 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z, int repeat_count
 			// save new tool offset
 			snprintf(buff, sizeof(buff), "M493.1 R%d", i);
 			this->script_queue.push(buff);
+
+			if(this->enable_3dtoolsetter && !is_probe) {
+				// Diameter touch-off sequence for non-probe tools uses reverse spindle direction.
+				snprintf(buff, sizeof(buff), "G91 G0 Z2");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "G91 G0 X-10.5");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "G91 G1 Z-3.5 F100");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "M4 S2000");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "G38.6 X3.5 F30");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "G91 G0 X-0.5");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "M5");
+				this->script_queue.push(buff);
+			}
+
 			// lift z to safe position with fast speed
 			snprintf(buff, sizeof(buff), "G53 G0 Z%.3f", THEROBOT->from_millimeters(this->clearance_z));
 			this->script_queue.push(buff);
@@ -1761,6 +1782,7 @@ void ATCHandler::on_config_reload(void *argument)
 	this->probe_slow_rate = THEKERNEL->config->value(atc_checksum, probe_checksum, slow_rate_mm_m_checksum)->as_number(60   );
 	this->probe_retract_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, retract_mm_checksum)->as_number(2   );
 	this->probe_height_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, probe_height_mm_checksum)->as_number(0   );
+	this->enable_3dtoolsetter = THEKERNEL->config->value(atc_checksum, three_d_toolsetter_checksum)->as_bool(false);
 	
 	this->anchor_width = THEKERNEL->config->value(coordinate_checksum, anchor_width_checksum)->as_number(15  );
 	this->anchor1_x = THEKERNEL->config->value(coordinate_checksum, anchor1_x_checksum)->as_number(-359  );

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -42,6 +42,21 @@
 #include <math.h>
 #include <vector>
 
+namespace {
+inline void send_internal_gcode(const char *cmd)
+{
+	string g(cmd);
+	Gcode gc(g, &(StreamOutput::NullStream));
+	THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
+}
+
+// Diameter touch-off geometry constants:
+// - Start offset: spindle center starts this far left of disk center.
+// - Contact radius: half of the calibrated contact disk diameter.
+constexpr float kToolDiaTouchoffStartOffsetMm = 10.5f;
+constexpr float kToolDiaTouchoffContactRadiusMm = 5.0f;
+}
+
 #define ATC_AXIS 4
 #define STEPPER THEROBOT->actuators
 // #define STEPS_PER_MM(a) (STEPPER[a]->get_steps_per_mm())
@@ -76,6 +91,7 @@
 #define probe_height_mm_checksum	CHECKSUM("probe_height_mm")
 
 #define coordinate_checksum			CHECKSUM("coordinate")
+#define spindle_checksum            CHECKSUM("spindle")
 #define anchor_width_checksum		CHECKSUM("anchor_width")
 #define anchor1_x_checksum			CHECKSUM("anchor1_x")
 #define anchor1_y_checksum			CHECKSUM("anchor1_y")
@@ -97,6 +113,7 @@
 #define probe_mcs_z_checksum		CHECKSUM("probe_mcs_z")
 #define reference_tool_mz_checksum	CHECKSUM("reference_tool_mz")
 #define three_axis_probe_tlo_correction_checksum CHECKSUM("three_axis_probe_tlo_correction")
+#define three_axis_probe_tdo_correction_checksum CHECKSUM("three_axis_probe_tdo_correction")
 #define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
 
 ATCHandler::ATCHandler()
@@ -108,6 +125,11 @@ ATCHandler::ATCHandler()
     ref_tool_mz = 0.0;
     cur_tool_mz = 0.0;
     tool_offset = 0.0;
+	tool_dia_probe_start_x = 0.0f;
+	tool_dia_probe_start_valid = false;
+	run_diameter_touchoff_after_tlo = false;
+	diameter_touchoff_use_wear_update = false;
+	spindle_3dtoolsetter_enabled = false;
     last_pos[0] = 0.0;
     last_pos[1] = 0.0;
     last_pos[2] = 0.0;
@@ -145,6 +167,81 @@ void ATCHandler::clear_script_queue(){
 	while (!this->script_queue.empty()) {
 		this->script_queue.pop();
 	}
+}
+
+void ATCHandler::queue_tool_dia_touchoff_sequence()
+{
+	char buff[100];
+	const float probe_x = kToolDiaTouchoffStartOffsetMm - kToolDiaTouchoffContactRadiusMm;
+
+	this->script_queue.push("G91 G0 Z2");
+	snprintf(buff, sizeof(buff), "G91 G0 X-%.3f", kToolDiaTouchoffStartOffsetMm);
+	this->script_queue.push(buff);
+	this->script_queue.push("G91 G1 Z-3.5 F100");
+	this->script_queue.push("M4 S2000");
+	snprintf(buff, sizeof(buff), "G38.6 X%.3f F30", probe_x);
+	this->script_queue.push(buff);
+	this->script_queue.push("G91 G0 X-0.5");
+	this->script_queue.push("M5");
+}
+
+void ATCHandler::capture_tool_dia_probe_start()
+{
+	float mpos[3] = {0};
+	THEROBOT->get_current_machine_position(mpos);
+	if (THEROBOT->compensationTransform) THEROBOT->compensationTransform(mpos, true, false);
+	this->tool_dia_probe_start_x = mpos[X_AXIS];
+	this->tool_dia_probe_start_valid = true;
+}
+
+bool ATCHandler::finalize_tool_dia_measurement(const char* source_tag)
+{
+	const char* src = (source_tag != nullptr) ? source_tag : "unknown";
+	if (!this->tool_dia_probe_start_valid) {
+		THEKERNEL->streams->printf("ERROR: Tool diameter start point not captured (%s)\n", src);
+		this->diameter_touchoff_use_wear_update = false;
+		return false;
+	}
+
+	float px, py, pz;
+	uint8_t ps;
+	std::tie(px, py, pz, ps) = THEROBOT->get_last_probe_position();
+	if (ps != 1) {
+		THEKERNEL->streams->printf("ERROR: Tool diameter probe failed (%s)\n", src);
+		this->tool_dia_probe_start_valid = false;
+		this->diameter_touchoff_use_wear_update = false;
+		return false;
+	}
+
+	const float travel = px - this->tool_dia_probe_start_x;
+	const float travel_mm = fabsf(THEROBOT->from_millimeters(travel));
+	const float measured_radius = kToolDiaTouchoffStartOffsetMm - kToolDiaTouchoffContactRadiusMm - travel_mm;
+	const float measured_diameter_raw = measured_radius * 2.0f;
+	const float measured_diameter = measured_diameter_raw + this->three_axis_probe_tdo_correction;
+	if (measured_diameter <= 0.0f) {
+		THEKERNEL->streams->printf("ERROR: Invalid measured tool diameter (%s)\n", src);
+		this->tool_dia_probe_start_valid = false;
+		this->diameter_touchoff_use_wear_update = false;
+		return false;
+	}
+
+	float nominal = THEKERNEL->eeprom_data->TOOL_DIA;
+	if (nominal <= 0.0f) nominal = measured_diameter;
+	const float wear = measured_diameter - nominal;
+
+	THEKERNEL->streams->printf("Measured tool diameter [%.3f] mm (raw %.3f mm, nominal %.3f mm, wear %.3f mm)\n", measured_diameter, measured_diameter_raw, nominal, wear);
+
+	if (this->diameter_touchoff_use_wear_update) {
+		char cmd[100];
+		snprintf(cmd, sizeof(cmd), "M493.3 W%.3f", wear);
+		send_internal_gcode(cmd);
+		THEKERNEL->streams->printf("M493.4\r\n");
+		send_internal_gcode("M493.4");
+	}
+
+	this->tool_dia_probe_start_valid = false;
+	this->diameter_touchoff_use_wear_update = false;
+	return true;
 }
 
 void ATCHandler::load_custom_tool_slots() {
@@ -1410,22 +1507,8 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z, int repeat_count
 			snprintf(buff, sizeof(buff), "M493.1 R%d", i);
 			this->script_queue.push(buff);
 
-			if(this->enable_zprobe_3dtoolsetter && !is_probe) {
-				// Diameter touch-off sequence for non-probe tools uses reverse spindle direction.
-				snprintf(buff, sizeof(buff), "G91 G0 Z2");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "G91 G0 X-10.5");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "G91 G1 Z-3.5 F100");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "M4 S2000");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "G38.6 X5.5 F30");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "G91 G0 X-0.5");
-				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "M5");
-				this->script_queue.push(buff);
+			if(this->enable_zprobe_3dtoolsetter && !is_probe && this->run_diameter_touchoff_after_tlo) {
+				this->queue_tool_dia_touchoff_sequence();
 			}
 
 			// lift z to safe position with fast speed
@@ -1785,6 +1868,7 @@ void ATCHandler::on_config_reload(void *argument)
 	this->probe_height_mm = THEKERNEL->config->value(atc_checksum, probe_checksum, probe_height_mm_checksum)->as_number(0   );
 	this->enable_3dtoolsetter = THEKERNEL->config->value(atc_checksum, three_d_toolsetter_checksum)->as_bool(false);
 	this->enable_zprobe_3dtoolsetter = THEKERNEL->config->value(zprobe_checksum, three_d_toolsetter_checksum)->as_bool(false);
+	this->spindle_3dtoolsetter_enabled = THEKERNEL->config->value(spindle_checksum, three_d_toolsetter_checksum)->as_bool(false);
 	
 	this->anchor_width = THEKERNEL->config->value(coordinate_checksum, anchor_width_checksum)->as_number(15  );
 	this->anchor1_x = THEKERNEL->config->value(coordinate_checksum, anchor1_x_checksum)->as_number(-359  );
@@ -1895,6 +1979,7 @@ void ATCHandler::on_config_reload(void *argument)
 
 	this->skip_path_origin = THEKERNEL->config->value(atc_checksum, skip_path_origin_checksum)->as_bool(false);
 	this->three_axis_probe_tlo_correction = THEKERNEL->config->value(zprobe_checksum, three_axis_probe_tlo_correction_checksum)->as_number(0.0f);
+	this->three_axis_probe_tdo_correction = THEKERNEL->config->value(zprobe_checksum, three_axis_probe_tdo_correction_checksum)->as_number(0.0f);
 	if(CARVERA == THEKERNEL->factory_set->MachineModel || CARVERA_AIR == THEKERNEL->factory_set->MachineModel){
 		this->ref_tool_mz = THEKERNEL->config->value(coordinate_checksum, reference_tool_mz_checksum)->as_number(-115.34f); // Represents the machine Z coordinate when the tool length is 0
 	}else{
@@ -1931,6 +2016,9 @@ void ATCHandler::abort(){
 		THEROBOT->set_tool_not_calibrated(true);
 	}
 	this->atc_status = NONE;
+	this->tool_dia_probe_start_valid = false;
+	this->run_diameter_touchoff_after_tlo = false;
+	this->diameter_touchoff_use_wear_update = false;
 	this->a_axis_cor.phase = 0;
 	this->a_axis_cor.pass = 0;
 	this->clear_script_queue();
@@ -2710,6 +2798,8 @@ void ATCHandler::on_gcode_received(void *argument)
 				// Set TLO calibration flag to disable 3D probe crash detection
 				bool tlo_calibrating = true;
 				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
+				this->run_diameter_touchoff_after_tlo = false;
+				this->diameter_touchoff_use_wear_update = false;
 				this->fill_cali_scripts(active_tool == 0 || active_tool >= 9 || active_tool == 9999, true);
 
 				THECONVEYOR->wait_for_idle();
@@ -2755,6 +2845,29 @@ void ATCHandler::on_gcode_received(void *argument)
 					return;
 				}
 
+			} else if (gcode->subcode == 3) {
+				if (!this->enable_3dtoolsetter || !this->spindle_3dtoolsetter_enabled) {
+					THEKERNEL->streams->printf("ERROR: M491.3 requires atc.3dtoolsetter and spindle.3dtoolsetter\n");
+					return;
+				}
+
+				uint8_t repeat_count = 1;
+				if (gcode->has_letter('R') && gcode->get_value('R') > 0) {
+					repeat_count = gcode->get_value('R');
+				}
+
+				THEROBOT->push_state();
+				THEROBOT->get_axis_position(last_pos, 3);
+				THEKERNEL->streams->printf("Saved XY position: X%.3f Y%.3f\n", last_pos[0], last_pos[1]);
+				set_inner_playing(true);
+				this->clear_script_queue();
+				atc_status = CALI;
+				bool tlo_calibrating = true;
+				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
+				this->run_diameter_touchoff_after_tlo = true;
+				this->diameter_touchoff_use_wear_update = true;
+				this->fill_cali_scripts(active_tool == 0 || active_tool >= 999990 || active_tool == 9999, true, repeat_count);
+
 			} else if (gcode->subcode == 0) {
 				
 				// Handle one-off probe position offsets
@@ -2793,6 +2906,8 @@ void ATCHandler::on_gcode_received(void *argument)
 				// Set TLO calibration flag to disable 3D probe crash detection
 				bool tlo_calibrating = true;
 				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
+				this->run_diameter_touchoff_after_tlo = false;
+				this->diameter_touchoff_use_wear_update = false;
 				this->fill_cali_scripts(active_tool == 0 || active_tool >= 999990 || active_tool == 9999, true, repeat_count);
 
 			} else {
@@ -2891,11 +3006,30 @@ void ATCHandler::on_gcode_received(void *argument)
 					this->set_tlo_by_offset(gcode->get_value('H'));
 					THEROBOT->set_tool_not_calibrated(false);
 				}
+				if (gcode->has_letter('D')) { //set stored nominal tool diameter
+					float diameter = gcode->get_value('D');
+					if (diameter > 0.0f) {
+						THEKERNEL->eeprom_data->TOOL_DIA = diameter;
+						THEKERNEL->write_eeprom_data();
+						THEKERNEL->streams->printf("Nominal tool diameter set to %.3fmm\n", diameter);
+					} else {
+						THEKERNEL->streams->printf("WARNING: Tool diameter not changed - value must be > 0 (got %.3f)\n", diameter);
+					}
+				}
+				if (gcode->has_letter('W')) { //set additive diameter wear
+					float wear = gcode->get_value('W');
+					THEKERNEL->eeprom_data->TOOL_DIA_WEAR = wear;
+					THEKERNEL->write_eeprom_data();
+					THEKERNEL->streams->printf("Tool diameter wear set to %.3fmm\n", wear);
+				}
 
 
 				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
 			} else if (gcode->subcode == 4) { //report current TLO
 				THEKERNEL->streams->printf("current tool offset [%.3f] , reference tool offset [%.3f]\n",cur_tool_mz,ref_tool_mz);
+				THEKERNEL->streams->printf("stored tool diameter [%.3f]\n", THEKERNEL->eeprom_data->TOOL_DIA);
+				THEKERNEL->streams->printf("stored tool diameter wear [%.3f]\n", THEKERNEL->eeprom_data->TOOL_DIA_WEAR);
+				THEKERNEL->streams->printf("3-axis TDO correction [%.3f]\n", this->three_axis_probe_tdo_correction);
 				if (this->probe_oneoff_configured) {
 					THEKERNEL->streams->printf("one-off tool setter position offsets: X[%.3f] Y[%.3f] Z[%.3f]\n", this->probe_oneoff_x, this->probe_oneoff_y, this->probe_oneoff_z);
 				} else {
@@ -3267,6 +3401,11 @@ void ATCHandler::on_gcode_received(void *argument)
 			this->save_custom_tool_slots_to_file();
 		}
 
+    } else if (gcode->has_g && gcode->g == 38 && gcode->subcode == 6) {
+		// Internal-only diameter touch-off capture for the queued G38.6 X probe.
+		if (this->atc_status == CALI && this->diameter_touchoff_use_wear_update && gcode->has_letter('X') && !this->tool_dia_probe_start_valid) {
+			this->capture_tool_dia_probe_start();
+		}
     } else if (gcode->has_g && gcode->g == 28 && gcode->subcode == 0) {
     	g28_triggered = true;
     }
@@ -3292,6 +3431,8 @@ void ATCHandler::on_main_loop(void *argument)
             	this->clear_script_queue();
 
 				this->atc_status = NONE;
+				this->run_diameter_touchoff_after_tlo = false;
+				this->diameter_touchoff_use_wear_update = false;
 				// Clear TLO calibration flag to re-enable 3D probe crash detection
 				bool tlo_calibrating = false;
 				PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );
@@ -3322,6 +3463,9 @@ void ATCHandler::on_main_loop(void *argument)
         }
 
 		if (this->atc_status != AUTOMATION) {
+			if (this->diameter_touchoff_use_wear_update) {
+				this->finalize_tool_dia_measurement("ATC diameter touch-off");
+			}
 	        // return to z clearance position
 	        rapid_move(true, NAN, NAN, this->clearance_z, NAN, NAN);
 			THEKERNEL->streams->printf("Return to XY position: X%.3f Y%.3f\n", last_pos[0], last_pos[1]);
@@ -3330,6 +3474,8 @@ void ATCHandler::on_main_loop(void *argument)
 		}
 
         this->atc_status = NONE;
+		this->run_diameter_touchoff_after_tlo = false;
+		this->diameter_touchoff_use_wear_update = false;
 		// Clear TLO calibration flag to re-enable 3D probe crash detection
 		bool tlo_calibrating = false;
 		PublicData::set_value( zprobe_checksum, set_tlo_calibrating_checksum, &tlo_calibrating );

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -1419,11 +1419,13 @@ void ATCHandler::fill_cali_scripts(bool is_probe, bool clear_z, int repeat_count
 				this->script_queue.push(buff);
 				snprintf(buff, sizeof(buff), "M4 S2000");
 				this->script_queue.push(buff);
-				snprintf(buff, sizeof(buff), "G38.6 X3.5 F30");
+				snprintf(buff, sizeof(buff), "G38.6 X5.5 F30");
 				this->script_queue.push(buff);
 				snprintf(buff, sizeof(buff), "G91 G0 X-0.5");
 				this->script_queue.push(buff);
 				snprintf(buff, sizeof(buff), "M5");
+				this->script_queue.push(buff);
+				snprintf(buff, sizeof(buff), "M491.4");
 				this->script_queue.push(buff);
 			}
 

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -3006,7 +3006,21 @@ void ATCHandler::on_gcode_received(void *argument)
 					this->set_tlo_by_offset(gcode->get_value('H'));
 					THEROBOT->set_tool_not_calibrated(false);
 				}
-				if (gcode->has_letter('D')) { //set stored nominal tool diameter
+				if (gcode->has_letter('D')) { //set stored tool diameter
+					// Immutability latch: diameter must not change while G41/G42 is modal
+					if (THEROBOT->is_compensation_active()) {
+						bool is_playing = false;
+						PublicData::get_value(player_checksum, is_playing_checksum, &is_playing);
+						if (is_playing) {
+							THEKERNEL->streams->printf("ALARM: Cannot change tool diameter while G41/G42 compensation is active\n");
+							THEKERNEL->call_event(ON_HALT, nullptr);
+							THEKERNEL->set_halt_reason(MANUAL);
+							return;
+						} else {
+							THEKERNEL->streams->printf("WARNING: Tool diameter not changed - G41/G42 compensation is active. Issue G40 first.\n");
+							return;
+						}
+					}
 					float diameter = gcode->get_value('D');
 					if (diameter > 0.0f) {
 						THEKERNEL->eeprom_data->TOOL_DIA = diameter;
@@ -3016,7 +3030,20 @@ void ATCHandler::on_gcode_received(void *argument)
 						THEKERNEL->streams->printf("WARNING: Tool diameter not changed - value must be > 0 (got %.3f)\n", diameter);
 					}
 				}
-				if (gcode->has_letter('W')) { //set additive diameter wear
+				if (gcode->has_letter('W')) { // set additive diameter wear
+					if (THEROBOT->is_compensation_active()) {
+						bool is_playing = false;
+						PublicData::get_value(player_checksum, is_playing_checksum, &is_playing);
+						if (is_playing) {
+							THEKERNEL->streams->printf("ALARM: Cannot change tool diameter wear while G41/G42 compensation is active\n");
+							THEKERNEL->call_event(ON_HALT, nullptr);
+							THEKERNEL->set_halt_reason(MANUAL);
+							return;
+						} else {
+							THEKERNEL->streams->printf("WARNING: Tool diameter wear not changed - G41/G42 compensation is active. Issue G40 first.\n");
+							return;
+						}
+					}
 					float wear = gcode->get_value('W');
 					THEKERNEL->eeprom_data->TOOL_DIA_WEAR = wear;
 					THEKERNEL->write_eeprom_data();

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -42,8 +42,7 @@
 #include <math.h>
 #include <vector>
 
-namespace {
-inline void send_internal_gcode(const char *cmd)
+static inline void send_internal_gcode(const char *cmd)
 {
 	string g(cmd);
 	Gcode gc(g, &(StreamOutput::NullStream));
@@ -55,7 +54,6 @@ inline void send_internal_gcode(const char *cmd)
 // - Contact radius: half of the calibrated contact disk diameter.
 constexpr float kToolDiaTouchoffStartOffsetMm = 10.5f;
 constexpr float kToolDiaTouchoffContactRadiusMm = 5.0f;
-}
 
 #define ATC_AXIS 4
 #define STEPPER THEROBOT->actuators
@@ -900,8 +898,6 @@ void ATCHandler::calibrate_a_axis_height(Gcode *gcode) //M469.5
 	this->script_queue.push(buff);
 }
 
-namespace {
-
 // M469.6 continuation phases (advanced by M469.7 P6 after each probe)
 enum CorPhase : uint8_t {
 	COR_IDLE = 0,
@@ -913,7 +909,7 @@ enum CorPhase : uint8_t {
 };
 
 // MCS positions matching gcode #5022 / #5023 / #5024
-void atc_get_mcs_yza(float &y, float &z, float &a)
+static void atc_get_mcs_yza(float &y, float &z, float &a)
 {
 	float mpos[3];
 	THEROBOT->get_current_machine_position(mpos);
@@ -923,7 +919,7 @@ void atc_get_mcs_yza(float &y, float &z, float &a)
 	a = THEROBOT->actuators[A_AXIS]->get_current_position();
 }
 
-float atc_get_mcs_axis(uint8_t axis)
+static float atc_get_mcs_axis(uint8_t axis)
 {
 
 	if (axis == A_AXIS) {
@@ -936,12 +932,10 @@ float atc_get_mcs_axis(uint8_t axis)
 	return mpos[axis];
 }
 
-const char* cor_probe_cmd(bool invert)
+static const char* cor_probe_cmd(bool invert)
 {
 	return invert ? "G38.4" : "G38.2";
 }
-
-} // namespace
 
 void ATCHandler::cor_queue_z_clearance()
 {
@@ -3008,7 +3002,7 @@ void ATCHandler::on_gcode_received(void *argument)
 				}
 				if (gcode->has_letter('D')) { //set stored tool diameter
 					// Immutability latch: diameter must not change while G41/G42 is modal
-					if (THEROBOT->is_compensation_active()) {
+					if (THEKERNEL->is_flex_compensation_active()) {
 						bool is_playing = false;
 						PublicData::get_value(player_checksum, is_playing_checksum, &is_playing);
 						if (is_playing) {
@@ -3031,7 +3025,7 @@ void ATCHandler::on_gcode_received(void *argument)
 					}
 				}
 				if (gcode->has_letter('W')) { // set additive diameter wear
-					if (THEROBOT->is_compensation_active()) {
+					if (THEKERNEL->is_flex_compensation_active()) {
 						bool is_playing = false;
 						PublicData::get_value(player_checksum, is_playing_checksum, &is_playing);
 						if (is_playing) {

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -112,6 +112,9 @@ private:
     void fill_zprobe_scripts(float x_pos, float y_pos, float x_offset, float y_offset);
     void fill_zprobe_abs_scripts();
     void fill_xyzprobe_scripts(float tool_dia, float probe_height);
+    void queue_tool_dia_touchoff_sequence();
+    void capture_tool_dia_probe_start();
+    bool finalize_tool_dia_measurement(const char* source_tag);
 
     //
     void set_tlo_by_offset(float z_axis_offset);
@@ -196,6 +199,7 @@ private:
     float probe_retract_mm;
     float probe_height_mm;
     float three_axis_probe_tlo_correction;
+    float three_axis_probe_tdo_correction;
 
     // Configurable probe position (absolute Machine Coordinate System)
     float probe_mcs_x;
@@ -327,6 +331,11 @@ private:
     float ref_tool_mz;
     float cur_tool_mz;
     float tool_offset;
+    float tool_dia_probe_start_x;
+    bool tool_dia_probe_start_valid;
+    bool run_diameter_touchoff_after_tlo;
+    bool diameter_touchoff_use_wear_update;
+    bool spindle_3dtoolsetter_enabled;
     const uint8_t max_tl_mcz_values = 5;
     deque<float> tl_mcz_values = deque<float>(max_tl_mcz_values, 0.0f);
     int beep_state;

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -150,6 +150,7 @@ private:
     bool atc_homing;
     bool detecting;
     bool disable_toolsensor;
+    bool enable_3dtoolsetter;
 
     bool playing_file;
     bool g28_triggered;

--- a/src/modules/tools/atc/ATCHandler.h
+++ b/src/modules/tools/atc/ATCHandler.h
@@ -151,6 +151,7 @@ private:
     bool detecting;
     bool disable_toolsensor;
     bool enable_3dtoolsetter;
+    bool enable_zprobe_3dtoolsetter;
 
     bool playing_file;
     bool g28_triggered;

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -38,6 +38,8 @@
 
 void AnalogSpindleControl::on_module_loaded()
 {
+    this->load_3dtoolsetter_config();
+
     spindle_on = false;
     target_rpm = 0;
     current_rpm = 0;

--- a/src/modules/tools/spindle/ModbusSpindleControl.cpp
+++ b/src/modules/tools/spindle/ModbusSpindleControl.cpp
@@ -23,6 +23,8 @@
 void ModbusSpindleControl::on_module_loaded()
 {
 
+    this->load_3dtoolsetter_config();
+
     spindle_on = false;
     PinName rx_pin;
     PinName tx_pin;

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -53,6 +53,8 @@ PWMSpindleControl::PWMSpindleControl()
 
 void PWMSpindleControl::on_module_loaded()
 {
+    this->load_3dtoolsetter_config();
+
     last_time = 0;
     last_edge = 0;
     current_rpm = 0;

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -53,6 +53,7 @@ PWMSpindleControl::PWMSpindleControl()
 
 void PWMSpindleControl::on_module_loaded()
 {
+    this->supports_3dtoolsetter_m4 = true;
     this->load_3dtoolsetter_config();
 
     last_time = 0;

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -72,15 +72,10 @@ void SpindleControl::on_gcode_received(void *argument)
                 return;
             }
 
-            // Only in 3dtoolsetter mode do we force EXT spindle direction.
-            // Hardware behavior verified on Carvera: HIGH=forward, LOW=reverse.
-            // M3 => HIGH/forward, M4 => LOW/reverse.
-            if (this->enable_3dtoolsetter) {
-                if (gcode->m == 3) {
-                    send_internal_command("M851 S100");
-                } else {
-                    send_internal_command("M852");
-                }
+            // In 3dtoolsetter mode, keep M3 unmodified and apply direction override only on M4.
+            // M5 clears this override back to default state.
+            if (this->enable_3dtoolsetter && gcode->m == 4) {
+                send_internal_command("M851 S100");
             }
 
         	if (!THEKERNEL->get_laser_mode()) {

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -10,15 +10,21 @@
 #include "Gcode.h"
 #include "Conveyor.h"
 #include "SpindleControl.h"
+#include "Config.h"
+#include "ConfigValue.h"
 #include "libs/StreamOutputPool.h"
 #include "libs/PublicData.h"
 #include "SwitchPublicAccess.h"
 #include "ATCHandlerPublicAccess.h"
 
+#define spindle_checksum CHECKSUM("spindle")
+#define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
+
 void SpindleControl::on_gcode_received(void *argument) 
 {
     
     Gcode *gcode = static_cast<Gcode *>(argument);
+    bool enable_3dtoolsetter = THEKERNEL->config->value(spindle_checksum, three_d_toolsetter_checksum)->as_bool(false);
         
     if (gcode->has_m)
     {
@@ -41,7 +47,7 @@ void SpindleControl::on_gcode_received(void *argument)
             report_settings();
           
         }
-        else if (gcode->m == 3)
+        else if (gcode->m == 3 || (enable_3dtoolsetter && gcode->m == 4))
         {
         	if(THEKERNEL->is_halted()) return; // if in halted state ignore any commands
         	if (!THEKERNEL->get_laser_mode()) {
@@ -61,12 +67,12 @@ void SpindleControl::on_gcode_received(void *argument)
 
                 THECONVEYOR->wait_for_idle();
 
-                // M3 with S value provided: set speed
+                // M3/M4 with S value provided: set speed
                 if (gcode->has_letter('S'))
                 {
                     set_speed(gcode->get_value('S'));
                 }
-                // M3: Spindle on
+                // M3/M4: Spindle on
                 if (!spindle_on) {
                     turn_on();
                 }
@@ -79,16 +85,20 @@ void SpindleControl::on_gcode_received(void *argument)
         		bool b = true;
         		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
         	}
-            // open extout if set
+            // Set extout behavior.
+            // Default behavior keeps extout on for M3 only.
+            // 3dtoolsetter mode maps M3/M4 to opposite EXT direction states.
         	if (THEKERNEL->get_extout_mode()) {
-        		// open extout
-        		bool b = true;
+                bool b = true;
         		struct pad_switch pad;
 			    bool ok = false;
+                if (enable_3dtoolsetter) {
+                    b = (gcode->m == 3);
+                }
             	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-			    ok = PublicData::get_value(switch_checksum, vacuum_checksum, 0, &pad);
-			    if (ok) {
-			    	pad.state = true;
+                ok = PublicData::get_value(switch_checksum, enable_3dtoolsetter ? extendout_checksum : vacuum_checksum, 0, &pad);
+                if (ok) {
+                    	pad.state = enable_3dtoolsetter ? b : true;
 			    	pad.value = pad.defaultvalue;
 			    	PublicData::set_value( switch_checksum, extendout_checksum, state_value_checksum, &pad );
 			    }

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -20,11 +20,24 @@
 #define spindle_checksum CHECKSUM("spindle")
 #define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
 
+namespace {
+void send_internal_command(const char *cmd)
+{
+    string g(cmd);
+    Gcode gc(g, &(StreamOutput::NullStream));
+    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
+}
+}
+
+void SpindleControl::load_3dtoolsetter_config()
+{
+    this->enable_3dtoolsetter = THEKERNEL->config->value(spindle_checksum, three_d_toolsetter_checksum)->as_bool(false);
+}
+
 void SpindleControl::on_gcode_received(void *argument) 
 {
     
     Gcode *gcode = static_cast<Gcode *>(argument);
-    bool enable_3dtoolsetter = THEKERNEL->config->value(spindle_checksum, three_d_toolsetter_checksum)->as_bool(false);
         
     if (gcode->has_m)
     {
@@ -47,9 +60,29 @@ void SpindleControl::on_gcode_received(void *argument)
             report_settings();
           
         }
-        else if (gcode->m == 3 || (enable_3dtoolsetter && gcode->m == 4))
+        else if (gcode->m == 4 && !this->enable_3dtoolsetter)
         {
-        	if(THEKERNEL->is_halted()) return; // if in halted state ignore any commands
+            THEKERNEL->streams->printf("ERROR: M4 is disabled unless spindle.3dtoolsetter is true\n");
+            return;
+        }
+        else if (gcode->m == 3 || gcode->m == 4)
+        {
+            if(THEKERNEL->is_halted()) {
+                THEKERNEL->streams->printf("ERROR: Cannot start spindle while machine is halted\n");
+                return;
+            }
+
+            // Only in 3dtoolsetter mode do we force EXT spindle direction.
+            // Hardware behavior verified on Carvera: HIGH=forward, LOW=reverse.
+            // M3 => HIGH/forward, M4 => LOW/reverse.
+            if (this->enable_3dtoolsetter) {
+                if (gcode->m == 3) {
+                    send_internal_command("M851 S100");
+                } else {
+                    send_internal_command("M852");
+                }
+            }
+
         	if (!THEKERNEL->get_laser_mode()) {
                 // current tool number and tool offset
                 struct tool_status tool;
@@ -85,24 +118,6 @@ void SpindleControl::on_gcode_received(void *argument)
         		bool b = true;
         		PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
         	}
-            // Set extout behavior.
-            // Default behavior keeps extout on for M3 only.
-            // 3dtoolsetter mode maps M3/M4 to opposite EXT direction states.
-        	if (THEKERNEL->get_extout_mode()) {
-                bool b = true;
-        		struct pad_switch pad;
-			    bool ok = false;
-                if (enable_3dtoolsetter) {
-                    b = (gcode->m == 3);
-                }
-            	PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-                ok = PublicData::get_value(switch_checksum, enable_3dtoolsetter ? extendout_checksum : vacuum_checksum, 0, &pad);
-                if (ok) {
-                    	pad.state = enable_3dtoolsetter ? b : true;
-			    	pad.value = pad.defaultvalue;
-			    	PublicData::set_value( switch_checksum, extendout_checksum, state_value_checksum, &pad );
-			    }
-        	}
         }
         else if (gcode->m == 5)
         {
@@ -121,11 +136,9 @@ void SpindleControl::on_gcode_received(void *argument)
                 PublicData::set_value( switch_checksum, vacuum_checksum, state_checksum, &b );
         	}
             // close extout if set
-        	if (THEKERNEL->get_extout_mode()) {
-        		// close extout
-        		bool b = false;
-                PublicData::set_value( switch_checksum, extendout_checksum, state_checksum, &b );
-        	}
+            if (this->enable_3dtoolsetter) {
+                send_internal_command("M852");
+            }
         }
         else if (gcode->m == 223)
         {	// M222 - rpm override percentage

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -20,13 +20,11 @@
 #define spindle_checksum CHECKSUM("spindle")
 #define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
 
-namespace {
-void send_internal_command(const char *cmd)
+static void send_internal_command(const char *cmd)
 {
     string g(cmd);
     Gcode gc(g, &(StreamOutput::NullStream));
     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
-}
 }
 
 void SpindleControl::load_3dtoolsetter_config()
@@ -60,7 +58,7 @@ void SpindleControl::on_gcode_received(void *argument)
             report_settings();
           
         }
-        else if (gcode->m == 4 && !this->enable_3dtoolsetter)
+        else if (gcode->m == 4 && this->supports_3dtoolsetter_m4 && !this->enable_3dtoolsetter)
         {
             THEKERNEL->streams->printf("ERROR: M4 is disabled unless spindle.3dtoolsetter is true\n");
             return;
@@ -74,7 +72,7 @@ void SpindleControl::on_gcode_received(void *argument)
 
             // In 3dtoolsetter mode, keep M3 unmodified and apply direction override only on M4.
             // M5 clears this override back to default state.
-            if (this->enable_3dtoolsetter && gcode->m == 4) {
+            if (this->supports_3dtoolsetter_m4 && this->enable_3dtoolsetter && gcode->m == 4) {
                 send_internal_command("M851 S100");
             }
 

--- a/src/modules/tools/spindle/SpindleControl.h
+++ b/src/modules/tools/spindle/SpindleControl.h
@@ -18,6 +18,8 @@ class SpindleControl: public Module {
 
     protected:
         bool spindle_on;
+        bool enable_3dtoolsetter{false};
+        void load_3dtoolsetter_config();
 
     private:
         void on_gcode_received(void *argument);

--- a/src/modules/tools/spindle/SpindleControl.h
+++ b/src/modules/tools/spindle/SpindleControl.h
@@ -18,6 +18,7 @@ class SpindleControl: public Module {
 
     protected:
         bool spindle_on;
+        bool supports_3dtoolsetter_m4{false};
         bool enable_3dtoolsetter{false};
         void load_3dtoolsetter_config();
 

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -186,7 +186,8 @@ void Switch::on_config_reload(void *argument)
             Pin *pin= new Pin();
             pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->as_string("nc"))->as_output();
             if(pin->connected()) {
-                this->swpwm_pin= new SoftPWM(pin, !pin->is_inverting());
+                // Pin::set already applies '!' inversion, so keep SWPWM polarity fixed here.
+                this->swpwm_pin= new SoftPWM(pin, true);
                 if(failsafe == 1) {
                     set_high_on_debug(pin->port_number, pin->pin);
                 }else{

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -49,6 +49,7 @@
 #define probe_height_checksum    CHECKSUM("probe_height")
 #define probe_tip_diameter_checksum CHECKSUM("probe_tip_diameter")
 #define probe_calibration_safety_margin_checksum CHECKSUM("calibration_safety_margin")
+#define three_d_toolsetter_checksum CHECKSUM("3dtoolsetter")
 #define toolZeroIs3Axis_checksum  CHECKSUM("tool_zero_is_3axis")
 #define gamma_max_checksum       CHECKSUM("gamma_max")
 #define max_z_checksum           CHECKSUM("max_z")
@@ -184,6 +185,7 @@ void ZProbe::config_load()
     this->max_z         = THEKERNEL->config->value(zprobe_checksum, max_z_checksum)->as_number(NAN); // maximum zprobe distance
     THEKERNEL->probe_tip_diameter = THEKERNEL->config->value(zprobe_checksum, probe_tip_diameter_checksum)->as_number(2); // probe tip diameter
     this->tool_0_3axis  = THEKERNEL->config->value(zprobe_checksum, toolZeroIs3Axis_checksum)->as_bool(false);
+    this->enable_3dtoolsetter = THEKERNEL->config->value(zprobe_checksum, three_d_toolsetter_checksum)->as_bool(false);
     if(isnan(this->max_z)){
         this->max_z = THEKERNEL->config->value(gamma_max_checksum)->as_number(200); // maximum zprobe distance
     }
@@ -315,6 +317,14 @@ uint32_t ZProbe::read_probe(uint32_t dummy)
             if (!probe_detected) {
                 probe_detected = true;
                 probe_pin_position = STEPPER[Z_AXIS]->get_current_position();
+                // In 3dtoolsetter mode, for 3D probe tools, probe trigger alone completes calibration.
+                if (calibrating && this->enable_3dtoolsetter && check_probe_tool() == 2) {
+                    calibrate_detected = true;
+                    calibrate_pin_position = probe_pin_position;
+                    for (auto &a : THEROBOT->actuators) a->stop_moving();
+                    debounce = 0;
+                    cali_debounce = 0;
+                }
             // if we are calibrating, the stop to the actuators comes from the read_calibrate method
             } else if (!calibrating) {
                 // we signal the motors to stop, which will preempt any moves on that axis
@@ -335,8 +345,8 @@ uint32_t ZProbe::read_calibrate(uint32_t dummy)
 {
     if (!calibrating) return 0;
 
-    // just check z Axis move
-    if (STEPPER[Z_AXIS]->is_moving()) {
+    // check all axes in case calibration movement includes X/Y components
+    if (STEPPER[X_AXIS]->is_moving() || STEPPER[Y_AXIS]->is_moving() || STEPPER[Z_AXIS]->is_moving()) {
         // if it is moving then we check the probe, and debounce it
         if (this->calibrate_pin.get()) {
             if (cali_debounce < debounce_ms) {
@@ -931,13 +941,24 @@ void ZProbe::on_set_public_data(void* argument) {
 // just probe / calibrate Z using calibrate pin
 void ZProbe::calibrate_Z(Gcode *gcode)
 {
-    float z= 0;
+    float x = 0;
+    float y = 0;
+    float z = 0;
+
+    if(gcode->has_letter('X')) {
+        x= gcode->get_value('X');
+    }
+
+    if(gcode->has_letter('Y')) {
+        y= gcode->get_value('Y');
+    }
+
     if(gcode->has_letter('Z')) {
         z= gcode->get_value('Z');
     }
 
-    if(z == 0) {
-        gcode->stream->printf("error: Z must be specified, and be > or < 0\n");
+    if(x == 0 && y == 0 && z == 0) {
+        gcode->stream->printf("error: at least one of X, Y, or Z must be specified, and be > or < 0\n");
         return;
     }
 
@@ -967,10 +988,10 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     }
 
     // do a delta move which will stop as soon as the probe is triggered, or the distance is reached
-    float delta[3]= {0, 0, z};
+    float delta[3]= {x, y, z};
     THEKERNEL->set_zprobing(true);
     if(!THEROBOT->delta_move(delta, rate, 3)) {
-        gcode->stream->printf("ERROR: Probing move too small,  %1.3f\n", z);
+        gcode->stream->printf("ERROR: Probing move too small, X: %1.3f, Y: %1.3f, Z: %1.3f\n", x, y, z);
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         calibrating = false;
@@ -1018,7 +1039,8 @@ void ZProbe::calibrate_Z(Gcode *gcode)
                              calibrate_pin_position);
     }
     
-    uint8_t calibrateok = calibrate_detected ? 1 : 0;
+    bool probe_only_calibration = this->enable_3dtoolsetter && (check_probe_tool() == 2);
+    uint8_t calibrateok = (calibrate_detected || (probe_only_calibration && probe_detected)) ? 1 : 0;
 
     // print results using the GRBL format
     gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -101,6 +101,7 @@ void ZProbe::on_module_loaded()
     // we read the probe in this timer
     probing = false;
     calibrating = false;
+    probe_only_calibration_active = false;
     tlo_calibrating = false;
     THEKERNEL->slow_ticker->attach(1000, this, &ZProbe::read_probe);
     THEKERNEL->slow_ticker->attach(1000, this, &ZProbe::read_calibrate);
@@ -318,9 +319,7 @@ uint32_t ZProbe::read_probe(uint32_t dummy)
                 probe_detected = true;
                 probe_pin_position = STEPPER[Z_AXIS]->get_current_position();
                 // In 3dtoolsetter mode, for 3D probe tools, probe trigger alone completes calibration.
-                if (calibrating && this->enable_3dtoolsetter && check_probe_tool() == 2) {
-                    calibrate_detected = true;
-                    calibrate_pin_position = probe_pin_position;
+                if (this->probe_only_calibration_active) {
                     for (auto &a : THEROBOT->actuators) a->stop_moving();
                     debounce = 0;
                     cali_debounce = 0;
@@ -344,6 +343,9 @@ uint32_t ZProbe::read_probe(uint32_t dummy)
 uint32_t ZProbe::read_calibrate(uint32_t dummy)
 {
     if (!calibrating) return 0;
+
+    // In 3dtoolsetter probe-only calibration mode, G38.6 success/fail is based solely on probe pin transitions.
+    if (this->probe_only_calibration_active) return 0;
 
     // check all axes in case calibration movement includes X/Y components
     if (STEPPER[X_AXIS]->is_moving() || STEPPER[Y_AXIS]->is_moving() || STEPPER[Z_AXIS]->is_moving()) {
@@ -807,6 +809,7 @@ void ZProbe::on_gcode_received(void *argument)
 
 void ZProbe::reset_probe_tracking() {
     safety_margin_exceeded = false;
+    probe_only_calibration_active = false;
     calibrate_pin_position = 0.0F;
     probe_pin_position = 0.0F;
     calibrate_current_z = 0.0F;
@@ -958,7 +961,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
     }
 
     if(x == 0 && y == 0 && z == 0) {
-        gcode->stream->printf("error: at least one of X, Y, or Z must be specified, and be > or < 0\n");
+        gcode->stream->printf("error: at least one of X, Y, or Z must be non-zero\n");
         return;
     }
 
@@ -982,6 +985,9 @@ void ZProbe::calibrate_Z(Gcode *gcode)
 
     reset_probe_tracking();
 
+    bool probe_only_calibration = this->enable_3dtoolsetter && (check_probe_tool() == 2);
+    this->probe_only_calibration_active = probe_only_calibration;
+
     // If calibration is happening with a probe tool, enable tracking of probe position in the read_probe ISR.
     if (check_probe_tool() > 0) {
         probing = true;
@@ -995,6 +1001,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
         THEKERNEL->set_halt_reason(PROBE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
         calibrating = false;
+        this->probe_only_calibration_active = false;
         THEKERNEL->set_zprobing(false);
         return;
     }
@@ -1028,6 +1035,7 @@ void ZProbe::calibrate_Z(Gcode *gcode)
         gcode->stream->printf("debounce: %d, cali_debounce: %d, debounce_ms: %d\n", debounce, cali_debounce, debounce_ms);
         gcode->stream->printf("ERROR: Probe failed to trigger within safety margin (%.2fmm). See MDI\n", this->probe_calibration_safety_margin);
         THEKERNEL->call_event(ON_HALT, nullptr);
+        this->probe_only_calibration_active = false;
         return;
     }
 
@@ -1039,7 +1047,6 @@ void ZProbe::calibrate_Z(Gcode *gcode)
                              calibrate_pin_position);
     }
     
-    bool probe_only_calibration = this->enable_3dtoolsetter && (check_probe_tool() == 2);
     uint8_t calibrateok = (calibrate_detected || (probe_only_calibration && probe_detected)) ? 1 : 0;
 
     // print results using the GRBL format
@@ -1052,10 +1059,16 @@ void ZProbe::calibrate_Z(Gcode *gcode)
 
     if (calibrateok == 0) {
         // issue error if probe was not triggered and subcode is 2 or 4
-        gcode->stream->printf("ERROR: Calibrate fail!\n");
+        if (probe_only_calibration) {
+            gcode->stream->printf("ERROR: Probe-only calibration failed: probe pin did not trigger\n");
+        } else {
+            gcode->stream->printf("ERROR: Calibrate fail!\n");
+        }
         THEKERNEL->set_halt_reason(CALIBRATE_FAIL);
         THEKERNEL->call_event(ON_HALT, nullptr);
     }
+
+    this->probe_only_calibration_active = false;
 
     if (probe_detected) {
     	this->probe_trigger_time = us_ticker_read();

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -163,6 +163,7 @@ private:
     bool tool_0_3axis;
     float dwell_before_probing;
     bool is_3dprobe_active;
+    bool enable_3dtoolsetter;
 
     Gcode* gcodeBuffer;
     char buff[100];

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -163,7 +163,7 @@ private:
     bool tool_0_3axis;
     float dwell_before_probing;
     bool is_3dprobe_active;
-    bool enable_3dtoolsetter;
+    bool enable_3dtoolsetter{false};
 
     Gcode* gcodeBuffer;
     char buff[100];
@@ -184,6 +184,7 @@ private:
     volatile bool tlo_calibrating;
     volatile bool probe_detected;
     volatile bool calibrate_detected;
+    volatile bool probe_only_calibration_active;
     volatile bool probe_triggered;
     volatile bool halt_pending;
 


### PR DESCRIPTION
# 3D Tool setter mod and M3/M4 spindle control (D word forwarding pending tool table decision making)

https://www.youtube.com/watch?v=FAFIXv_KpY4

This PR accompanies a mod for the C1 which adds an additional v6 probe to the bed of the machine.  With the proper accessories and software configurations this v6 probe acts as a 3d tool sensor which will measure the diameter of your tools as an extension of the M491 command.  This PR builds on the work proposed in PR303 but does had a stacked relationship where the measured data from the sensor affects the W and D params of the active tool directly.  Please note that this is ONLY affects the active tool and if cutter comp is used the user must incorporate M491.3 into Gcode or plan to measure diameter of the the active to prior to operations specifically using that tool for compensation.  

The physical mod requires that the EXT port on the controller be electrically coupled to the C1's stock BLD 300 spindle controller on its FWD / REV control input.  Keep in mind that this electrical coupling will invert the functional direction of the spindle and will require the following edits to the config.txt in order to invert the pin with the "!" character. 
- switch.extendout.output_type	swpwm
- switch.extendout.output_pin	2.2!

## What this PR changes
- M4 additive-only in 3dtoolsetter mode by applying the direction override command but requires spindle.3dtoolsetter=true
- Fixes SWPWM inversion so pin modifier `!` works as expected on switch outputs (could have been its own PR but what the heck).
- Extends M491 calibration routine when atc.3dtoolsetter=true and zprobe.3dtoolsetter=true, adding M491.3 for dedicated diameter measurement.
- Extends G38.6 to include X and Y axis
- Config gated change to calibrate 3d probe based on probe signal only (spring force of 3d tool sensor is much more than 3d probe and does not have a hard bottom out like the stock TLO).  Still requires an offset.  
- zprobe.calibration_safety_margin              0.1  
- zprobe.3dtoolsetter                                   true

## Scope
- `src/modules/tools/spindle/SpindleControl.cpp`
- `src/modules/tools/switch/Switch.cpp`
- `src/modules/tools/atc/ATCHandler.cpp`
- `src/modules/tools/atc/ATCHandler.h`
- `src/config.txt`

## Testing
- Built and flashed local firmware build to C1 machine.
- Verified `M851 S100` and `M852` behavior on `switch.extendout.output_pin 2.2` and `2.2!` via multimeter.
- Verified M3 uses default direction path; M4 applies override path and visually tested via CLI on machine.
- Verified `M491` nominal and extended functionality on machine and lots of tool change situations including switching from 3d probe to different tools.  Testing coverage is not 100% for every case yet but working up to it. 

## Backward compatibility
- New behavior is gated behind existing 3dtoolsetter config flags and nominal / default behavior is expected.  Because this feature requires a high level of reliability it should be introduced after exhaustive testing and safety review by developers and beta testers.
- No change to non-3dtoolsetter spindle flows. M3 behavior is unmodified when not in 3dtoolsetter mode. 