### PR TITLE
Keep Makera controls responsive during continuous jog

### DIFF
--- a/src/libs/MakeraControl.h
+++ b/src/libs/MakeraControl.h
@@ -29,6 +29,13 @@ constexpr ControlAction decode_control(uint8_t control) {
   }
 }
 
+inline bool is_jog_command(const char* command, std::size_t length) {
+  if (command == nullptr || length < 2 || std::memcmp(command, "$J", 2) != 0) return false;
+  if (length == 2) return true;
+  const char next = command[2];
+  return next == ' ' || next == '\t' || next == '\r' || next == '\n';
+}
+
 inline bool is_deferred_command(const char* command, std::size_t length) {
   if (command == nullptr) return false;
   const auto starts_with_token = [command, length](const char* token, std::size_t token_length, bool subcodes = false) {
@@ -39,7 +46,8 @@ inline bool is_deferred_command(const char* command, std::size_t length) {
   };
 
   return starts_with_token("suspend", 7) || starts_with_token("abort", 5) || starts_with_token("resume", 6) ||
-         starts_with_token("M600", 4, true) || starts_with_token("M601", 4, true) || starts_with_token("goto", 4);
+         starts_with_token("M600", 4, true) || starts_with_token("M601", 4, true) || starts_with_token("goto", 4) ||
+         is_jog_command(command, length);
 }
 
 ControlAction handle_control(uint8_t control);

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -53,6 +53,8 @@ SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate )
     this->last_activity_ms = 0;
     this->makera_rx_overflow = false;
     this->processing_makera_input = false;
+    this->makera_controls_only = false;
+    this->makera_command_rejected = false;
     this->makera_frame_decoder.reset();
     this->deferred_makera_command.clear();
     makera_rx_bytes.tail = makera_rx_bytes.head;
@@ -197,7 +199,8 @@ void SerialConsole::on_idle(void * argument)
     if (communication_protocol == PROTOCOL_MAKERA && !processing_makera_input &&
         now_ms - last_activity_ms >= makera_rx_quiet_ms) {
         processing_makera_input = true;
-        while (deferred_makera_command.empty() && makera_rx_bytes.tail != makera_rx_bytes.head) {
+        while ((makera_controls_only || deferred_makera_command.empty()) &&
+               makera_rx_bytes.tail != makera_rx_bytes.head) {
             char received;
             makera_rx_bytes.pop_front(received);
             process_makera_byte(static_cast<uint8_t>(received));
@@ -217,6 +220,11 @@ void SerialConsole::on_idle(void * argument)
     if (makera_rx_overflow) {
         makera_rx_overflow = false;
         PacketMessage(PTYPE_NORMAL_INFO, "ERROR: serial receive buffer full\r\n", 0);
+    }
+
+    if (makera_command_rejected) {
+        makera_command_rejected = false;
+        PacketMessage(PTYPE_NORMAL_INFO, "ERROR: command rejected while continuous jog is active\r\n", 0);
     }
 
     if (makera_file_cancel) {
@@ -267,8 +275,11 @@ void SerialConsole::on_main_loop(void * argument){
             message.stream = this;
             message.line = 0;
 
-            processing_makera_input = true;
+            const bool jog_command = makera::is_jog_command(message.message.data(), message.message.size());
+            processing_makera_input = !jog_command;
+            makera_controls_only = jog_command;
             THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+            makera_controls_only = false;
             processing_makera_input = false;
         }
         return;
@@ -386,6 +397,17 @@ void SerialConsole::process_makera_byte(uint8_t received)
         return;
     }
 
+    if (makera_controls_only && (packet.type == PTYPE_CTRL_MULTI || packet.type == PTYPE_FILE_START)) {
+        if (packet.type == PTYPE_FILE_START || packet.data_length == 0) {
+            if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
+        } else if (deferred_makera_command.empty()) {
+            deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+        } else {
+            makera_command_rejected = true;
+        }
+        return;
+    }
+
     if (packet.type == PTYPE_CTRL_MULTI && makera::is_deferred_command(
             reinterpret_cast<const char *>(packet.data), packet.data_length)) {
         deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
@@ -456,6 +478,8 @@ void SerialConsole::on_protocol_changed()
     makera_file_cancel = false;
     makera_rx_overflow = false;
     processing_makera_input = false;
+    makera_controls_only = false;
+    makera_command_rejected = false;
     deferred_makera_command.clear();
     makera_rx_bytes.tail = makera_rx_bytes.head;
     makera_frame_decoder.reset();

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -78,6 +78,8 @@ class SerialConsole : public Module, public StreamOutput {
           volatile bool query_flag:1;
           volatile bool halt_flag:1;
           volatile bool diagnose_flag:1;
+          bool makera_controls_only:1;
+          bool makera_command_rejected:1;
         };
         volatile bool makera_file_cancel;
         volatile bool makera_rx_overflow;

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -80,6 +80,8 @@ WifiProvider::WifiProvider()
 	has_data_flag = false;
 	makera_file_cancel = false;
 	processing_makera_input = false;
+	makera_controls_only = false;
+	makera_command_rejected = false;
 	deferred_makera_command.clear();
 	makera_remote_port = 0;
 	makera_remote_known = false;
@@ -264,7 +266,8 @@ void WifiProvider::receive_wifi_data() {
 	// hardware) and closes its advertised window when they fill. Leave unread
 	// commands there and let TCP apply backpressure instead of duplicating that
 	// buffer in the LPC's limited RAM.
-	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS && deferred_makera_command.empty()) {
+	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS &&
+			(makera_controls_only || deferred_makera_command.empty())) {
 		uint16_t wanted = static_cast<uint16_t>(makera_frame_decoder.bytes_wanted());
 		if (wanted > WIFI_DATA_MAX_SIZE) wanted = WIFI_DATA_MAX_SIZE;
 		if (frames > 0 && !makera_frame_decoder.has_header() && !M8266WIFI_SPI_Has_DataReceived()) return;
@@ -324,6 +327,17 @@ void WifiProvider::receive_wifi_data() {
 
 			if (packet.data_length == 0) {
 				if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
+				continue;
+			}
+
+			if (makera_controls_only) {
+				if (packet.type == PTYPE_FILE_START) {
+					makera_file_cancel = true;
+				} else if (deferred_makera_command.empty()) {
+					deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
+				} else {
+					makera_command_rejected = true;
+				}
 				continue;
 			}
 
@@ -545,7 +559,7 @@ void WifiProvider::on_idle(void *argument)
 	if (THEKERNEL->is_uploading()) return;
 
 	// FILE_START leaves the following file data for Player::gets().
-	if (!processing_makera_input && deferred_makera_command.empty() &&
+	if (!processing_makera_input && (makera_controls_only || deferred_makera_command.empty()) &&
 			(has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
 		has_data_flag = false;
 		processing_makera_input = true;
@@ -557,6 +571,11 @@ void WifiProvider::on_idle(void *argument)
 		makera_file_cancel = false;
 		static const char cancel_payload[] = "ok\r\n";
 		PacketMessage(PTYPE_FILE_CAN, cancel_payload, sizeof(cancel_payload));
+	}
+
+	if (makera_command_rejected) {
+		makera_command_rejected = false;
+		PacketMessage(PTYPE_NORMAL_INFO, "ERROR: command rejected while continuous jog is active\r\n", 0);
 	}
 
     if (query_flag) {
@@ -600,8 +619,11 @@ void WifiProvider::on_main_loop(void *argument)
 			message.stream = this;
 			message.line = 0;
 
-			processing_makera_input = true;
+			const bool jog_command = makera::is_jog_command(message.message.data(), message.message.size());
+			processing_makera_input = !jog_command;
+			makera_controls_only = jog_command;
 			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+			makera_controls_only = false;
 			processing_makera_input = false;
 		}
 		return;
@@ -635,6 +657,8 @@ void WifiProvider::on_protocol_changed()
 	diagnose_flag = false;
 	makera_file_cancel = false;
 	processing_makera_input = false;
+	makera_controls_only = false;
+	makera_command_rejected = false;
 	deferred_makera_command.clear();
 	makera_remote_known = false;
 	makera_frame_decoder.reset();

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -112,6 +112,8 @@ private:
     	volatile bool diagnose_flag:1;
     	volatile bool has_data_flag:1;
     	bool makera_remote_known:1;
+		bool makera_controls_only:1;
+		bool makera_command_rejected:1;
     };
     bool makera_file_cancel;
     bool processing_makera_input;


### PR DESCRIPTION
# Summary

Continuous jogging waits for keep-alive messages while servicing the firmware's idle loop. Makera command reception was suppressed during this wait, so keep-alive, stop, and status controls could be delayed or missed. This caused uneven jogging and could eventually leave continuous jogging unresponsive.

Continue receiving single-byte Makera controls over UART and Wi-Fi while a continuous jog is active. One other command received through the same transport can wait until the jog finishes instead of being dispatched recursively.

This affects only the Makera protocol. Smoothie protocol handling and machine configuration are unchanged.

Simultaneous command submission through UART and Wi-Fi remains unsupported. Command execution is coordinated independently by each transport, so a command received through one transport may execute while the other transport is busy.

Validation:

- `./build/build.sh --clean`
- Built and flashed on a bare C1 controller board.
- Exercised command bursts, continuous-jog keep-alives, stop controls, command traffic during jogging, and recovery through UART and Wi-Fi independently.
- Uploaded and played a test G-code file through UART.
- Confirmed the documented concurrent UART/Wi-Fi limitation on the testbed.

AI assistance: Codex was used for implementation, code review, and validation.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)