### PR TITLE
Fix incorrect arc paths after jogging and position resets

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1580,6 +1580,8 @@ void Robot::reset_axis_position(float x, float y, float z)
         compensationTransform(machine_position, true, false);
     }
 
+    memcpy(arc_milestone, machine_position, sizeof(arc_milestone));
+
     // now set the actuator positions based on the supplied compensated position
     ActuatorCoordinates actuator_pos;
     arm_solution->cartesian_to_actuator(this->compensated_machine_position, actuator_pos);
@@ -1638,6 +1640,9 @@ void Robot::reset_position_from_current_actuator_position()
 
     // compensated_machine_position includes the compensation transform so we need to get the inverse to get actual machine_position
     if(compensationTransform) compensationTransform(machine_position, true, false); // get inverse compensation transform
+
+    // Arcs must start at the actual position after a jog or interrupted move.
+    memcpy(arc_milestone, machine_position, sizeof(arc_milestone));
 
     // now reset actuator::machine_position, NOTE this may lose a little precision as FK is not always entirely accurate.
     // NOTE This is required to sync the machine position with the actuator position, we do a somewhat redundant cartesian_to_actuator() call
@@ -1968,6 +1973,7 @@ bool Robot::delta_move(const float *delta, float rate_mm_s, uint8_t naxis)
     bool moved = append_milestone(target, rate_mm_s * seconds_per_minute, 0);
     if(moved) {
         memcpy(machine_position, target, n_motors*sizeof(float));
+        memcpy(arc_milestone, target, sizeof(arc_milestone));
     }
     this->inverse_time_mode = saved_itm; // restore G93/G94
 

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,5 @@
 [unreleased]
+- Fixed: Arcs start at the current position after jogging, direct moves, and coordinate resets.
 - Fixed: CMake builds include the merged SRAM allocator and Makera protocol sources and report the consolidated heap.
 - Enhancement: Add a tool to check or fix the code formatting according to Google C/C++ style guide.
 - Enhancement: Add CMake support for better IDE integration


### PR DESCRIPTION
# Summary

Running G2/G3 after jogging could produce an unexpected move toward an old position followed by a helical arc, even when the command specified no Z movement. Repeating the same arc then worked correctly.

Arcs use a separately stored start position that was not updated by direct moves or coordinate resets. Keep it synchronized after continuous jogging, step jogging, internal moves such as probe retracts, and position resets.

No configuration changes are required.

Validation:

- `./build/build.sh --clean`
- Reproduced over Wi-Fi on a C1 controller board: after jogging Z downward, an XY circle climbed toward the previous height and spiralled back down.
- With the fix, flat arcs maintained constant Z after continuous jogging, step jogging, and a G28.3 coordinate reset.
- Repeated arcs and explicitly commanded helical arcs worked correctly in each case.
- Testing used a bare controller board without connected machine mechanics.

AI assistance: Codex assisted with debugging, implementation, and testing.

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Build (`./build/build.sh --clean`) passes with no errors.
- [x] The changes have been tested on real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Community_Firmware#filing-issues-and-contributing)
