### PR TITLE
Revert of Spindle PWM addition to status

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -401,8 +401,8 @@ std::string Kernel::get_query_string()
 
     // current spindle rpm and request rpm and override
     struct spindle_status ss;
-    bool pwm_spindle = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
-    if (pwm_spindle) {
+    ok = PublicData::get_value(pwm_spindle_control_checksum, get_spindle_status_checksum, &ss);
+    if (ok) {
         n= snprintf(buf, sizeof(buf), "|S:%1.1f,%1.1f,%1.1f,%d", ss.current_rpm, ss.target_rpm, ss.factor, int(this->get_vacuum_mode()));
         if(n > sizeof(buf)) n= sizeof(buf);
         str.append(buf, n);
@@ -509,13 +509,6 @@ std::string Kernel::get_query_string()
     n = snprintf(buf, sizeof(buf), "|C:%d,%d,%d,%d", THEKERNEL->factory_set->MachineModel,THEKERNEL->factory_set->FuncSetting,THEROBOT->inch_mode,THEROBOT->absolute_mode);
     if(n > sizeof(buf)) n = sizeof(buf);
     str.append(buf, n);
-
-    // PWM value for PWM spindle (similar to M957 output)
-    if (pwm_spindle) {
-        n = snprintf(buf, sizeof(buf), "|PWM:%5.3f", ss.current_pwm_value);
-        if(n > sizeof(buf)) n = sizeof(buf);
-        str.append(buf, n);
-    }
 
     str.append(">\n");
     return str;

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,6 @@
+[unreleased]
+- Removed: The spindle PWM value from the status response (? command)
+
 [2.2.0c-RC3]
 - Fixed: A-axis position tracking no longer lags the commanded angle when a move is smaller than one stepper step
 - Fixed: Makera protocol realtime control commands were not immediately processed under certain conditions


### PR DESCRIPTION
# Summary

Reverts https://github.com/Carvera-Community/Carvera_Community_Firmware/commit/83a8ef783d81bda9a15839496bcedd30d0aa562e. I realised during testing of https://github.com/Carvera-Community/Carvera_Controller/pull/587 that the PWM is just speed request, not torque request. So we can't infer the Spindle Power from it. No point in having it in the status response.

It's a straight revert with a changelog entry.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
