### PR TITLE
Generated md5 hashes on-the-fly for files without them

### DIFF
--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -280,11 +280,28 @@ std::string absolute_from_relative( std::string path )
     return cwd + '/' + path;
 }
 
+// Name stored under /sd/gcodes/.md5 or .lz for a data file.
+// Paths under gcodes/ keep the relative path (including subdirs). Other
+// files use the basename, e.g. /sd/config.default -> config.default.
+static string sidecar_relative_name(const string& origin)
+{
+	static const char gcodes[] = "gcodes/";
+	const size_t gcodes_len = sizeof(gcodes) - 1;
+	size_t found = origin.find(gcodes);
+	if (found != string::npos) {
+		return origin.substr(found + gcodes_len);
+	}
+	size_t slash = origin.find_last_of('/');
+	if (slash != string::npos) {
+		return origin.substr(slash + 1);
+	}
+	return origin;
+}
+
 // Change from origin path to sub path
 std::string change_to_md5_path( std::string origin )
 {
-	unsigned found = origin.find("gcodes/");
-	string filename = origin.substr(found + 7);
+	string filename = sidecar_relative_name(origin);
 	string path = "/sd/gcodes";
 	DIR * d = fwfs::opendir(path.c_str());
 	if(NULL == d )
@@ -312,8 +329,7 @@ std::string change_to_md5_path( std::string origin )
 // Change from origin path to quicklz file sub path
 std::string change_to_lz_path( std::string origin )
 {
-	unsigned found = origin.find("gcodes/");
-	string filename = origin.substr(found + 7);	
+	string filename = sidecar_relative_name(origin);
 	string path = "/sd/gcodes/.lz";
 	DIR * d = fwfs::opendir(path.c_str());
 	if(NULL == d )

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -552,9 +552,6 @@ void Player::on_console_line_received( void *argument )
     	this->upload_command( possible_command, new_message.stream );
     }else if (cmd == "download") {
         memset(md5_str, 0, sizeof(md5_str));
-    	if (possible_command.find("config.txt") != string::npos) {
-        	this->test_command( possible_command, new_message.stream );
-    	}
     	this->download_command( possible_command, new_message.stream );
     }
 }
@@ -2067,26 +2064,50 @@ upload_success:
 }
 
 
+static bool md5_digest_usable(const char *s)
+{
+    if (s == NULL) {
+        return false;
+    }
+    for (int i = 0; i < 32; i++) {
+        char c = s[i];
+        if (c >= 'A' && c <= 'F') {
+            c = static_cast<char>(c + 32);
+        }
+        if ((c < '0' || c > '9') && (c < 'a' || c > 'f')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool fill_md5_from_path(const char *path, char *out, size_t out_size)
+{
+    if (out == NULL || out_size < 33) {
+        return false;
+    }
+    memset(out, 0, out_size);
+    FILE *fd = fwfs::fopen(path, "rb");
+    if (fd == NULL) {
+        return false;
+    }
+    MD5 md5;
+    uint8_t buf[64];
+    do {
+        size_t n = fwfs::fread(buf, 1, sizeof(buf), fd);
+        if (n > 0) {
+            md5.update(buf, n);
+        }
+        THEKERNEL->call_event(ON_IDLE);
+    } while (!fwfs::feof(fd));
+    fwfs::fclose(fd);
+    strcpy(out, md5.finalize().hexdigest().c_str());
+    return md5_digest_usable(out);
+}
+
 void Player::test_command( string parameters, StreamOutput* stream ) {
     string filename = absolute_from_relative(shift_parameter(parameters));
-	FILE *fd = fwfs::fopen(filename.c_str(), "rb");
-	if (NULL != fd) {
-        MD5 md5;
-        uint8_t smoothie_md5_buf[64];
-        do {
-            if (communication_protocol == PROTOCOL_SMOOTHIE) { 
-                size_t n = fwfs::fread(smoothie_md5_buf, 1, sizeof(smoothie_md5_buf), fd);
-                if (n > 0) md5.update(smoothie_md5_buf, n);
-            } else {
-                size_t n = fwfs::fread(md5buf, 1, sizeof(md5buf), fd);
-                if (n > 0) md5.update(md5buf, n);
-            }
-            THEKERNEL->call_event(ON_IDLE);
-        } while (!fwfs::feof(fd));
-        strcpy(md5_str, md5.finalize().hexdigest().c_str());
-        fwfs::fclose(fd);
-        fd = NULL;
-	}
+    fill_md5_from_path(filename.c_str(), md5_str, sizeof(md5_str));
 }
 
 void Player::download_command( string parameters, StreamOutput *stream )
@@ -2165,19 +2186,23 @@ void Player::download_command( string parameters, StreamOutput *stream )
     
 
     FILE *fd = fwfs::fopen(md5_filename.c_str(), "rb");
+    bool have_digest = false;
     if (fd != NULL) {
         if (communication_protocol == PROTOCOL_SMOOTHIE) {
             fwfs::fread(md5, sizeof(char), 64, fd);
+            have_digest = md5_digest_usable(md5);
         } else {
             fwfs::fread(md5buf, sizeof(char), 64, fd);
+            have_digest = md5_digest_usable(md5buf);
         }
         fwfs::fclose(fd);
         fd = NULL;
-    } else {
+    }
+    if (!have_digest) {
         if (communication_protocol == PROTOCOL_SMOOTHIE) {
-            strcpy(md5, this->md5_str);
+            fill_md5_from_path(filename.c_str(), md5, sizeof(md5));
         } else {
-            strcpy(md5buf, this->md5_str);
+            fill_md5_from_path(filename.c_str(), md5buf, sizeof(md5buf));
         }
     }
 	

--- a/version.txt
+++ b/version.txt
@@ -3,7 +3,8 @@
 - Enhancement: Add CMake support for better IDE integration
 - Removed: The spindle PWM value from the status response (? command)
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
-- Fixed: MD5 hashes for files other than config.txt in the SD card root were invalid. Now md5 is generated on-the-fly if not pre-calculated
+- Fixed: MD5 hashes for files other than config.txt in the SD card root were invalid
+- Changed: Files without a pre-calculated MD5 hash on the SD card now get a MD5 generated on-the-fly when downloaded
 
 [2.2.0c-RC3]
 - Fixed: A-axis position tracking no longer lags the commanded angle when a move is smaller than one stepper step

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 [unreleased]
-- Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration
 - Removed: The spindle PWM value from the status response (? command)
+- Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
+- Fixed: MD5 hashes for files other than config.txt in the SD card root were invalid. Now md5 is generated on-the-fly if not pre-calculated
 
 [2.2.0c-RC3]
 - Fixed: A-axis position tracking no longer lags the commanded angle when a move is smaller than one stepper step


### PR DESCRIPTION
# Summary

This addresses #434 and #357 by:

1. Fixing the relative file name pathing broken substring in #434 
2. Generating on-the-fly md5 for files without a pre-calculated one in `.md5` folders when downloaded

Tested on my C1 by running a config file backup using the Controller (previous versions would error out because of invalid md5 hashes returned). Also downloading gcode with existing hashes. 

AI Assistance was used in finding and writing the fix.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
