### PR TITLE
Run CI on release branch PRs and cascade release merges forward

### DIFF
--- a/.github/scripts/check-version-txt.sh
+++ b/.github/scripts/check-version-txt.sh
@@ -4,27 +4,40 @@ set -euo pipefail
 # Simple check to make sure version.txt has some kind of edit history for the
 # current PR, but only if files in the src/ directory have changed.
 
-# Extract the PR base branch name from the event payload
+# Extract the PR base branch and repository from the event payload
 BASE_REF=$(jq -r .pull_request.base.ref < "$GITHUB_EVENT_PATH")
+BASE_REPO=$(jq -r .pull_request.base.repo.clone_url < "$GITHUB_EVENT_PATH")
 
-if [[ -z "$BASE_REF" ]]; then
+if [[ -z "$BASE_REF" || "$BASE_REF" == "null" ]]; then
   echo "Could not determine base ref from GITHUB_EVENT_PATH. Skipping check."
-  exit 0 
+  exit 0
 fi
 
-DIFF_RANGE="origin/$BASE_REF...HEAD"
+# The workflow checks out the PR head repository, so on a fork the base branch
+# is usually absent from origin/. Fetch it from the base repository directly.
+# Without this the diff below fails, the error is swallowed by the "no src
+# changes" branch, and the check passes without having checked anything.
+if ! git fetch --no-tags --quiet "$BASE_REPO" \
+    "+refs/heads/$BASE_REF:refs/remotes/base/$BASE_REF"; then
+  echo "❌ Could not fetch base branch $BASE_REF"
+  echo ""
+  echo "The version.txt check needs the base branch to diff against, and"
+  echo "fetching it from $BASE_REPO failed."
+  exit 1
+fi
 
-# First check if any files in src/ directory have changed
-if ! git diff --name-only "$DIFF_RANGE" | grep -q "^src/"; then
+# Three-dot diff to see changes on HEAD since diverging from the base branch
+DIFF_RANGE="refs/remotes/base/$BASE_REF...HEAD"
+CHANGED=$(git diff --name-only "$DIFF_RANGE")
+
+if ! grep -q "^src/" <<< "$CHANGED"; then
   echo "ℹ️  No files changed in src/ directory. Skipping version.txt check."
   exit 0
 fi
 
 echo "ℹ️  Files changed in src/ directory. Checking version.txt update..."
 
-# List changed files compared to the base branch
-# Use three-dot diff to see changes on HEAD since diverging from origin/$BASE_REF
-if git diff --name-only "$DIFF_RANGE" | grep -qx version.txt; then
+if grep -qx version.txt <<< "$CHANGED"; then
   # PASS: version.txt was updated
   echo "✅ version.txt was updated in this PR."
   echo "(Checked diff range: $DIFF_RANGE)"

--- a/.github/workflows/cascading-merge.yml
+++ b/.github/workflows/cascading-merge.yml
@@ -1,0 +1,38 @@
+# .github/workflows/cascading-merge.yml
+name: Cascading Branch Merge
+
+# When a PR merges into a release branch, forward that change into every later
+# release branch in semantic version order, and finally into Dev. Without this,
+# a fix landed on an older release has to be cherry-picked by hand and is easy
+# to lose on the next release.
+#
+# Release branches must be named release/<semver> for the ordering to work,
+# for example release/2.2.0-rc.2 then release/2.2.0 then release/2.3.0.
+# See DEVELOPER.md.
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  merge:
+    name: Cascading Auto Merge
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.base_ref, 'release/')
+
+    steps:
+      - name: Automatic Merge
+        uses: ActionsDesk/cascading-downstream-merge@v3.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prefixes: release/
+          ref_branch: Dev

--- a/.github/workflows/cascading-merge.yml
+++ b/.github/workflows/cascading-merge.yml
@@ -7,7 +7,7 @@ name: Cascading Branch Merge
 # to lose on the next release.
 #
 # Release branches must be named release/<semver> for the ordering to work,
-# for example release/2.2.0-rc.2 then release/2.2.0 then release/2.3.0.
+# for example release/2.1.x then release/2.2.x then release/2.3.x.
 # See DEVELOPER.md.
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: ['v*']
     branches: ['Dev']
   pull_request:
-    branches: ['master', 'Dev']
+    branches: ['master', 'Dev', 'release-*', 'release/*']
   workflow_dispatch:
 env:
   GCC_VERSION: 14.2
@@ -19,6 +19,8 @@ jobs:
       pull-requests: read
       contents: read
     if: github.event_name == 'pull_request'
+    outputs:
+      build: ${{ steps.build-changes.outputs.build }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: ['v*']
     branches: ['Dev']
   pull_request:
-    branches: ['master', 'Dev', 'release-*', 'release/*']
+    branches: ['master', 'Dev', 'release/*']
   workflow_dispatch:
 env:
   GCC_VERSION: 14.2

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -609,8 +609,6 @@ this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
 Release branches are named `release/<semver>`:
 
 ```
-release/2.2.0-rc.1
-release/2.2.0-rc.2
 release/2.2.0
 release/2.3.0
 ```
@@ -621,19 +619,3 @@ change into every later release branch and finally into `Dev`, ordering the
 branches by parsing the part after `release/` as a semantic version. A branch
 whose name does not parse is skipped, so a fix landed on it would quietly fail
 to reach later releases.
-
-That means the prerelease suffix has to be lowercase and dot-separated
-(`-rc.2`, not `-RC2`), and the version needs three numeric components with no
-extra letters (`2.1.0`, not `2.1.0c`).
-
-Two repository settings are required for the cascade to work, both under
-repository or organisation administration:
-
-* **Allow GitHub Actions to create and approve pull requests** must be enabled,
-  since the cascade opens the follow-on PRs.
-* **Automatically delete head branches** must be disabled, because the cascade
-  needs the merged branch to survive long enough to merge onward.
-
-Rename an existing release branch through the GitHub web interface rather than
-by pushing a new name and deleting the old one. The web interface retargets any
-open pull requests; a delete-and-recreate closes them.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -606,16 +606,18 @@ this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
 
 # Release branches
 
-Release branches are named `release/<semver>`:
+Release branches are named `release/<major>.<minor>.x` and stay open for the
+whole minor line, so 2.2.0, 2.2.1, … all land on the same branch:
 
 ```
-release/2.2.0
-release/2.3.0
+release/2.2.x
+release/2.3.x
 ```
+
+Cut the actual firmware versions with tags (`v2.2.0`, `v2.2.1`, …) from that
+branch.
 
 The naming is not cosmetic. When a PR merges into a release branch,
 [`cascading-merge.yml`](./.github/workflows/cascading-merge.yml) forwards that
-change into every later release branch and finally into `Dev`, ordering the
-branches by parsing the part after `release/` as a semantic version. A branch
-whose name does not parse is skipped, so a fix landed on it would quietly fail
-to reach later releases.
+change into every later release branch and finally into `Dev`. Ordering is
+token-based (not strict semver): `release/2.2.x` sorts before `release/2.3.x`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,6 +17,7 @@
 * [Static analysis](#static-analysis)
   * [Requirements](#requirements)
   * [Running analysis](#running-analysis)
+* [Release branches](#release-branches)
 
 See also [TODO](./TODO.md) for some ideas on things to work on :)
 
@@ -602,3 +603,37 @@ So to read a bool config value you would use:
 this->config->value( disable_leds_checksum )->as_bool(false);
 instead of
 this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
+
+# Release branches
+
+Release branches are named `release/<semver>`:
+
+```
+release/2.2.0-rc.1
+release/2.2.0-rc.2
+release/2.2.0
+release/2.3.0
+```
+
+The naming is not cosmetic. When a PR merges into a release branch,
+[`cascading-merge.yml`](./.github/workflows/cascading-merge.yml) forwards that
+change into every later release branch and finally into `Dev`, ordering the
+branches by parsing the part after `release/` as a semantic version. A branch
+whose name does not parse is skipped, so a fix landed on it would quietly fail
+to reach later releases.
+
+That means the prerelease suffix has to be lowercase and dot-separated
+(`-rc.2`, not `-RC2`), and the version needs three numeric components with no
+extra letters (`2.1.0`, not `2.1.0c`).
+
+Two repository settings are required for the cascade to work, both under
+repository or organisation administration:
+
+* **Allow GitHub Actions to create and approve pull requests** must be enabled,
+  since the cascade opens the follow-on PRs.
+* **Automatically delete head branches** must be disabled, because the cascade
+  needs the merged branch to survive long enough to merge onward.
+
+Rename an existing release branch through the GitHub web interface rather than
+by pushing a new name and deleting the old one. The web interface retargets any
+open pull requests; a delete-and-recreate closes them.


### PR DESCRIPTION
This adds CI functionality to cascading merges of changes based on semver.

This enables us to work on multiple releases concurrently. Changes in lower numbered released cascade down to higher (eg change in `release/2.2.x` will be made into `release/2.3.x` but not vise versa). The `Dev` branch will always have the very latest code.