### PR TITLE
Stop probing cycles after a failed probe move

### DIFF
--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -1184,7 +1184,7 @@ bool CartGridStrategy::doFlexMeasurement(Gcode *gc)
             zprobe->coordinated_move(probe_x, NAN, NAN, params.rapid_rate / 60);
             
             // Use ZProbe's internal fast_slow_probe_sequence for Y-axis
-            zprobe->fast_slow_probe_sequence_public(Y_AXIS, 1); // Probe in positive Y direction
+            if (!zprobe->fast_slow_probe_sequence_public(Y_AXIS, 1)) return false;
             
             // Get the result from ZProbe's output coordinates
             xy_output_coordinates& coords = zprobe->get_output_coordinates();

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -118,6 +118,7 @@ void ZProbe::config_load()
     this->probe_calibration_safety_margin = THEKERNEL->config->value(zprobe_checksum, probe_calibration_safety_margin_checksum)->as_number(0.1F);
     this->halt_pending = false;
     this->probe_triggered = false;
+    this->probe_crash_count = 0;
 
     // get strategies to load
     vector<uint16_t> modules;
@@ -288,6 +289,7 @@ uint32_t ZProbe::read_probe(uint32_t dummy)
                 THEKERNEL->set_halted(true);
                 // Set a flag to process the halt event in the main loop
                 halt_pending = true;
+                ++probe_crash_count;
                 THEKERNEL->streams->printf("error:3D Probe crash detected\r\n");
                 THEKERNEL->streams->printf("Manually move the probe to a safe position\r\n");
             } 
@@ -700,7 +702,7 @@ void ZProbe::on_gcode_received(void *argument)
                 }
                 break;
             case 465:
-                parse_parameters(gcode, true);
+                if (!parse_parameters(gcode, true)) return;
                 if (gcode->subcode == 1){
                     if (!gcode->has_letter('Y') || !gcode->has_letter('H')){
                         gcode->stream->printf("ERROR: Probe fail: No distance or height set\n");
@@ -1131,6 +1133,7 @@ float ZProbe::get_xyz_move_length(float x, float y, float z){
 }
 
 bool ZProbe::fast_slow_probe_sequence(int axis, int direction){
+    const uint32_t initial_probe_crash_count = probe_crash_count;
     float moveBuffer[3];
     float mpos[3];
     //float old_mpos[3];
@@ -1192,19 +1195,26 @@ bool ZProbe::fast_slow_probe_sequence(int axis, int direction){
     memset(&this->buff, 0 , sizeof(this->buff));
     std::sprintf(this->buff, "G38.%i X%.3f Y%.3f Z%.3f F%.3f", 2 + param.probe_g38_subcode, THEROBOT->from_millimeters(x), THEROBOT->from_millimeters(y), THEROBOT->from_millimeters(z), param.feed_rate);
     this->gcodeBuffer = new Gcode(this->buff, &StreamOutput::NullStream);
-    probe_XYZ(this->gcodeBuffer);
+    bool probe_ok = probe_XYZ(this->gcodeBuffer);
     delete gcodeBuffer;
+    if (!probe_ok) return false;
+
     //move off the surface
     moveBuffer[0] = retractx;
     moveBuffer[1] = retracty;
     moveBuffer[2] = retractz;
     THEROBOT->delta_move(moveBuffer, param.feed_rate, 3);
+    THECONVEYOR->wait_for_idle();
+    if (probe_crash_count != initial_probe_crash_count) return false;
+
     //slow probe
     memset(&this->buff, 0 , sizeof(this->buff));
     std::sprintf(this->buff, "G38.%i X%.3f Y%.3f Z%.3f", 2 + param.probe_g38_subcode,THEROBOT->from_millimeters(x), THEROBOT->from_millimeters(y), THEROBOT->from_millimeters(z));
     this->gcodeBuffer = new Gcode(this->buff, &StreamOutput::NullStream);
-    probe_XYZ(this->gcodeBuffer);
+    probe_ok = probe_XYZ(this->gcodeBuffer);
     delete gcodeBuffer;
+    if (!probe_ok) return false;
+
     // always wait for idle before getting the machine pos
     THECONVEYOR->wait_for_idle();
     //store position
@@ -1245,7 +1255,7 @@ bool ZProbe::fast_slow_probe_sequence(int axis, int direction){
     THEROBOT->delta_move(moveBuffer, param.feed_rate, 3);
     // always wait for idle before getting the machine pos
     THECONVEYOR->wait_for_idle();
-    return probe_detected;
+    return probe_detected && probe_crash_count == initial_probe_crash_count;
 }
 
 int ZProbe::xy_probe_move_alarm_when_hit(int direction, int probe_g38_subcode, float x, float y, float feed_rate){
@@ -1420,14 +1430,14 @@ void ZProbe::probe_bore(bool calibration) //M461
 	for(int i=0; i< param.repeat; i++) {
         if (param.x_axis_distance != 0) {
             // probe in positive x direction
-            fast_slow_probe_sequence(X_AXIS, POS);
+            if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.x_positive_x_out, out_coords.x_positive_y_out);
             //move back to the center position
             coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate);
 
             // probe in negative x direction
-            fast_slow_probe_sequence(X_AXIS, NEG);
+            if (!fast_slow_probe_sequence(X_AXIS, NEG)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.x_negative_x_out, out_coords.x_negative_y_out);
             //calculate center of bore (will only be centered in x)
@@ -1447,7 +1457,7 @@ void ZProbe::probe_bore(bool calibration) //M461
 
         if (param.y_axis_distance != 0) {
             // probe in positive < direction
-            fast_slow_probe_sequence(Y_AXIS, POS);
+            if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.y_positive_x_out, out_coordsy_positive_y_out);
             //goto current center position
@@ -1455,7 +1465,7 @@ void ZProbe::probe_bore(bool calibration) //M461
             THECONVEYOR->wait_for_idle();
             
             // probe in negative y direction
-            fast_slow_probe_sequence(Y_AXIS, NEG);
+            if (!fast_slow_probe_sequence(Y_AXIS, NEG)) return;
             
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.x_negative_x_out, out_coords.x_negative_y_out);
             //calculate center of bore (will only be centered in x)
@@ -1532,7 +1542,7 @@ void ZProbe::probe_boss(bool calibration) //M462
 	//slow zprobe without alarm to probe_height. Skip if probe height is 0
 	if (param.probe_height != 0){
         param.z_axis_distance = param.probe_height;
-        fast_slow_probe_sequence(Z_AXIS, POS);
+        if (!fast_slow_probe_sequence(Z_AXIS, POS)) return;
         if (param.save_position == 2 && check_last_probe_ok()){
             THEROBOT->set_current_wcs_by_mpos( NAN, NAN, out_coords.z_negative_z_out);
         }
@@ -1570,7 +1580,7 @@ void ZProbe::probe_boss(bool calibration) //M462
             }
 
             // probe in negative x direction
-            fast_slow_probe_sequence(X_AXIS, NEG);
+            if (!fast_slow_probe_sequence(X_AXIS, NEG)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.x_positive_x_out, out_coords.x_positive_y_out);
             //goto clearance_world_pos in z
@@ -1592,7 +1602,7 @@ void ZProbe::probe_boss(bool calibration) //M462
             }
 
             // probe in positive x direction
-            fast_slow_probe_sequence(X_AXIS, POS);
+            if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.x_positive_x_out, out_coords.x_positive_y_out);
             //calculate center of bore (will only be centered in x)
@@ -1627,7 +1637,7 @@ void ZProbe::probe_boss(bool calibration) //M462
             }
             
             // probe in negative y direction
-            fast_slow_probe_sequence(Y_AXIS, NEG);
+            if (!fast_slow_probe_sequence(Y_AXIS, NEG)) return;
 
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.y_positive_x_out, out_coords.y_positive_y_out);
             //goto clearance_world_pos in z
@@ -1649,7 +1659,7 @@ void ZProbe::probe_boss(bool calibration) //M462
             }
 
             // probe in positive y direction
-            fast_slow_probe_sequence(Y_AXIS, POS);
+            if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
             
             //THEKERNEL->streams->printf("X: %.3f Y: %.3f\n", out_coords.y_positive_x_out, out_coords.y_positive_y_out);
             //calculate center of bore (will only be centered in x)
@@ -1722,7 +1732,7 @@ void ZProbe::probe_insideCorner() //M463
 	//setup repeat
 	for(int i=0; i< param.repeat; i++) {
         
-        fast_slow_probe_sequence(X_AXIS, POS);
+        if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
 
         out_coords.x_positive_x_out = out_coords.x_positive_x_out + (param.x_axis_distance>= 0 ? 1.0f : -1.0f) *  param.half_tool_dia_rotated_x_x;
         out_coords.x_positive_y_out = out_coords.x_positive_y_out + (param.x_axis_distance>= 0 ? 1.0f : -1.0f) *  param.half_tool_dia_rotated_x_y;
@@ -1733,7 +1743,7 @@ void ZProbe::probe_insideCorner() //M463
         coordinated_move(out_coords.origin_x, out_coords.origin_y, NAN, param.rapid_rate );
         THECONVEYOR->wait_for_idle();
 
-        fast_slow_probe_sequence(Y_AXIS, POS);
+        if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
 
         out_coords.y_positive_y_out = out_coords.y_positive_y_out + (param.y_axis_distance>= 0 ? 1.0f : -1.0f) * param.half_tool_dia_rotated_y_y;
         out_coords.y_positive_x_out = out_coords.y_positive_x_out + (param.y_axis_distance>= 0 ? 1.0f : -1.0f) * param.half_tool_dia_rotated_y_x;
@@ -1785,7 +1795,7 @@ void ZProbe::probe_outsideCorner() //M464
 	//slow zprobe without alarm to probe_height. Skip if probe height is 0
 	if (param.probe_height != 0){
         param.z_axis_distance = param.probe_height;
-        fast_slow_probe_sequence(Z_AXIS, POS);
+        if (!fast_slow_probe_sequence(Z_AXIS, POS)) return;
         if (param.save_position == 2 && check_last_probe_ok()){
             THEROBOT->set_current_wcs_by_mpos( NAN, NAN, out_coords.z_negative_z_out);
         }
@@ -1826,7 +1836,7 @@ void ZProbe::probe_outsideCorner() //M464
         }
         
         // probe in positive x direction
-        fast_slow_probe_sequence(X_AXIS, POS);
+        if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
 
         out_coords.x_positive_x_out = out_coords.x_positive_x_out + (param.x_axis_distance>= 0 ? 1.0f : -1.0f) *  param.half_tool_dia_rotated_x_x;
         out_coords.x_positive_y_out = out_coords.x_positive_y_out + (param.x_axis_distance>= 0 ? 1.0f : -1.0f) *  param.half_tool_dia_rotated_x_y;
@@ -1852,7 +1862,7 @@ void ZProbe::probe_outsideCorner() //M464
         }
 
         // probe in positive y direction
-        fast_slow_probe_sequence(Y_AXIS, POS);
+        if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
 
         out_coords.y_positive_y_out = out_coords.y_positive_y_out + (param.y_axis_distance>= 0 ? 1.0f : -1.0f) * param.half_tool_dia_rotated_y_y;
         out_coords.y_positive_x_out = out_coords.y_positive_x_out + (param.y_axis_distance>= 0 ? 1.0f : -1.0f) * param.half_tool_dia_rotated_y_x;
@@ -2009,7 +2019,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
                 return;
             }
             
-            fast_slow_probe_sequence(Z_AXIS, NEG);
+            if (!fast_slow_probe_sequence(Z_AXIS, NEG)) return;
             if (check_last_probe_ok()){
                 out_coords.y_positive_y_out = out_coords.z_negative_z_out;
             }else{
@@ -2025,7 +2035,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
                 THEKERNEL->set_halt_reason(PROBE_FAIL);
                 return;
             }
-            fast_slow_probe_sequence(Z_AXIS, NEG);
+            if (!fast_slow_probe_sequence(Z_AXIS, NEG)) return;
             if (check_last_probe_ok()){
                 out_coords.y_negative_y_out = out_coords.z_negative_z_out;
             }
@@ -2043,7 +2053,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
 
         }else if (probe_x) {
             
-            fast_slow_probe_sequence(Y_AXIS, POS);
+            if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
@@ -2068,7 +2078,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             }
 
             //probe along y axis to find second point
-            fast_slow_probe_sequence(Y_AXIS, POS);
+            if (!fast_slow_probe_sequence(Y_AXIS, POS)) return;
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
@@ -2092,7 +2102,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             angle_measurements.push_back(current_angle);
             THEKERNEL->streams->printf("Measurement %d: Angle from X Axis is: %.3f degrees or %.3f radians\n" , i+1, current_angle, current_angle * pi / 180 );
         }else{
-            fast_slow_probe_sequence(X_AXIS, POS);
+            if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
@@ -2117,7 +2127,7 @@ void ZProbe::probe_axisangle(bool probe_a_axis, bool probe_with_offset) //M465
             }
 
             //probe along y axis to find second point
-            fast_slow_probe_sequence(X_AXIS, POS);
+            if (!fast_slow_probe_sequence(X_AXIS, POS)) return;
             THECONVEYOR->wait_for_idle();
             
             if (!check_last_probe_ok()) {
@@ -2258,7 +2268,7 @@ void ZProbe::probe_square(){
         // go to starting position
         coordinated_move(out_coords.origin_x, out_coords.origin_y, out_coords.origin_z, param.rapid_rate);
         for (int j = 0; j < 4; j++){
-            fast_slow_probe_sequence(Z_AXIS, NEG);
+            if (!fast_slow_probe_sequence(Z_AXIS, NEG)) return;
             z_pos[j] = out_coords.z_negative_z_out;
             if (j == 0){
                 min_z = max_z = z_pos[j];
@@ -2453,7 +2463,7 @@ void ZProbe::single_axis_probe_double_tap(){
 
         THECONVEYOR->wait_for_idle();
         // POS doesn't do anything here since it's a XYZ Probe move
-        fast_slow_probe_sequence(XYZ, POS);
+        if (!fast_slow_probe_sequence(XYZ, POS)) return;
 
         THECONVEYOR->wait_for_idle();
         

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -184,6 +184,7 @@ private:
     volatile bool calibrate_detected;
     volatile bool probe_triggered;
     volatile bool halt_pending;
+    volatile uint32_t probe_crash_count;
 
     PROBING_CYCLES probing_cycle;
 

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,5 @@
 [unreleased]
+- Fixed: Probing cycles stop when a probe move fails.
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration


### PR DESCRIPTION
# Summary

Stop compound probing cycles when a probe move fails or the probe activates unexpectedly during a retract.

Previously, the fast/slow probing sequence ignored failures from its probe moves. Higher-level probing routines also ignored the sequence result, allowing the remainder of a probing cycle to run after an alarm. M465 additionally started its probing cycle even when parameter validation had already failed.

The sequence could also report success after its probing move had completed but the subsequent retract raised a 3D-probe crash alarm. If the controller then cleared the alarm to move to safe Z, the interrupted probing routine could continue. The sequence now remembers such a crash and reports failure even if the alarm is cleared before it returns.

This change propagates both failure conditions through the calling routines and prevents an invalid M465 command from starting a cycle.

No configuration changes are required.

Validation:

- `./build/build.sh --clean`
- Reproduced the original behavior on a C1 controller board with an open probe input: the probing routine continued after the failed move, and a rejected M465 command still started probing.
- Flashed the fixed firmware on the same board and confirmed that probing stopped at the first failed move.
- Confirmed that clearing the alarm and issuing a safe-Z move did not resume the failed probing cycle.
- Confirmed that an invalid-tool M465 command was rejected without starting a probing cycle.
- Confirmed from Z1 controller logs that an unexpected probe activation during a retract could raise a crash alarm and then allow the probing cycle to continue after the alarm was cleared.
- The test used a bare controller board without connected machine mechanics or a physical probe.

AI assistance: Codex assisted with debugging, implementation, and testing.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
