### PR TITLE
Prevent Makera serial commands from being discarded

### DIFF
--- a/src/libs/MakeraControl.h
+++ b/src/libs/MakeraControl.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace makera {
 
@@ -25,6 +27,19 @@ constexpr ControlAction decode_control(uint8_t control) {
     default:
       return ControlAction::none;
   }
+}
+
+inline bool is_deferred_command(const char* command, std::size_t length) {
+  if (command == nullptr) return false;
+  const auto starts_with_token = [command, length](const char* token, std::size_t token_length, bool subcodes = false) {
+    if (length < token_length || std::memcmp(command, token, token_length) != 0) return false;
+    if (length == token_length) return true;
+    const char next = command[token_length];
+    return next == ' ' || next == '\t' || next == '\r' || next == '\n' || (subcodes && next == '.');
+  };
+
+  return starts_with_token("suspend", 7) || starts_with_token("abort", 5) || starts_with_token("resume", 6) ||
+         starts_with_token("M600", 4, true) || starts_with_token("M601", 4, true) || starts_with_token("goto", 4);
 }
 
 ControlAction handle_control(uint8_t control);

--- a/src/libs/MakeraFrame.h
+++ b/src/libs/MakeraFrame.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 
 #include "CRC16.h"
 
@@ -30,8 +29,6 @@ struct Packet {
 };
 
 enum class DecodeResult : uint8_t { incomplete, complete, invalid_length, invalid_crc, invalid_footer };
-enum class QueueResult : uint8_t { accepted, empty, too_large, full };
-
 class FrameDecoder {
  public:
   explicit FrameDecoder(Packet& packet) : packet_(packet) {}
@@ -59,44 +56,6 @@ class FrameDecoder {
   bool header_prefix_ = false;
   bool have_last_byte_ = false;
   Packet& packet_;
-};
-
-template <std::size_t Depth, std::size_t MaxSize>
-class CommandQueue {
- public:
-  static_assert(Depth > 1, "A command queue needs at least two slots");
-
-  QueueResult push(const char* data, std::size_t size) {
-    if (data == nullptr || size == 0) return QueueResult::empty;
-    if (size > MaxSize) return QueueResult::too_large;
-    if (full()) return QueueResult::full;
-    std::memcpy(data_[tail_], data, size);
-    sizes_[tail_] = static_cast<uint16_t>(size);
-    tail_ = next(tail_);
-    return QueueResult::accepted;
-  }
-
-  const char* front(std::size_t& size) const {
-    if (empty()) return nullptr;
-    size = sizes_[head_];
-    return data_[head_];
-  }
-
-  void pop() {
-    if (!empty()) head_ = next(head_);
-  }
-
-  void clear() { head_ = tail_ = 0; }
-  bool empty() const { return head_ == tail_; }
-  bool full() const { return next(tail_) == head_; }
-
- private:
-  static uint8_t next(uint8_t index) { return static_cast<uint8_t>((index + 1) % Depth); }
-
-  char data_[Depth][MaxSize];
-  uint16_t sizes_[Depth];
-  volatile uint8_t head_ = 0;
-  volatile uint8_t tail_ = 0;
 };
 
 }  // namespace makera

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -33,10 +33,11 @@ using std::string;
 
 extern unsigned char xbuff[XBUFF_LENGTH];
 
-// The frame buffer and command queue stay in main RAM (SerialConsole itself is AHB-allocated).
-enum { MAKERA_CMD_QUEUE_DEPTH = 4, MAKERA_CMD_MAX_LEN = 256 };
+// SerialConsole is AHB-allocated, so keep the larger Makera receive buffer in main RAM.
 static makera::Packet makera_packet;
-static makera::CommandQueue<MAKERA_CMD_QUEUE_DEPTH, MAKERA_CMD_MAX_LEN> makera_commands;
+static RingBuffer<char, 1024> makera_rx_bytes;
+// Let a back-to-back burst finish before command handlers reply on the same UART.
+constexpr uint32_t makera_rx_quiet_ms = 2;
 
 // Serial reading module
 // Treats every received line as a command and passes it ( via event call ) to the command dispatcher.
@@ -50,9 +51,11 @@ SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate )
     this->default_baud_rate = baud_rate;
     this->temp_baud_rate = 0;
     this->last_activity_ms = 0;
-    this->makera_error = makera::QueueResult::accepted;
+    this->makera_rx_overflow = false;
+    this->processing_makera_input = false;
     this->makera_frame_decoder.reset();
-    makera_commands.clear();
+    this->deferred_makera_command.clear();
+    makera_rx_bytes.tail = makera_rx_bytes.head;
     this->reset_file_parser();
 }
 
@@ -124,9 +127,12 @@ void SerialConsole::on_serial_char_received() {
 		}
 
         if (communication_protocol == PROTOCOL_MAKERA) {
-            // Keep RX IRQ enabled and queue completed commands. Disabling IRQ while a
-            // command is pending drops back-to-back host traffic (e.g. buffer then play).
-            process_makera_byte(static_cast<uint8_t>(received));
+            const int next = makera_rx_bytes.next_block_index(makera_rx_bytes.head);
+            if (next == makera_rx_bytes.tail) {
+                makera_rx_overflow = true;
+            } else {
+                makera_rx_bytes.push_back(received);
+            }
             continue;
         }
 		
@@ -187,8 +193,20 @@ void SerialConsole::on_idle(void * argument)
 {
 	if (THEKERNEL->is_uploading()) return;
 
+    const uint32_t now_ms = us_ticker_read() / 1000;
+    if (communication_protocol == PROTOCOL_MAKERA && !processing_makera_input &&
+        now_ms - last_activity_ms >= makera_rx_quiet_ms) {
+        processing_makera_input = true;
+        while (deferred_makera_command.empty() && makera_rx_bytes.tail != makera_rx_bytes.head) {
+            char received;
+            makera_rx_bytes.pop_front(received);
+            process_makera_byte(static_cast<uint8_t>(received));
+            if (THEKERNEL->is_uploading()) break;
+        }
+        processing_makera_input = false;
+    }
+
     if (temp_baud_rate != 0) {
-        uint32_t now_ms = us_ticker_read() / 1000;
         if ((now_ms - last_activity_ms) >= 15000) {
             this->serial->baud(default_baud_rate);
             this->current_baud_rate = default_baud_rate;
@@ -196,12 +214,9 @@ void SerialConsole::on_idle(void * argument)
         }
     }
 
-    if (makera_error != makera::QueueResult::accepted) {
-        const char *message = makera_error == makera::QueueResult::too_large
-            ? "ERROR: command discarded, longer than the 256 byte limit\r\n"
-            : "ERROR: command discarded, command queue full\r\n";
-        makera_error = makera::QueueResult::accepted;
-        PacketMessage(PTYPE_NORMAL_INFO, message, 0);
+    if (makera_rx_overflow) {
+        makera_rx_overflow = false;
+        PacketMessage(PTYPE_NORMAL_INFO, "ERROR: serial receive buffer full\r\n", 0);
     }
 
     if (makera_file_cancel) {
@@ -246,16 +261,15 @@ void SerialConsole::on_idle(void * argument)
 // Actual event calling must happen in the main loop because if it happens in the interrupt we will loose data
 void SerialConsole::on_main_loop(void * argument){
     if (communication_protocol == PROTOCOL_MAKERA) {
-        size_t payload_length = 0;
-        const char *payload = makera_commands.front(payload_length);
-        if (payload != nullptr) {
+        if (!deferred_makera_command.empty()) {
             struct SerialMessage message;
-            message.message.assign(payload, payload_length);
+            message.message.swap(deferred_makera_command);
             message.stream = this;
             message.line = 0;
 
-            makera_commands.pop();
+            processing_makera_input = true;
             THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+            processing_makera_input = false;
         }
         return;
     }
@@ -293,8 +307,15 @@ int SerialConsole::puts(const char* s, int size)
 int SerialConsole::gets(char** buf, int size)
 {
 	if (communication_protocol == PROTOCOL_MAKERA) {
-        while (this->serial->readable()) {
-            uint8_t received = static_cast<uint8_t>(this->serial->getc());
+        while (makera_rx_bytes.tail != makera_rx_bytes.head || this->serial->readable()) {
+            uint8_t received;
+            if (makera_rx_bytes.tail != makera_rx_bytes.head) {
+                char buffered;
+                makera_rx_bytes.pop_front(buffered);
+                received = static_cast<uint8_t>(buffered);
+            } else {
+                received = static_cast<uint8_t>(this->serial->getc());
+            }
             uint16_t checksum;
 
             switch (file_parse_state) {
@@ -365,17 +386,23 @@ void SerialConsole::process_makera_byte(uint8_t received)
         return;
     }
 
+    if (packet.type == PTYPE_CTRL_MULTI && makera::is_deferred_command(
+            reinterpret_cast<const char *>(packet.data), packet.data_length)) {
+        deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+        return;
+    }
+
     if (packet.type == PTYPE_CTRL_MULTI || packet.type == PTYPE_FILE_START) {
-        const makera::QueueResult queued = makera_commands.push(
-            reinterpret_cast<const char *>(packet.data), packet.data_length);
-        if (queued == makera::QueueResult::empty) {
+        if (packet.data_length == 0) {
             if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
             return;
         }
-        if (queued != makera::QueueResult::accepted) {
-            makera_error = queued;
-            if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
-        }
+
+        struct SerialMessage message;
+        message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+        message.stream = this;
+        message.line = 0;
+        THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
     }
 }
 
@@ -427,8 +454,10 @@ void SerialConsole::on_protocol_changed()
     halt_flag = false;
     diagnose_flag = false;
     makera_file_cancel = false;
-    makera_error = makera::QueueResult::accepted;
-    makera_commands.clear();
+    makera_rx_overflow = false;
+    processing_makera_input = false;
+    deferred_makera_command.clear();
+    makera_rx_bytes.tail = makera_rx_bytes.head;
     makera_frame_decoder.reset();
     reset_file_parser();
 }
@@ -445,7 +474,8 @@ int SerialConsole::_getc()
 
 bool SerialConsole::ready()
 {
-    return this->serial->readable();
+	return (communication_protocol == PROTOCOL_MAKERA && makera_rx_bytes.tail != makera_rx_bytes.head) ||
+           this->serial->readable();
 }
 
 // Does the queue have a given char ?

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -57,7 +57,8 @@ class SerialConsole : public Module, public StreamOutput {
         int temp_baud_rate;                       // non-zero = temporary baud active
         uint32_t last_activity_ms;                // for 15s timeout revert
         makera::FrameDecoder makera_frame_decoder;
-        volatile makera::QueueResult makera_error;
+        std::string deferred_makera_command;
+        bool processing_makera_input;
 
         enum FileParseState {
             FILE_WAIT_HEADER,
@@ -79,6 +80,7 @@ class SerialConsole : public Module, public StreamOutput {
           volatile bool diagnose_flag:1;
         };
         volatile bool makera_file_cancel;
+        volatile bool makera_rx_overflow;
 };
 
 #endif

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -66,9 +66,8 @@
 #define XBUFF_LENGTH	8208
 extern unsigned char xbuff[XBUFF_LENGTH];
 extern unsigned char fbuff[4096];
-enum { MAKERA_CMD_QUEUE_DEPTH = 3, MAKERA_CMD_MAX_LEN = 510, MAKERA_MAX_RECEIVE_CALLS = 10 };
+enum { MAKERA_MAX_RECEIVE_CALLS = 10 };
 static makera::Packet makera_packet LOCATED_IN_AHBSRAM;
-static makera::CommandQueue<MAKERA_CMD_QUEUE_DEPTH, MAKERA_CMD_MAX_LEN> makera_commands LOCATED_IN_AHBSRAM;
 
 
 
@@ -79,12 +78,11 @@ WifiProvider::WifiProvider()
 	udp_link_no = 1;
 	wifi_init_ok = false;
 	has_data_flag = false;
-	makera_file_pending = false;
 	makera_file_cancel = false;
+	processing_makera_input = false;
+	deferred_makera_command.clear();
 	makera_remote_port = 0;
 	makera_remote_known = false;
-	makera_error = makera::QueueResult::accepted;
-	makera_commands.clear();
 	connection_fail_count = 0;
 	sta_down_seconds = 0;
 	last_sta_connection_status = 0xff;
@@ -262,9 +260,11 @@ void WifiProvider::receive_wifi_data() {
 	int frames = 0;
 	int receive_calls = 0;
 	uint16_t header_errors = 0;
-	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS && !makera_file_pending) {
-		if (!makera_frame_decoder.has_header() && makera_commands.full()) return;
-
+	// The M8266 receive side buffers six TCP segments (8,760 bytes, measured on
+	// hardware) and closes its advertised window when they fill. Leave unread
+	// commands there and let TCP apply backpressure instead of duplicating that
+	// buffer in the LPC's limited RAM.
+	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS && deferred_makera_command.empty()) {
 		uint16_t wanted = static_cast<uint16_t>(makera_frame_decoder.bytes_wanted());
 		if (wanted > WIFI_DATA_MAX_SIZE) wanted = WIFI_DATA_MAX_SIZE;
 		if (frames > 0 && !makera_frame_decoder.has_header() && !M8266WIFI_SPI_Has_DataReceived()) return;
@@ -322,18 +322,24 @@ void WifiProvider::receive_wifi_data() {
 
 			if (packet.type != PTYPE_CTRL_MULTI && packet.type != PTYPE_FILE_START) continue;
 
-			const makera::QueueResult queued = makera_commands.push(
-				reinterpret_cast<const char *>(packet.data), packet.data_length);
-			if (queued == makera::QueueResult::accepted) {
-				if (packet.type == PTYPE_FILE_START) makera_file_pending = true;
-			} else if (queued == makera::QueueResult::empty) {
+			if (packet.data_length == 0) {
 				if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
-			} else {
-				makera_error = queued;
-				if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
+				continue;
 			}
 
-			if (makera_file_pending) return;
+			if (packet.type == PTYPE_CTRL_MULTI && makera::is_deferred_command(
+					reinterpret_cast<const char *>(packet.data), packet.data_length)) {
+				deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+				return;
+			}
+
+			struct SerialMessage message;
+			message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+			message.stream = this;
+			message.line = 0;
+
+			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+			if (packet.type == PTYPE_FILE_START) return;
 		}
 	}
 
@@ -539,17 +545,12 @@ void WifiProvider::on_idle(void *argument)
 	if (THEKERNEL->is_uploading()) return;
 
 	// FILE_START leaves the following file data for Player::gets().
-	if (!makera_file_pending && (has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
+	if (!processing_makera_input && deferred_makera_command.empty() &&
+			(has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
 		has_data_flag = false;
+		processing_makera_input = true;
 		receive_wifi_data();
-	}
-
-	if (makera_error != makera::QueueResult::accepted) {
-		const char *message = makera_error == makera::QueueResult::too_large
-			? "ERROR: command discarded, longer than the 510 byte limit\r\n"
-			: "ERROR: command discarded, command queue full\r\n";
-		makera_error = makera::QueueResult::accepted;
-		PacketMessage(PTYPE_NORMAL_INFO, message, 0);
+		processing_makera_input = false;
 	}
 
 	if (makera_file_cancel) {
@@ -593,17 +594,15 @@ void WifiProvider::on_idle(void *argument)
 void WifiProvider::on_main_loop(void *argument)
 {
 	if (communication_protocol == PROTOCOL_MAKERA) {
-		size_t payload_length = 0;
-		const char *payload = makera_commands.front(payload_length);
-		if (payload != nullptr) {
+		if (!deferred_makera_command.empty()) {
 			struct SerialMessage message;
-			message.message.assign(payload, payload_length);
+			message.message.swap(deferred_makera_command);
 			message.stream = this;
 			message.line = 0;
 
-			makera_commands.pop();
+			processing_makera_input = true;
 			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
-			if (makera_file_pending && makera_commands.empty()) makera_file_pending = false;
+			processing_makera_input = false;
 		}
 		return;
 	}
@@ -634,11 +633,10 @@ void WifiProvider::on_protocol_changed()
 	query_flag = false;
 	halt_flag = false;
 	diagnose_flag = false;
-	makera_file_pending = false;
 	makera_file_cancel = false;
+	processing_makera_input = false;
+	deferred_makera_command.clear();
 	makera_remote_known = false;
-	makera_error = makera::QueueResult::accepted;
-	makera_commands.clear();
 	makera_frame_decoder.reset();
 	reset();
 }

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -9,8 +9,8 @@
 #define WIFIPROVIDER_H_
 
 using namespace std;
+#include <string>
 #include <vector>
-#include <queue>
 
 #include "Pin.h"
 #include "Module.h"
@@ -113,11 +113,11 @@ private:
     	volatile bool has_data_flag:1;
     	bool makera_remote_known:1;
     };
-    bool makera_file_pending;
     bool makera_file_cancel;
+    bool processing_makera_input;
+    std::string deferred_makera_command;
     u16 makera_remote_port;
     makera::FrameDecoder makera_frame_decoder;
-    makera::QueueResult makera_error;
     ParseState currentState = WAIT_HEADER;    
     int ptrData;
     int ptr_xbuff;

--- a/tests/TEST_MakeraFrameParser/test_makera_frame_parser.cpp
+++ b/tests/TEST_MakeraFrameParser/test_makera_frame_parser.cpp
@@ -67,13 +67,6 @@ struct Decoder {
   makera::FrameDecoder* operator->() { return &frame; }
 };
 
-template <typename Queue>
-std::string queue_front(const Queue& queue) {
-  std::size_t size = 0;
-  const char* data = queue.front(size);
-  return data == nullptr ? std::string() : std::string(data, size);
-}
-
 }  // namespace
 
 int main() {
@@ -261,40 +254,6 @@ int main() {
     CHECK(makera::decode_control('!') == makera::ControlAction::feed_hold);
     CHECK(makera::decode_control('~') == makera::ControlAction::feed_resume);
     CHECK(makera::decode_control('x') == makera::ControlAction::none);
-  }
-
-  {
-    TEST("the command queue preserves order and capacity");
-    makera::CommandQueue<4, 256> queue;
-    CHECK(queue.empty());
-    CHECK(queue.push("first", 5) == makera::QueueResult::accepted);
-    CHECK(queue.push("second", 6) == makera::QueueResult::accepted);
-    CHECK(queue.push("third", 5) == makera::QueueResult::accepted);
-    CHECK(queue.full());
-    CHECK(queue.push("overflow", 8) == makera::QueueResult::full);
-    CHECK(queue_front(queue) == "first");
-    queue.pop();
-    CHECK(queue_front(queue) == "second");
-    queue.pop();
-    CHECK(queue_front(queue) == "third");
-    queue.pop();
-    CHECK(queue.empty());
-    CHECK(queue.push("fourth", 6) == makera::QueueResult::accepted);
-    CHECK(queue.push("fifth", 5) == makera::QueueResult::accepted);
-    CHECK(queue_front(queue) == "fourth");
-    queue.pop();
-    CHECK(queue_front(queue) == "fifth");
-  }
-
-  {
-    TEST("the command queue rejects oversized data");
-    makera::CommandQueue<4, 4> queue;
-    CHECK(queue.push("four", 4) == makera::QueueResult::accepted);
-    CHECK(queue.push("large", 5) == makera::QueueResult::too_large);
-    CHECK(queue.push("", 0) == makera::QueueResult::empty);
-    CHECK(queue_front(queue) == "four");
-    queue.clear();
-    CHECK(queue.empty());
   }
 
   std::printf("\n%d checks, %d failures\n", checks, failures);


### PR DESCRIPTION
# Summary

Back-to-back Makera protocol commands could fill the small command queues used by the UART and Wi-Fi paths before the main loop processed them. The firmware then reported:

    ERROR: command discarded, command queue full

This could discard ordinary commands as well as important controls such as pause and abort.

For UART, this change keeps incoming Makera protocol bytes in a 1 KiB receive buffer and decodes them from the main context. For Wi-Fi, ordinary commands are dispatched while reading from the ESP8266 instead of being copied into another queue on the LPC. Commands that may wait for motion—pause, abort, resume, `goto`, `M600`, and `M601`—remain deferred to the main loop so nested idle processing cannot execute later commands out of order.

The ESP8266 receive side has a measured TCP window of 8,760 bytes, or six TCP segments. When the LPC stops reading, TCP backpressure leaves further commands at the sender until space is available. The firmware therefore does not need to duplicate that buffer in the LPC's limited RAM.

File transfers consume bytes already present in the receive buffer before reading more from the UART. If the byte buffer itself fills, the firmware reports a serial receive buffer error instead of silently overwriting data.

The Smoothie serial protocol and configuration are unchanged. Makera commands may wait for a 2 ms receive quiet period before processing.

Validation:

- `./build/build.sh --clean` completed successfully.
- Host protocol checks passed: 63 checks, 0 failures.
- A Carvera controller board processed bursts of 8, 20, and 50 back-to-back commands without losing responses or reporting queue errors.
- A command handler that performs nested idle processing preserved response order.
- The change was included in a Z1 build and confirmed working on a physical machine, including pause and abort.
- On a Carvera controller board over Wi-Fi, fragmented and maximum-size commands, malformed-frame recovery, 256 back-to-back commands, a deferred command followed by 32 ordinary commands, and a small SD-card upload completed successfully.
- With the LPC halted over SWD, the ESP8266 accepted 8,760 bytes before applying TCP backpressure. After the LPC resumed, the buffered stream and a trailing command were delivered successfully in three repeated tests.

Codex assisted with implementation, testing, and code review.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
