### PR TITLE
Extend led colour control commands

### DIFF
--- a/docs/commands.json
+++ b/docs/commands.json
@@ -1211,7 +1211,7 @@
     },
     "M337": {
       "type": "mcode",
-      "description": "Set the LED bar color. (Works on all machines except for Carvera C1)",
+      "description": "Set LED colour. Without R/U/B, reports the current colour",
       "parameters": {
         "R": {
           "required": false,
@@ -1227,8 +1227,18 @@
           "required": false,
           "description": "Blue 0–255.",
           "default": null
+        },
+        "I": {
+          "required": false,
+          "description": "LED index 1–5. Omit to address all the leds.",
+          "default": null
         }
       }
+    },
+    "M338": {
+      "type": "mcode",
+      "description": "Restore the LEDs to the current machine status colour.",
+      "parameters": {}
     },
     "M370": {
       "type": "mcode",

--- a/src/modules/utils/mainbutton/MainButton.cpp
+++ b/src/modules/utils/mainbutton/MainButton.cpp
@@ -59,11 +59,17 @@ MainButton::MainButton()
 	this->hold_toggle = 0;
     this->button_state = NONE;
     this->button_pressed = false;
+    this->led_override = false;
     this->stop_on_cover_open = false;
     this->sleep_countdown_us = us_ticker_read();
     this->light_countdown_us = us_ticker_read();
     this->power_fan_countdown_us = us_ticker_read();
     this->old_state = IDLE;
+    for (uint8_t i = 0; i < 5; i++) {
+        this->led_px[i][0] = 0;
+        this->led_px[i][1] = 0;
+        this->led_px[i][2] = 0;
+    }
 }
 
 void MainButton::on_module_loaded()
@@ -382,72 +388,14 @@ void MainButton::on_idle(void *argument)
     		// update led status
 		    if(CARVERA == THEKERNEL->factory_set->MachineModel)
 		    {
-	    		switch (state) {
-	    			case IDLE:
-	    			    this->main_button_LED_R.set(0);
-	    			    this->main_button_LED_G.set(0);
-	    			    this->main_button_LED_B.set(1);
-	    				break;
-	    			case RUN:
-	    			    this->main_button_LED_R.set(0);
-	    			    this->main_button_LED_G.set(1);
-	    			    this->main_button_LED_B.set(0);
-	    				break;
-	    			case HOME:
-	    			    this->main_button_LED_R.set(1);
-	    			    this->main_button_LED_G.set(1);
-	    			    this->main_button_LED_B.set(0);
-	    				break;
-	    			case HOLD:
-	    				this->hold_toggle ++;
-	    			    this->main_button_LED_R.set(0);
-	    			    this->main_button_LED_G.set(this->hold_toggle % 4  < 2 ? 1 : 0);
-	    			    this->main_button_LED_B.set(0);
-	    				break;
-	    			case ALARM:
-	    			    this->main_button_LED_R.set(1);
-	    			    this->main_button_LED_G.set(0);
-	    			    this->main_button_LED_B.set(0);
-	    			    break;
-	    			case SLEEP:
-	    			    this->main_button_LED_R.set(1);
-	    			    this->main_button_LED_G.set(1);
-	    			    this->main_button_LED_B.set(1);
-	    				break;
-	    			case SUSPEND:
-	    				this->hold_toggle ++;
-	    			    this->main_button_LED_R.set(0);
-	    			    this->main_button_LED_G.set(0);
-	    			    this->main_button_LED_B.set(this->hold_toggle % 4  < 2 ? 1 : 0);
-	    				break;
-	    			case WAIT:
-	    				this->hold_toggle ++;
-	    			    this->main_button_LED_R.set(this->hold_toggle % 4  < 2 ? 1 : 0);
-	    			    this->main_button_LED_G.set(this->hold_toggle % 4  < 2 ? 1 : 0);
-	    			    this->main_button_LED_B.set(0);
-	    				break;
-					case TOOL:
-						this->hold_toggle ++;
-						struct tool_status tool;
-						PublicData::get_value( atc_handler_checksum, get_tool_status_checksum, &tool );
-						uint8_t r = 0;
-						uint8_t g = 0;
-						uint8_t b = 0;
-						if (tool.target_collet_type == 0){
-							r = 0;
-							g = 1;
-							b = 1;
-						}else{
-							r = 1;
-							g = 1;
-							b = 0;
-						}
-						this->main_button_LED_R.set(this->hold_toggle % 4  < 2 ? r : 0);
-						this->main_button_LED_G.set(this->hold_toggle % 4  < 2 ? g : 0);
-						this->main_button_LED_B.set(this->hold_toggle % 4  < 2 ? b : 0);
-						break;
-	    		}
-
+				const bool blinking = (state == HOLD || state == SUSPEND || state == WAIT || state == TOOL);
+				if (this->led_override && !blinking && state == this->old_state) {
+					this->apply_led_rgb(this->led_px[0][0], this->led_px[0][1], this->led_px[0][2]);
+				} else {
+					this->led_override = false;
+					this->old_state = state;
+					this->apply_c1_status_leds(state);
+				}
 	    	}
 /*			else if(CARVERA_AIR == THEKERNEL->factory_set->MachineModel)
 		    {
@@ -634,6 +582,15 @@ void MainButton::on_get_public_data(void* argument)
 			// e-stop status
 			data[0] = (char)this->e_stop.get();
 			pdr->set_taken();
+    	} else if (pdr->second_element_is(get_led_bar_checksum)) {
+			struct led_bar_state *bar = static_cast<led_bar_state *>(pdr->get_data_ptr());
+			bar->n = (CARVERA == THEKERNEL->factory_set->MachineModel) ? 1 : 5;
+			for (uint8_t i = 0; i < 5; i++) {
+				bar->r[i] = this->led_px[i][0];
+				bar->g[i] = this->led_px[i][1];
+				bar->b[i] = this->led_px[i][2];
+			}
+			pdr->set_taken();
     	}
     }
 }
@@ -653,9 +610,32 @@ void MainButton::on_set_public_data(void* argument)
 			pdr->set_taken();
 		} else if (pdr->second_element_is(set_led_bar_checksum)) {
 			struct led_rgb *colors = static_cast<led_rgb *>(pdr->get_data_ptr());
-			THEKERNEL->streams->printf("R: %dG:%dB:%d", colors->r, colors->g, colors->b);
+			if (colors->i > 0) {
+				THEKERNEL->streams->printf("I%d R: %dG:%dB:%d", colors->i, colors->r, colors->g, colors->b);
+			} else {
+				THEKERNEL->streams->printf("R: %dG:%dB:%d", colors->r, colors->g, colors->b);
+			}
 			if (colors->r <= 255 && colors->g <= 255 && colors->b <= 255){
-				this->set_led_colors(colors->r, colors->g, colors->b);
+				if (CARVERA == THEKERNEL->factory_set->MachineModel) {
+					this->led_override = true;
+					this->old_state = THEKERNEL->get_state();
+					this->apply_led_rgb(colors->r, colors->g, colors->b);
+				} else if (colors->i >= 1 && colors->i <= 5) {
+					this->set_led_pixel(static_cast<uint8_t>(colors->i - 1), colors->r, colors->g, colors->b);
+				} else {
+					this->apply_led_rgb(colors->r, colors->g, colors->b);
+				}
+			}
+			pdr->set_taken();
+		} else if (pdr->second_element_is(restore_led_bar_checksum)) {
+			this->led_override = false;
+			this->old_state = 0xFF;
+			if (CARVERA == THEKERNEL->factory_set->MachineModel) {
+				uint8_t state = THEKERNEL->get_state();
+				this->old_state = state;
+				this->apply_c1_status_leds(state);
+			} else if (CARVERA_AIR == THEKERNEL->factory_set->MachineModel) {
+				this->led_tick(0);
 			}
 			pdr->set_taken();
     	}
@@ -819,8 +799,82 @@ uint32_t MainButton::led_tick(uint32_t dummy)
 	return 0;
 }
 
+void MainButton::apply_led_rgb(unsigned char r, unsigned char g, unsigned char b)
+{
+	if (CARVERA == THEKERNEL->factory_set->MachineModel) {
+		this->led_px[0][0] = r;
+		this->led_px[0][1] = g;
+		this->led_px[0][2] = b;
+		this->main_button_LED_R.set(r != 0);
+		this->main_button_LED_G.set(g != 0);
+		this->main_button_LED_B.set(b != 0);
+	} else {
+		this->set_led_colors(r, g, b);
+	}
+}
+
+void MainButton::apply_c1_status_leds(uint8_t state)
+{
+	switch (state) {
+		case IDLE:
+			this->apply_led_rgb(0, 0, 255);
+			break;
+		case RUN:
+			this->apply_led_rgb(0, 255, 0);
+			break;
+		case HOME:
+			this->apply_led_rgb(255, 255, 0);
+			break;
+		case HOLD:
+			this->hold_toggle++;
+			this->apply_led_rgb(0, this->hold_toggle % 4 < 2 ? 255 : 0, 0);
+			break;
+		case ALARM:
+			this->apply_led_rgb(255, 0, 0);
+			break;
+		case SLEEP:
+			this->apply_led_rgb(255, 255, 255);
+			break;
+		case SUSPEND:
+			this->hold_toggle++;
+			this->apply_led_rgb(0, 0, this->hold_toggle % 4 < 2 ? 255 : 0);
+			break;
+		case WAIT:
+			this->hold_toggle++;
+			this->apply_led_rgb(this->hold_toggle % 4 < 2 ? 255 : 0, this->hold_toggle % 4 < 2 ? 255 : 0, 0);
+			break;
+		case TOOL: {
+			this->hold_toggle++;
+			struct tool_status tool;
+			PublicData::get_value(atc_handler_checksum, get_tool_status_checksum, &tool);
+			uint8_t r = 0;
+			uint8_t g = 0;
+			uint8_t b = 0;
+			if (tool.target_collet_type == 0) {
+				g = 255;
+				b = 255;
+			} else {
+				r = 255;
+				g = 255;
+			}
+			if (this->hold_toggle % 4 >= 2) {
+				r = 0;
+				g = 0;
+				b = 0;
+			}
+			this->apply_led_rgb(r, g, b);
+			break;
+		}
+	}
+}
+
 void MainButton::set_led_color(unsigned char R1, unsigned char G1, unsigned char B1,unsigned char R2, unsigned char G2, unsigned char B2,unsigned char R3, unsigned char G3, unsigned char B3,unsigned char R4, unsigned char G4, unsigned char B4,unsigned char R5, unsigned char G5, unsigned char B5)
 {
+	this->led_px[0][0] = R1; this->led_px[0][1] = G1; this->led_px[0][2] = B1;
+	this->led_px[1][0] = R2; this->led_px[1][1] = G2; this->led_px[1][2] = B2;
+	this->led_px[2][0] = R3; this->led_px[2][1] = G3; this->led_px[2][2] = B3;
+	this->led_px[3][0] = R4; this->led_px[3][1] = G4; this->led_px[3][2] = B4;
+	this->led_px[4][0] = R5; this->led_px[4][1] = G5; this->led_px[4][2] = B5;
 	mainbutton_led_write_strip(R1, G1, B1, R2, G2, B2, R3, G3, B3, R4, G4, B4, R5, G5, B5);
 }
 
@@ -885,6 +939,24 @@ void MainButton::set_led_colors(unsigned char R, unsigned char G, unsigned char 
     //__enable_irq();
     NVIC_EnableIRQ(TIMER0_IRQn);     // Enable interrupt handler
 	NVIC_EnableIRQ(TIMER1_IRQn);     // Enable interrupt handler
+}
+
+void MainButton::set_led_pixel(uint8_t index, unsigned char r, unsigned char g, unsigned char b)
+{
+	if (index >= 5) return;
+	this->led_px[index][0] = r;
+	this->led_px[index][1] = g;
+	this->led_px[index][2] = b;
+	NVIC_DisableIRQ(TIMER0_IRQn);
+	NVIC_DisableIRQ(TIMER1_IRQn);
+	set_led_color(
+		this->led_px[0][0], this->led_px[0][1], this->led_px[0][2],
+		this->led_px[1][0], this->led_px[1][1], this->led_px[1][2],
+		this->led_px[2][0], this->led_px[2][1], this->led_px[2][2],
+		this->led_px[3][0], this->led_px[3][1], this->led_px[3][2],
+		this->led_px[4][0], this->led_px[4][1], this->led_px[4][2]);
+	NVIC_EnableIRQ(TIMER0_IRQn);
+	NVIC_EnableIRQ(TIMER1_IRQn);
 }
 
 void MainButton::set_led_num(unsigned char ColorFR, unsigned char ColorFG, unsigned char ColorFB, unsigned char ColorBR, unsigned char ColorBG, unsigned char ColorBB, unsigned char num, bool row)

--- a/src/modules/utils/mainbutton/MainButton.h
+++ b/src/modules/utils/mainbutton/MainButton.h
@@ -49,6 +49,7 @@ class MainButton : public Module {
         uint32_t light_countdown_us;
 
         bool button_pressed;
+        bool led_override;
         volatile BUTTON_STATE button_state;
         
         bool stop_on_cover_open;
@@ -61,6 +62,10 @@ class MainButton : public Module {
         void switch_power_12(int state);
         void switch_power_24(int state);
         uint8_t old_state;
+        uint8_t led_px[5][3];
+        void apply_led_rgb(unsigned char r, unsigned char g, unsigned char b);
+        void apply_c1_status_leds(uint8_t state);
+        void set_led_pixel(uint8_t index, unsigned char r, unsigned char g, unsigned char b);
         void set_led_color(unsigned char R1, unsigned char G1, unsigned char B1,unsigned char R2, unsigned char G2, unsigned char B2,unsigned char R3, unsigned char G3, unsigned char B3,unsigned char R4, unsigned char G4, unsigned char B4,unsigned char R5, unsigned char G5, unsigned char B5);
         void set_led_colors(unsigned char R, unsigned char G, unsigned char B);
         void set_led_num(unsigned char ColorFR, unsigned char ColorFG, unsigned char ColorFB, unsigned char ColorBR, unsigned char ColorBG, unsigned char ColorBB, unsigned char num, bool row = false);

--- a/src/modules/utils/mainbutton/MainButtonPublicAccess.h
+++ b/src/modules/utils/mainbutton/MainButtonPublicAccess.h
@@ -2,6 +2,7 @@
 #define MAINBUTTONPUBLICACCESS_H
 
 #include "checksumm.h"
+#include <stdint.h>
 #include <string>
 
 #define main_button_checksum   		CHECKSUM("main_button")
@@ -10,11 +11,21 @@
 #define switch_power_24_checksum	CHECKSUM("switch_power_24")
 #define get_e_stop_state_checksum	CHECKSUM("get_e_stop_state")
 #define set_led_bar_checksum        CHECKSUM("set_led_bar")
+#define get_led_bar_checksum        CHECKSUM("get_led_bar")
+#define restore_led_bar_checksum    CHECKSUM("restore_led_bar")
 
 struct led_rgb{
     int r;
     int g;
     int b;
+    int i;
+};
+
+struct led_bar_state{
+    uint8_t r[5];
+    uint8_t g[5];
+    uint8_t b[5];
+    uint8_t n;
 };
 
 #endif

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -267,14 +267,43 @@ void SimpleShell::on_gcode_received(void *argument)
 			THEKERNEL->set_line_by_line_exec_mode(true);
 			gcode->stream->printf("turning line by line execute mode on.\r\nPlaying file will pause after every valid gcode line, skipping empty and commented lines\r\n");
 		}else if (gcode->m == 337){
-            struct led_rgb colors;
-            colors.r = 0;
-            colors.g = 0;
-            colors.b = 0;
-            if (gcode->has_letter('R')) colors.r = gcode->get_value('R');
-            if (gcode->has_letter('U')) colors.g = gcode->get_value('U');
-            if (gcode->has_letter('B')) colors.b = gcode->get_value('B');
-            PublicData::set_value(main_button_checksum, set_led_bar_checksum, &colors);
+            int index = 0;
+            if (gcode->has_letter('I')) index = gcode->get_int('I');
+            if (gcode->has_letter('R') || gcode->has_letter('U') || gcode->has_letter('B')) {
+                struct led_rgb colors;
+                colors.r = 0;
+                colors.g = 0;
+                colors.b = 0;
+                colors.i = index;
+                if (gcode->has_letter('R')) colors.r = gcode->get_value('R');
+                if (gcode->has_letter('U')) colors.g = gcode->get_value('U');
+                if (gcode->has_letter('B')) colors.b = gcode->get_value('B');
+                PublicData::set_value(main_button_checksum, set_led_bar_checksum, &colors);
+            } else {
+                struct led_bar_state bar;
+                if (PublicData::get_value(main_button_checksum, get_led_bar_checksum, &bar)) {
+                    if (index >= 1 && index <= bar.n) {
+                        gcode->stream->printf("I%d R:%dG:%dB:%d\r\n", index, bar.r[index - 1], bar.g[index - 1], bar.b[index - 1]);
+                    } else {
+                        bool same = true;
+                        for (uint8_t i = 1; i < bar.n; i++) {
+                            if (bar.r[i] != bar.r[0] || bar.g[i] != bar.g[0] || bar.b[i] != bar.b[0]) {
+                                same = false;
+                                break;
+                            }
+                        }
+                        if (same || bar.n == 1) {
+                            gcode->stream->printf("R:%dG:%dB:%d\r\n", bar.r[0], bar.g[0], bar.b[0]);
+                        } else {
+                            for (uint8_t i = 0; i < bar.n; i++) {
+                                gcode->stream->printf("I%d R:%dG:%dB:%d\r\n", i + 1, bar.r[i], bar.g[i], bar.b[i]);
+                            }
+                        }
+                    }
+                }
+            }
+        } else if (gcode->m == 338) {
+            PublicData::set_value(main_button_checksum, restore_led_bar_checksum, nullptr);
         } else if (gcode->m == 485) { //swap communication protocols
             if (gcode->subcode == 1) {
                 gcode->stream->printf("setting to smoothie communication protocol\n");

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
 [unreleased]
+- Enhancement: M337 sets LED colour on the CA1 LED bar and also the C1 main button. Without R/U/B it reports the current colour. On CA1, I1–I5 select a single bar LED.
+- Enhancement: M338 restores the LEDs to the current machine status colour
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration


### PR DESCRIPTION
# Summary

This PR:
* Adds: `M338` which restores the leds to Restore the LEDs to the current machine status colour
* Extends `M337` to also work on the C1. There is no led bar but there is a main button which has an addressable led
* Extends `M337` so that a bare execution with no parameters simply outputs the current led values
* Extends `M337` to be able to set the colours of the individually addressable leds of the CA1

I've tested all of this functionality that is possible on the C1 (everything but the addressable LEDs which it just ignores)

AI Assistance was used. Model: cursor-grok-4.6-high-fast

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
