### PR TITLE
Fix corruption when decompressing uploaded files

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -1542,8 +1542,6 @@ int Player::decompress(string sfilename, string dfilename, uint32_t sfilesize, S
 		{
 			u16Sum += fbuff[j];
 		}
-		// Set the file write system buffer 4096 Byte
-		setvbuf(f_out, (char*)&xbuff[4096], _IOFBF, 4096);
 		fwfs::fwrite(fbuff, sizeof(char),u32DcmprsSize, f_out);
 		u32TotalDcmprsSize += u32DcmprsSize;
 		u32BlockNum += 1;

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,5 @@
 [unreleased]
+- Fixed: Prevent compressed file corruption during decompression.
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration


### PR DESCRIPTION
# Summary

Compressed uploads could be corrupted during decompression because part of
`xbuff` was used as the output file's stdio buffer while the same array was
reused for each compressed input block. A compressed block larger than 4096
bytes could overwrite pending output data.

Use unbuffered output while decompressing so the input buffer is never shared
with stdio. This only affects QuickLZ decompression; configuration and
uncompressed file transfers are unchanged.

Tested on a C1 controller board using a Makera Studio G-code file containing a
thumbnail, compressed in the same format as Carvera Controller and uploaded
over the Makera UART protocol.

Before the fix, the upload reported success but 115 bytes were corrupted at
4096-byte output boundaries. This included changing the final `M05`, `G28`, and
`M02` commands. After the fix, the decompressed file matched the original
byte-for-byte.

`./build/build.sh --clean` passes.

AI was used: Codex assisted with diagnosis, implementation, and validation.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
