### PR TITLE
A-axis position tracking for substeps

### DIFF
--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -68,9 +68,11 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
 
     for (size_t i = 0; i < n_motors; i++) {
         int32_t steps = THEROBOT->actuators[i]->steps_to_target(actuator_pos[i]);
-        // Update current position
+        // Keep last_milestone mm in sync with the commanded position even when
+        // this axis takes no steps. Step counts still only advance when steps
+        // != 0, so a later move can still accumulate into a full step.
+        THEROBOT->actuators[i]->update_last_milestones(actuator_pos[i], steps);
         if(steps != 0) {
-            THEROBOT->actuators[i]->update_last_milestones(actuator_pos[i], steps);
             has_steps = true;
         }
 

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,6 @@
+[unreleased]
+- Fixed: A-axis position tracking no longer lags the commanded angle when a move is smaller than one stepper step
+
 [2.2.0c-RC2]
 - Fixed: Makera commands received over Wi-Fi no longer block reception while an earlier command is running.
 - Fixed: Added newline chars to the end of SimpleShell commands without them


### PR DESCRIPTION
# Summary
Resolves #421 

This is an issue that occurs when an A axis movement is so small that it's less than a microstep on the stepper after rounding. The A axis movement is skipped and treated as if it was performed. However the steppers stored position is not updated.

This later causes an issue when there is what should have been a linear movement, but instead results in a linear + rotation movement. The difference between the two is in how the `F` parameter is treated. On the expected movement (linear) the F is treated like a normal mm/min XYZ movement, but in the linear + rotation movement scenario `F` is treated as a target surface speed and allowed to accelerate beyond the normal mm/min. This in fact raises the whole feed to axis max ( F200 → F3000)!

Here is a minimum reproduction of the scenario

```gcode
G1 A0.2 F500
G1 A0 F500
G0 X0 Y0 Z10
G1 X1 A-0.0004 F300
G1 X40 F200  ; This should be a plain linear move gets interpreted as a compound movement and speeds up to F3000
```

The fix I've put together here has the planner write the commanded position into that stored A position even when no step is taken. There is no lose of precision here because these instructions that are too small for a movement still get accumulated, and as soon as they add up to a step it will be taken.

I've tested this change on my C1 which is more susceptible to this issue because a single 4th axis microstep is about 0.0023 degree.

AI was used in finding the issue but the code (comment) is my own.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
