### PR TITLE
Keep Makera realtime controls responsive during command handling

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -15,6 +15,7 @@
 #include "libs/Adc.h"
 #include "libs/compiler.h"
 #include "libs/StreamOutputPool.h"
+#include "libs/SerialMessage.h"
 #include <mri.h>
 #include "checksumm.h"
 #include "ConfigValue.h"
@@ -105,6 +106,7 @@ Kernel::Kernel()
     keep_alive_request = false;
     flex_compensation_load_error = false;
     config_load_error = false;
+    dispatching_console_line = false;
 
     // Point the variable arrays at their AHBSRAM-backed storage
     local_vars   = ahb_local_vars;
@@ -674,6 +676,16 @@ void Kernel::add_module(Module* module)
 void Kernel::register_for_event(_EVENT_ENUM id_event, Module *mod)
 {
     this->hooks[id_event].push_back(mod);
+}
+
+bool Kernel::dispatch_console_line(SerialMessage& message)
+{
+    if (dispatching_console_line) return false;
+
+    dispatching_console_line = true;
+    call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+    dispatching_console_line = false;
+    return true;
 }
 
 // Call a specific event with an argument

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -39,6 +39,7 @@ class Adc;
 class PublicData;
 class SimpleShell;
 class Configurator;
+struct SerialMessage;
 
 enum STATE {
 	IDLE    = 0,
@@ -130,6 +131,8 @@ class Kernel {
         void add_module(Module* module);
         void register_for_event(_EVENT_ENUM id_event, Module *module);
         void call_event(_EVENT_ENUM id_event, void * argument= nullptr);
+        bool dispatch_console_line(SerialMessage& message);
+        bool is_dispatching_console_line() const { return dispatching_console_line; }
 
         bool kernel_has_event(_EVENT_ENUM id_event, Module *module);
         void unregister_for_event(_EVENT_ENUM id_event, Module *module);
@@ -310,6 +313,7 @@ class Kernel {
             bool flex_compensation_active:1;
             bool flex_compensation_load_error:1;
             bool config_load_error:1;
+            bool dispatching_console_line:1;
         };
         int iic_page_write(unsigned char u8PageNum, unsigned char u8len, unsigned char *pu8Array);
 

--- a/src/libs/MakeraControl.h
+++ b/src/libs/MakeraControl.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
-#include <cstring>
 
 namespace makera {
 
@@ -27,27 +25,6 @@ constexpr ControlAction decode_control(uint8_t control) {
     default:
       return ControlAction::none;
   }
-}
-
-inline bool is_jog_command(const char* command, std::size_t length) {
-  if (command == nullptr || length < 2 || std::memcmp(command, "$J", 2) != 0) return false;
-  if (length == 2) return true;
-  const char next = command[2];
-  return next == ' ' || next == '\t' || next == '\r' || next == '\n';
-}
-
-inline bool is_deferred_command(const char* command, std::size_t length) {
-  if (command == nullptr) return false;
-  const auto starts_with_token = [command, length](const char* token, std::size_t token_length, bool subcodes = false) {
-    if (length < token_length || std::memcmp(command, token, token_length) != 0) return false;
-    if (length == token_length) return true;
-    const char next = command[token_length];
-    return next == ' ' || next == '\t' || next == '\r' || next == '\n' || (subcodes && next == '.');
-  };
-
-  return starts_with_token("suspend", 7) || starts_with_token("abort", 5) || starts_with_token("resume", 6) ||
-         starts_with_token("M600", 4, true) || starts_with_token("M601", 4, true) || starts_with_token("goto", 4) ||
-         is_jog_command(command, length);
 }
 
 ControlAction handle_control(uint8_t control);

--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -52,11 +52,8 @@ SerialConsole::SerialConsole( PinName tx_pin, PinName rx_pin, int baud_rate )
     this->temp_baud_rate = 0;
     this->last_activity_ms = 0;
     this->makera_rx_overflow = false;
-    this->processing_makera_input = false;
-    this->makera_controls_only = false;
-    this->makera_command_rejected = false;
+    this->command_waiting = false;
     this->makera_frame_decoder.reset();
-    this->deferred_makera_command.clear();
     makera_rx_bytes.tail = makera_rx_bytes.head;
     this->reset_file_parser();
 }
@@ -196,17 +193,14 @@ void SerialConsole::on_idle(void * argument)
 	if (THEKERNEL->is_uploading()) return;
 
     const uint32_t now_ms = us_ticker_read() / 1000;
-    if (communication_protocol == PROTOCOL_MAKERA && !processing_makera_input &&
+    if (communication_protocol == PROTOCOL_MAKERA && !command_waiting &&
         now_ms - last_activity_ms >= makera_rx_quiet_ms) {
-        processing_makera_input = true;
-        while ((makera_controls_only || deferred_makera_command.empty()) &&
-               makera_rx_bytes.tail != makera_rx_bytes.head) {
+        while (!command_waiting && makera_rx_bytes.tail != makera_rx_bytes.head) {
             char received;
             makera_rx_bytes.pop_front(received);
             process_makera_byte(static_cast<uint8_t>(received));
             if (THEKERNEL->is_uploading()) break;
         }
-        processing_makera_input = false;
     }
 
     if (temp_baud_rate != 0) {
@@ -220,11 +214,6 @@ void SerialConsole::on_idle(void * argument)
     if (makera_rx_overflow) {
         makera_rx_overflow = false;
         PacketMessage(PTYPE_NORMAL_INFO, "ERROR: serial receive buffer full\r\n", 0);
-    }
-
-    if (makera_command_rejected) {
-        makera_command_rejected = false;
-        PacketMessage(PTYPE_NORMAL_INFO, "ERROR: command rejected while continuous jog is active\r\n", 0);
     }
 
     if (makera_file_cancel) {
@@ -269,18 +258,15 @@ void SerialConsole::on_idle(void * argument)
 // Actual event calling must happen in the main loop because if it happens in the interrupt we will loose data
 void SerialConsole::on_main_loop(void * argument){
     if (communication_protocol == PROTOCOL_MAKERA) {
-        if (!deferred_makera_command.empty()) {
+        if (command_waiting && !THEKERNEL->is_dispatching_console_line()) {
+            const makera::Packet &packet = makera_frame_decoder.packet();
             struct SerialMessage message;
-            message.message.swap(deferred_makera_command);
+            message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
             message.stream = this;
             message.line = 0;
 
-            const bool jog_command = makera::is_jog_command(message.message.data(), message.message.size());
-            processing_makera_input = !jog_command;
-            makera_controls_only = jog_command;
-            THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
-            makera_controls_only = false;
-            processing_makera_input = false;
+            command_waiting = false;
+            THEKERNEL->dispatch_console_line(message);
         }
         return;
     }
@@ -397,23 +383,6 @@ void SerialConsole::process_makera_byte(uint8_t received)
         return;
     }
 
-    if (makera_controls_only && (packet.type == PTYPE_CTRL_MULTI || packet.type == PTYPE_FILE_START)) {
-        if (packet.type == PTYPE_FILE_START || packet.data_length == 0) {
-            if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
-        } else if (deferred_makera_command.empty()) {
-            deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
-        } else {
-            makera_command_rejected = true;
-        }
-        return;
-    }
-
-    if (packet.type == PTYPE_CTRL_MULTI && makera::is_deferred_command(
-            reinterpret_cast<const char *>(packet.data), packet.data_length)) {
-        deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
-        return;
-    }
-
     if (packet.type == PTYPE_CTRL_MULTI || packet.type == PTYPE_FILE_START) {
         if (packet.data_length == 0) {
             if (packet.type == PTYPE_FILE_START) makera_file_cancel = true;
@@ -424,7 +393,7 @@ void SerialConsole::process_makera_byte(uint8_t received)
         message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
         message.stream = this;
         message.line = 0;
-        THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+        if (!THEKERNEL->dispatch_console_line(message)) command_waiting = true;
     }
 }
 
@@ -477,10 +446,7 @@ void SerialConsole::on_protocol_changed()
     diagnose_flag = false;
     makera_file_cancel = false;
     makera_rx_overflow = false;
-    processing_makera_input = false;
-    makera_controls_only = false;
-    makera_command_rejected = false;
-    deferred_makera_command.clear();
+    command_waiting = false;
     makera_rx_bytes.tail = makera_rx_bytes.head;
     makera_frame_decoder.reset();
     reset_file_parser();

--- a/src/modules/communication/SerialConsole.h
+++ b/src/modules/communication/SerialConsole.h
@@ -57,8 +57,6 @@ class SerialConsole : public Module, public StreamOutput {
         int temp_baud_rate;                       // non-zero = temporary baud active
         uint32_t last_activity_ms;                // for 15s timeout revert
         makera::FrameDecoder makera_frame_decoder;
-        std::string deferred_makera_command;
-        bool processing_makera_input;
 
         enum FileParseState {
             FILE_WAIT_HEADER,
@@ -78,8 +76,7 @@ class SerialConsole : public Module, public StreamOutput {
           volatile bool query_flag:1;
           volatile bool halt_flag:1;
           volatile bool diagnose_flag:1;
-          bool makera_controls_only:1;
-          bool makera_command_rejected:1;
+          bool command_waiting:1;
         };
         volatile bool makera_file_cancel;
         volatile bool makera_rx_overflow;

--- a/src/modules/utils/wifi/WifiProvider.cpp
+++ b/src/modules/utils/wifi/WifiProvider.cpp
@@ -79,10 +79,7 @@ WifiProvider::WifiProvider()
 	wifi_init_ok = false;
 	has_data_flag = false;
 	makera_file_cancel = false;
-	processing_makera_input = false;
-	makera_controls_only = false;
-	makera_command_rejected = false;
-	deferred_makera_command.clear();
+	command_waiting = false;
 	makera_remote_port = 0;
 	makera_remote_known = false;
 	connection_fail_count = 0;
@@ -266,8 +263,7 @@ void WifiProvider::receive_wifi_data() {
 	// hardware) and closes its advertised window when they fill. Leave unread
 	// commands there and let TCP apply backpressure instead of duplicating that
 	// buffer in the LPC's limited RAM.
-	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS &&
-			(makera_controls_only || deferred_makera_command.empty())) {
+	while (frames < max_frames && receive_calls < MAKERA_MAX_RECEIVE_CALLS && !command_waiting) {
 		uint16_t wanted = static_cast<uint16_t>(makera_frame_decoder.bytes_wanted());
 		if (wanted > WIFI_DATA_MAX_SIZE) wanted = WIFI_DATA_MAX_SIZE;
 		if (frames > 0 && !makera_frame_decoder.has_header() && !M8266WIFI_SPI_Has_DataReceived()) return;
@@ -330,29 +326,12 @@ void WifiProvider::receive_wifi_data() {
 				continue;
 			}
 
-			if (makera_controls_only) {
-				if (packet.type == PTYPE_FILE_START) {
-					makera_file_cancel = true;
-				} else if (deferred_makera_command.empty()) {
-					deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
-				} else {
-					makera_command_rejected = true;
-				}
-				continue;
-			}
-
-			if (packet.type == PTYPE_CTRL_MULTI && makera::is_deferred_command(
-					reinterpret_cast<const char *>(packet.data), packet.data_length)) {
-				deferred_makera_command.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
-				return;
-			}
-
 			struct SerialMessage message;
 			message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
 			message.stream = this;
 			message.line = 0;
 
-			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+			if (!THEKERNEL->dispatch_console_line(message)) command_waiting = true;
 			if (packet.type == PTYPE_FILE_START) return;
 		}
 	}
@@ -559,23 +538,15 @@ void WifiProvider::on_idle(void *argument)
 	if (THEKERNEL->is_uploading()) return;
 
 	// FILE_START leaves the following file data for Player::gets().
-	if (!processing_makera_input && (makera_controls_only || deferred_makera_command.empty()) &&
-			(has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
+	if (!command_waiting && (has_data_flag || M8266WIFI_SPI_Has_DataReceived())) {
 		has_data_flag = false;
-		processing_makera_input = true;
 		receive_wifi_data();
-		processing_makera_input = false;
 	}
 
 	if (makera_file_cancel) {
 		makera_file_cancel = false;
 		static const char cancel_payload[] = "ok\r\n";
 		PacketMessage(PTYPE_FILE_CAN, cancel_payload, sizeof(cancel_payload));
-	}
-
-	if (makera_command_rejected) {
-		makera_command_rejected = false;
-		PacketMessage(PTYPE_NORMAL_INFO, "ERROR: command rejected while continuous jog is active\r\n", 0);
 	}
 
     if (query_flag) {
@@ -613,18 +584,15 @@ void WifiProvider::on_idle(void *argument)
 void WifiProvider::on_main_loop(void *argument)
 {
 	if (communication_protocol == PROTOCOL_MAKERA) {
-		if (!deferred_makera_command.empty()) {
+		if (command_waiting && !THEKERNEL->is_dispatching_console_line()) {
+			const makera::Packet &packet = makera_frame_decoder.packet();
 			struct SerialMessage message;
-			message.message.swap(deferred_makera_command);
+			message.message.assign(reinterpret_cast<const char *>(packet.data), packet.data_length);
 			message.stream = this;
 			message.line = 0;
 
-			const bool jog_command = makera::is_jog_command(message.message.data(), message.message.size());
-			processing_makera_input = !jog_command;
-			makera_controls_only = jog_command;
-			THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
-			makera_controls_only = false;
-			processing_makera_input = false;
+			command_waiting = false;
+			THEKERNEL->dispatch_console_line(message);
 		}
 		return;
 	}
@@ -656,10 +624,7 @@ void WifiProvider::on_protocol_changed()
 	halt_flag = false;
 	diagnose_flag = false;
 	makera_file_cancel = false;
-	processing_makera_input = false;
-	makera_controls_only = false;
-	makera_command_rejected = false;
-	deferred_makera_command.clear();
+	command_waiting = false;
 	makera_remote_known = false;
 	makera_frame_decoder.reset();
 	reset();

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -111,13 +111,10 @@ private:
     	volatile bool query_flag:1;
     	volatile bool diagnose_flag:1;
     	volatile bool has_data_flag:1;
-    	bool makera_remote_known:1;
-		bool makera_controls_only:1;
-		bool makera_command_rejected:1;
+		bool makera_remote_known:1;
+		bool command_waiting:1;
     };
     bool makera_file_cancel;
-    bool processing_makera_input;
-    std::string deferred_makera_command;
     u16 makera_remote_port;
     makera::FrameDecoder makera_frame_decoder;
     ParseState currentState = WAIT_HEADER;    


### PR DESCRIPTION
# Summary

Makera input can be processed from `ON_IDLE` while another console command is
still running. Dispatching another ordinary command from there causes reentrant
command handling, while blocking all input prevents status, stop, feed-hold and
continuous-jog traffic from being handled promptly.

This change serializes ordinary Makera commands through one common dispatcher
for UART and Wi-Fi. If a command is already running, one completed ordinary
command remains in its transport decoder until it can run. Single-byte realtime
controls continue to be handled immediately until an ordinary command is
waiting.

This removes the command-specific deferral and rejection logic. It does not add
another command queue or allocate another receive buffer.

Smoothie protocol handling is unchanged. No configuration changes are required.

Once an ordinary command is waiting, packets received after it remain buffered
until that command runs. Clients are therefore still expected to use ordinary
commands as request/response traffic.

## Validation

Built successfully with:

```sh
./build/build.sh --clean
```

Tested on a Carvera Air with its normal hardware attached over Wi-Fi:

- homing while polling status every 200 ms;
- continuous jogging with status and keep-alive traffic;
- X/Y motion with feed hold and resume;
- halt during a running command and subsequent unlock;
- file upload, download and playback;
- playback suspend, resume and abort;
- file-transfer cancellation followed by another upload/download;
- TCP disconnection and reconnection during playback, including live status and
  aborting the job from the new connection;
- the controller's protocol-detection and startup command sequence.

A waiting ordinary command still blocks packets behind it. In particular, the
controller currently sends `diagnose` as an ordinary command; opening diagnostics
during a synchronous operation can therefore delay subsequent status queries.
The existing realtime `*` diagnostic command avoids that limitation and should
be used by the controller.

Codex was used to inspect the communication paths, implement the change and
assist with validation.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
