### PR TITLE
Fix allocator wrapping in CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,17 @@ set(_link_lto -flto=auto)
 if(WIN32)
     set(_link_lto -flto)
 endif()
-set(_wraps --wrap=_isatty --wrap=malloc --wrap=realloc --wrap=free)
+set(_wraps
+    --wrap=_isatty
+    --wrap=malloc
+    --wrap=calloc
+    --wrap=realloc
+    --wrap=free
+    --wrap=_malloc_r
+    --wrap=_calloc_r
+    --wrap=_realloc_r
+    --wrap=_free_r
+)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND _wraps --wrap=_read --wrap=_write --wrap=semihost_connected)
 endif()


### PR DESCRIPTION
# Summary

CMake builds did not redirect `calloc` or newlib's re-entrant allocation functions to the firmware heap, unlike Make builds. Code using those entry points could therefore allocate from newlib's separate heap and overwrite memory managed by the firmware allocator.

Wrap the complete set of allocation entry points already used by the Make build:

- `malloc`, `calloc`, `realloc`, and `free`
- `_malloc_r`, `_calloc_r`, `_realloc_r`, and `_free_r`

This keeps all dynamic allocation within the unified firmware heap.

Validation:

- `./build/build-cmake.sh --clean VERSION=2.2.0c-cmake-allocator-check`
- `./build/build.sh --clean`
- Flashed the CMake-built firmware to a spare C1 controller board. The firmware remained running with no Cortex-M fault status. Before this change, a CMake-built firmware reproduced an early HardFault caused by heap corruption.

AI assistance: Codex assisted with diagnosis, implementation, hardware testing, and drafting this pull request.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
