### PR TITLE
Prevent long G-code lines from stalling playback

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -1052,8 +1052,16 @@ void Player::on_main_loop(void *argument)
 
             } else {
                 // discard long line
-                if (this->current_stream != nullptr) { this->current_stream->printf("Warning: Discarded long line\n"); }
+                if (!discard && this->current_stream != nullptr) {
+                    this->current_stream->printf("Warning: Discarded long line\n");
+                }
                 discard = true;
+
+                uint32_t now_us = us_ticker_read();
+                if ((now_us - last_idle_us) >= 200000) {
+                    THEKERNEL->call_event(ON_IDLE);
+                    last_idle_us = now_us;
+                }
             }
         }
 


### PR DESCRIPTION
# Summary

During verbose file playback, the player emitted `Warning: Discarded long line` for every 129-byte fragment of an overlong line.

Makera Studio appends thumbnails as a single base64 comment, which can be tens of kilobytes long. A 57.8 KiB thumbnail produced roughly 448 synchronous Wi-Fi messages. Under TCP backpressure, this could keep the main loop from servicing `ON_IDLE` long enough to trigger the watchdog.

This change:

- Reports the warning once per discarded physical line.
- Services `ON_IDLE` periodically while consuming the remainder of the line.

Long lines remain discarded as before.

## Validation

- `./build/build.sh --clean` passes.
- Flashed the fix on a Carvera (C1) controller board.
- Uploaded and played a test G-code file containing a 57,845-character thumbnail comment through the normal controller/XMODEM path.
- Withheld TCP reads for 15 seconds to force backpressure.
- Repeated the test three times; each run emitted one warning and remained responsive afterward.
- Verified normally drained discard completes in approximately 177 ms.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, and testing.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)